### PR TITLE
Added initial pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+**What current issue(s) from Trello/Github does this address?**
+
+**What problem does this PR solve?**
+
+**How did you solve this problem?**
+
+**How did you make sure your solution works?**
+
+**Are there any special changes in the code that we should be aware of?**
+
+**Is there anything else we should know?**
+
+- [ ] Unit tests written?


### PR DESCRIPTION
The template itself won't be used to make a PR until the template is on the default branch of the repo.

There is currently a Trello ticket for this https://trello.com/c/0dcsuovn but I decided to push it forward and submit it. Thanks for the help Jason

This is a starting point and we can see how it works and make changes as we go on with the project. If the template were available it would look like the following

---

**What current issue(s) from Trello/Github does this address?**
None.

**What problem does this PR solve?**
We currently don’t have a standard template for creating PR descriptions. This makes it difficult to review PRs. It also allows for novice programmers to create bad PRs forcing other programmers to spend more time than necessary on a PR. Finally, without proper PR description documentation, future code maintainers will have a more difficult time debugging code.

**How did you solve this problem?**
Let’s introduce a template for neon-wallet PRs. To do so, follow the link below:

https://github.com/blog/2111-issue-and-pull-request-templates

**How did you make sure your solution works?**
None.

**Are there any special changes in the code that we should be aware of?**
None.

**Is there anything else we should know?**
This is an example of a PR template and can be used as a template for PR templates in repos.

- [x] Unit tests written? N/A
