### PR TITLE
update readme to add a line saying a manual build now relies on neon-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The aim of this project is to port the current NEO web wallet to electron with a
 
 A standalone app will be available soon. For now, you will need to build the wallet manually. This project uses the current LTS node version, which is `v6.11.0`. You'll also need to have webpack installed globally `npm install -g webpack`
 
-To install the development version and its dependencies, move into the project directory and run `npm install`. Then build the project with `webpack` or `webpack --watch` (for auto-updates).
+To install the development version and its dependencies, move into the project directory and run `npm install`.
+Then install the neon-js pack by running `npm install --save git+https://github.com/CityOfZion/neon-js.git`
+Then build the project with `webpack` or `webpack --watch` (for auto-updates).
 
 To run the wallet: `npm start`


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**

**What problem does this PR solve?**

**How did you solve this problem?**

**How did you make sure your solution works?**

**Are there any special changes in the code that we should be aware of?**

**Is there anything else we should know?**

- [ ] Unit tests written?
