### PR TITLE
fixes issue with not working copy-to-clipboard button

### DIFF
--- a/app/components/CreateWallet.js
+++ b/app/components/CreateWallet.js
@@ -44,12 +44,12 @@ class CreateWallet extends Component {
       <div className="keyList">
         <span className="label">Public Address:</span>
         <span className="key">{this.props.address}</span>
-        <span className="copyKey" onClick={() => clipboard.writeText(this.props.address, 'selection')}><Copy data-tip data-for="copyPublicKeyTip" /></span>
+        <span className="copyKey" onClick={() => clipboard.writeText(this.props.address)}><Copy data-tip data-for="copyPublicKeyTip" /></span>
       </div>
       <div className="keyList">
         <span className="label">Private Key:</span>
         <span className="key">{this.props.wif}</span>
-        <span className="copyKey" onClick={() => clipboard.writeText(this.props.wif, 'selection')}><Copy data-tip data-for="copyPrivateKeyTip" /></span>
+        <span className="copyKey" onClick={() => clipboard.writeText(this.props.wif)}><Copy data-tip data-for="copyPrivateKeyTip" /></span>
       </div>
       <Link to="/"><button>Back to Login</button></Link>
       <ReactTooltip class="solidTip" id="copyPublicKeyTip" place="bottom" type="dark" effect="solid">

--- a/app/components/WalletInfo.js
+++ b/app/components/WalletInfo.js
@@ -33,7 +33,7 @@ class WalletInfo extends Component {
         <div className="label">Your Public Neo Address:</div>
         <div className="address">
           {this.props.address}
-            <span className="copyKey" onClick={() => clipboard.writeText(this.props.address, 'selection')}><Copy data-tip data-for="copyAddressTip" /></span>
+            <span className="copyKey" onClick={() => clipboard.writeText(this.props.address)}><Copy data-tip data-for="copyAddressTip" /></span>
         </div>
         <ReactTooltip class="solidTip" id="copyAddressTip" place="bottom" type="dark" effect="solid">
           <span>Copy Public Address</span>


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
https://github.com/CityOfZion/neon-wallet/issues/46

**What problem does this PR solve?**
It enables the user to use the copy-to-clipboard button again. Tested on Arch Linux

**How did you solve this problem?**
the `clipboard.writeText()` function has a next to the actual text a second type parameter. This type parameter seems to make problems. Without this optional parameter, the text is copied to the clipboard properly. 

See here: https://github.com/electron/electron/blob/master/docs/api/clipboard.md

**How did you make sure your solution works?**
I tested in on my local PC (Arch Linux with Gnome 3.24)

**Are there any special changes in the code that we should be aware of?**
I don't think so

**Is there anything else we should know?**
No

- [ ] Unit tests written? -> No
