### PR TITLE
Enables switching of price between USD and EUR

### DIFF
--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -23,12 +23,13 @@ export function newWallet(){
   }
 }
 
-export function setBalance(neo, gas, price){
+export function setBalance(neo, gas, price, currencyCode){
   return {
     type: types.SET_BALANCE,
     Neo: neo,
     Gas: gas,
-    price: price
+    price: price,
+    currencyCode: currencyCode
   }
 }
 

--- a/app/components/Balance.js
+++ b/app/components/Balance.js
@@ -1,0 +1,83 @@
+import React, {Component} from 'react';
+import {connect} from 'react-redux';
+import {setBalance} from '../actions/index.js';
+import {getBalance} from 'neon-js';
+
+let currencyFormatter = require('currency-formatter');
+
+// TODO will be removed if getMarketPrice is imported from neon-js
+var _axios2 = require('axios');
+
+// TODO move to neon-js and remove this method
+var getMarketPrice = exports.getMarketPrice = function getMarketPrice(amount, currencyCode) {
+    return _axios2.default.get(`https://api.coinmarketcap.com/v1/ticker/NEO/?convert=${currencyCode}`).then(function (response) {
+        var fieldName = 'price_' + currencyCode.toLowerCase();
+
+        if (response.data[0].hasOwnProperty(fieldName)) {
+            var lastPrice = Number(response.data[0][fieldName]);
+            return (lastPrice * amount);
+        }
+
+        throw new Error(`There is no field ${fieldName} in response json from coinmarketcap.`);
+
+    }).catch( () => {
+        throw new Error(`CurrencyCode ${currencyCode} is not supported by coinmarketcap api.`);
+    })
+};
+
+const formatCurrency = (price, currencyCode) => {
+    return currencyFormatter.format(price, { code: currencyCode });
+};
+
+const loadMarketPrice = (dispatch, net, address, currencyCode) => {
+
+    return getBalance(net, address).then((resultBalance) => {
+
+        return getMarketPrice(resultBalance, currencyCode).then((resultPrice) => {
+
+            if (resultPrice === undefined || resultPrice === null) {
+                dispatch(setBalance(resultBalance.Neo, resultBalance.Gas, '--', currencyCode));
+            } else {
+                let formattedPrice = formatCurrency(resultPrice, currencyCode);
+                dispatch(setBalance(resultBalance.Neo, resultBalance.Gas, formattedPrice, currencyCode));
+            }
+
+        }).catch( () => {
+            dispatch(setBalance(resultBalance.Neo, resultBalance.Gas, '--', currencyCode));
+        })
+    });
+};
+
+const switchCurrency = (dispatch, net, address, currentCurrencyCode) => {
+
+    let current = currentCurrencyCode;
+    current === 'USD' ? current = 'EUR' : current = 'USD';
+
+    return loadMarketPrice(dispatch, net, address, current);
+};
+
+class Balance extends Component {
+
+    componentDidMount = () => {
+        loadMarketPrice(this.props.dispatch, this.props.net, this.props.address, this.props.currencyCode)
+    };
+
+    render = () => {
+        return (
+            <div className="fiat" onClick={() => switchCurrency(this.props.dispatch, this.props.net, this.props.address, this.props.currencyCode)}>
+                {this.props.price}
+            </div>
+        )
+    }
+}
+
+const mapStateToProps = (state) => ({
+    neo: state.wallet.Neo,
+    gas: state.wallet.Gas,
+    price: state.wallet.price,
+    currencyCode: state.wallet.currencyCode
+});
+
+Balance = connect(mapStateToProps)(Balance);
+
+export { Balance, loadMarketPrice };

--- a/app/components/WalletInfo.js
+++ b/app/components/WalletInfo.js
@@ -8,11 +8,12 @@ import { resetPrice, sendEvent, clearTransactionEvent } from '../actions/index.j
 import { clipboard } from 'electron';
 import Copy from 'react-icons/lib/md/content-copy';
 import ReactTooltip from 'react-tooltip'
+import {Balance} from '../components/Balance';
 
 // force sync with balance data
-const refreshBalance = (dispatch, net, address) => {
+const refreshBalance = (dispatch, net, address, currencyCode) => {
   dispatch(sendEvent(true, "Refreshing..."));
-  initiateGetBalance(dispatch, net, address).then((response) => {
+  initiateGetBalance(dispatch, net, address, currencyCode).then((response) => {
     dispatch(sendEvent(true, "Received latest blockchain information."));
     setTimeout(() => dispatch(clearTransactionEvent()), 1000);
   });
@@ -21,7 +22,7 @@ const refreshBalance = (dispatch, net, address) => {
 class WalletInfo extends Component {
 
   componentDidMount = () => {
-    initiateGetBalance(this.props.dispatch, this.props.net, this.props.address);
+    initiateGetBalance(this.props.dispatch, this.props.net, this.props.address, this.props.currencyCode);
     QRCode.toCanvas(this.canvas, this.props.address, { version: 5 }, (err) => {
       if (err) console.log(err)
     });
@@ -48,8 +49,8 @@ class WalletInfo extends Component {
             <div className="label">GAS</div>
             <div className="amountBig">{this.props.gas < 0.001 ? 0 : this.props.gas.toPrecision(5)}</div>
           </div>
-          <div className="fiat">US {this.props.price}</div>
-          <div onClick={() => refreshBalance(this.props.dispatch, this.props.net, this.props.address)}>
+          <Balance/>
+          <div onClick={() => refreshBalance(this.props.dispatch, this.props.net, this.props.address, this.props.currencyCode)}>
             <MdSync id="refresh"/>
           </div>
         </div>

--- a/app/reducers/wallet.js
+++ b/app/reducers/wallet.js
@@ -1,10 +1,10 @@
 import * as types from '../actions/types';
 
 // reducer for wallet account balance
-export default (state = {Neo: 0, Gas: 0, transactions: [], price: '--'}, action) => {
+export default (state = {Neo: 0, Gas: 0, transactions: [], price: '--', currencyCode: 'USD'}, action) => {
   switch (action.type) {
       case types.SET_BALANCE:
-          return {...state, 'Neo': action.Neo, 'Gas': action.Gas, 'price': action.price };
+          return {...state, 'Neo': action.Neo, 'Gas': action.Gas, 'price': action.price, 'currencyCode': action.currencyCode };
       case types.RESET_PRICE:
           return {...state, 'price': '--'};
       case types.SET_MARKET_PRICE:  //current market price action type

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "bigi": "^1.4.2",
     "buffer": "^5.0.6",
     "crypto-js": "^3.1.9-1",
+    "currency-formatter": "^1.2.1",
     "ecurve": "^1.0.5",
     "elliptic": "^6.4.0",
     "file-loader": "^0.9.0",


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
https://github.com/CityOfZion/neon-wallet/issues/44

**What problem does this PR solve?**
Currently, the price of NEO is only displayed (hardcoded) in USD. With my approach, the currency is more dynamic and can be switched in the first approach between USD and EUR. Adding further currencies should be easy. 

**How did you solve this problem?**
I created a new React Component (Balance), with is responsible for fetching the balance and converting it into the current market price. This component is reusable and can be used in other parts of the application. With a click on the currency label, the price is switched between USD and EUR. For proper currency formatting, a node.js library was used. 


**How did you make sure your solution works?**
Unfortunately I don't know how to receive NEO on TestNet. Therefore, I only checked it with passing a manual price into the `getMarketPrice` method. If you can provide me test NEO, I'll do some test transaction and check whether the price is updated or not. 

**Are there any special changes in the code that we should be aware of?**
The `getMarketPrice` method should be moved to neon-js. I'll create a separate PR for this. After that, this method can be deleted in this codebase and imported from the new neon-js version.  

**Is there anything else we should know?**
I'm pretty new to React and this was basically my first approach. Please consider this PR more like an suggestion instead of a finished and well tested implementation. I'm open for your feedback. 

- [ ] Unit tests written?
