### PR TITLE
ExplorerSwitch component to select a english blockchain explorer

### DIFF
--- a/app/components/ExplorerSwitch.js
+++ b/app/components/ExplorerSwitch.js
@@ -4,8 +4,6 @@ import { setExplorer } from '../modules/explorer';
 
 class ExplorerSwitch extends Component {
   componentDidMount = () => {
-    console.log("state", this.state);
-    console.log("props", this.props);
     this.toggleExplorer = this.toggleExplorer.bind(this);
   }
   

--- a/app/components/ExplorerSwitch.js
+++ b/app/components/ExplorerSwitch.js
@@ -1,0 +1,32 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { setExplorer } from '../modules/explorer';
+
+class ExplorerSwitch extends Component {
+  componentDidMount = () => {
+    console.log("state", this.state);
+    console.log("props", this.props);
+    this.toggleExplorer = this.toggleExplorer.bind(this);
+  }
+  
+  toggleExplorer(){
+    const explorer = this.props.explorer.label === 'Antcha' ? 'NeoTracker' : 'Antcha';
+    this.props.dispatch( setExplorer(explorer) );
+  }
+
+
+  render = () =>
+    <div id="explorerSwitch">
+      <span className="transparent">Explorer: </span>
+      <span className="explorerName" onClick={() => this.toggleExplorer()}>{this.props.explorer.label}</span>
+    </div>;
+
+}
+
+const mapStateToProps = (state) => ({
+  explorer: state.explorer.selected
+});
+
+ExplorerSwitch = connect(mapStateToProps)(ExplorerSwitch);
+
+export default ExplorerSwitch;

--- a/app/components/TransactionHistory.js
+++ b/app/components/TransactionHistory.js
@@ -4,16 +4,16 @@ import { syncTransactionHistory } from "../components/NetworkSwitch";
 import { shell } from 'electron';
 import Copy from 'react-icons/lib/md/content-copy';
 import { clipboard } from 'electron';
-
+import ExplorerSwitch from '../components/ExplorerSwitch'
 // TODO: make this a user setting
-const getExplorerLink = (net, txid) => {
+const getExplorerLink = (net, txid, explorer) => {
   let base;
   if (net === "MainNet"){
-    base = "http://antcha.in";
+    base = explorer.mainnet_url;
   } else {
-    base = "http://testnet.antcha.in";
+    base = explorer.testnet_url;
   }
-  return base + "/tx/hash/" + txid;
+  return `${base}${explorer.hash_path}${txid}`;
 }
 
 // helper to open an external web link
@@ -30,6 +30,7 @@ class TransactionHistory extends Component {
   render = () =>
     <div id="transactionInfo">
       <div className="columnHeader">Transaction History</div>
+      <ExplorerSwitch />
       <div className="headerSpacer"></div>
       <ul id="transactionList">
         {this.props.transactions.map((t) => {
@@ -40,8 +41,8 @@ class TransactionHistory extends Component {
           if ((formatAmount > 0 && formatAmount < 0.001) || (formatAmount < 0 && formatAmount > -0.001)){
             formatAmount = 0.0.toPrecision(5);
           }
-          return (<li>
-              <div className="txid" onClick={() => openExplorer(getExplorerLink(this.props.net, t.txid))}>
+          return (<li key={t.txid}>
+              <div className="txid" onClick={() => openExplorer(getExplorerLink(this.props.net, t.txid, this.props.explorer))}>
                 {t.txid.substring(0,32)}</div><div className="amount">{formatAmount} {t.type}
               </div></li>);
         })}
@@ -52,7 +53,8 @@ class TransactionHistory extends Component {
 const mapStateToProps = (state) => ({
   address: state.account.address,
   net: state.metadata.network,
-  transactions: state.wallet.transactions
+  transactions: state.wallet.transactions,
+  explorer: state.explorer.selected
 });
 
 TransactionHistory = connect(mapStateToProps)(TransactionHistory);

--- a/app/containers/Dashboard.js
+++ b/app/containers/Dashboard.js
@@ -50,9 +50,9 @@ class Dashboard extends Component {
           <SplitPane className="navSplit" split="horizontal" size="40px" allowResize={false}>
             <div id="navBar">
               <div id="title"><img src={logo} width="60px"/></div>
-              <div id="version"><span className="grey">Version</span><span className="darker">{version}</span></div>              
+              <div id="version"><span className="grey">Version</span><span className="darker">{version}</span></div>
               <div id="height"><span className="grey">Block</span><span className="darker">{this.props.blockHeight}</span></div>
-              <NetworkSwitch />              
+              <NetworkSwitch />
               <Logout />
             </div>
             <SplitPane split="vertical" size="50%" allowResize={false}>

--- a/app/containers/Dashboard.js
+++ b/app/containers/Dashboard.js
@@ -50,9 +50,9 @@ class Dashboard extends Component {
           <SplitPane className="navSplit" split="horizontal" size="40px" allowResize={false}>
             <div id="navBar">
               <div id="title"><img src={logo} width="60px"/></div>
-              <div id="version"><span className="grey">Version</span><span className="darker">{version}</span></div>
+              <div id="version"><span className="grey">Version</span><span className="darker">{version}</span></div>              
               <div id="height"><span className="grey">Block</span><span className="darker">{this.props.blockHeight}</span></div>
-              <NetworkSwitch />
+              <NetworkSwitch />              
               <Logout />
             </div>
             <SplitPane split="vertical" size="50%" allowResize={false}>

--- a/app/modules/explorer.js
+++ b/app/modules/explorer.js
@@ -1,0 +1,39 @@
+// Constants
+import { find } from 'lodash';
+
+const SET_EXPLORER = 'SET_EXPLORER';
+const availableExplorers = [
+    {
+        label: 'Antcha',
+        mainnet_url: 'http://antcha.in',
+        testnet_url: 'http://testnet.antcha.in',
+        hash_path:   '/tx/hash/' 
+    },
+    {
+        label: 'NeoTracker',
+        mainnet_url: 'https://neotracker.io',
+        testnet_url: 'http://testnet.neotracker.io',
+        hash_path:   '/tx/' 
+    }
+];
+
+// Actions
+export function setExplorer(item){    
+  const explorer = find(availableExplorers, ['label', item]);
+  return {
+    type: SET_EXPLORER,
+    explorer: explorer
+  }
+};
+
+
+export default (state = { selected: availableExplorers[0] }, action) => {
+  switch (action.type) {
+    case SET_EXPLORER:
+      return { 
+          selected: action.explorer 
+    };
+    default:
+      return state;
+  }
+};

--- a/app/store/reducers.js
+++ b/app/store/reducers.js
@@ -6,6 +6,7 @@ import metadata from '../modules/metadata'
 import wallet from '../modules/wallet'
 import claim from '../modules/claim'
 import dashboard from '../modules/dashboard'
+import explorer from '../modules/explorer'
 
 export default combineReducers({
     account,
@@ -14,5 +15,6 @@ export default combineReducers({
     transactions,
     dashboard,
     metadata,
-    claim
+    claim,
+    explorer
 });

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -197,6 +197,22 @@ button.disabled{
 			cursor:pointer;
 		}
 	}
+
+	#explorerSwitch{
+		font-size:.8em;
+		right:80px;
+		top:13px;
+		span.transparent{
+			opacity:.6;
+			margin-right:4px;
+		}
+		span.explorerName{
+			color:$thin-text-color;
+			opacity:.8;
+			cursor:pointer;
+		}
+	}
+
 	#logout{
 		position:absolute;
 		font-size:1.5em;


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
[GitHub 43](https://github.com/CityOfZion/neon-wallet/issues/43)

**What problem does this PR solve?**
Add a switch component to select either `antcha.in` or `neotracker.io` as blockchain explorer.
Antcha is the default choice for retro compatibility.

**How did you solve this problem?**
Created the ExplorerSwitch component with related reducer.
<img src="https://media.giphy.com/media/26n6Bcj3UG1EVlWsE/giphy.gif"/>

**How did you make sure your solution works?**
Manual testing

**Are there any special changes in the code that we should be aware of?**
No
**Is there anything else we should know?**
No
- [ ] Unit tests written?
