### PR TITLE
#38 avoiding the app to 'freeze' in dock after being closed

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,6 +4,10 @@ const app = electron.app;
 const Menu = electron.Menu;
 const BrowserWindow = electron.BrowserWindow;
 
+app.on('window-all-closed', () => {
+  app.quit()
+})
+
 app.on('ready', () => {
   mainWindow = new BrowserWindow({
     height: 750,


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
[Github 38](https://github.com/CityOfZion/neon-wallet/issues/38)

**What problem does this PR solve?**
Quit the app once all the windows are closed.

**How did you solve this problem?**
Added a listener which will close the app on window-all-closed.

**How did you make sure your solution works?**
Manual testing on Sierra 10.12.4, I don't have a windows/linux machine to test on right now.

**Are there any special changes in the code that we should be aware of?**
Nope

**Is there anything else we should know?**
Nope

- [ ] Unit tests written?
