### PR TITLE
Added key property to transaction array li element

### DIFF
--- a/app/components/TransactionHistory.js
+++ b/app/components/TransactionHistory.js
@@ -40,7 +40,7 @@ class TransactionHistory extends Component {
           if ((formatAmount > 0 && formatAmount < 0.001) || (formatAmount < 0 && formatAmount > -0.001)){
             formatAmount = 0.0.toPrecision(5);
           }
-          return (<li>
+          return (<li key={t.txid}>
               <div className="txid" onClick={() => openExplorer(getExplorerLink(this.props.net, t.txid))}>
                 {t.txid.substring(0,32)}</div><div className="amount">{formatAmount} {t.type}
               </div></li>);


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
None.

**What problem does this PR solve?**
React warning message appeared in the console because sibling elements need some sort of unique identifier when they're created with functions such as `map`

**How did you solve this problem?**
Added key property to `li` element that is the transaction id `t.txid`

**How did you make sure your solution works?**
No console warning

**Are there any special changes in the code that we should be aware of?**
None

**Is there anything else we should know?**
No

- [ ] Unit tests written?

https://fb.me/react-warning-keys

<img width="990" alt="screen shot 2017-08-10 at 10 43 05 pm" src="https://user-images.githubusercontent.com/1169005/29202465-550d46be-7e1d-11e7-8d14-093ba14e6473.png">
