### PR TITLE
fix #72 Feeback when trying to log in with a wrong key

### DIFF
--- a/app/components/Login.js
+++ b/app/components/Login.js
@@ -17,6 +17,11 @@ let Login = ({ dispatch, loggedIn, wif }) =>
     <div className="login">
       <div className="logo"><img src={logo} width="60px"/></div>
       <input type="text" placeholder="Enter your private key here (WIF)" onChange={(e) => onWifChange(dispatch, e.target.value)} />
+        {!loggedIn && wif && wif.length > 0 ? (
+          <div>Private Key is not in proper WIF format.</div>
+        ) : (
+          <div></div>
+        )}
       <div className="loginButtons">
         {loggedIn ? <Link to="/dashboard"><button>Login</button></Link> : <button disabled="true">Login</button>}
         <Link to="/create"><button>New Wallet</button></Link>

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -35,7 +35,7 @@ button{
 	border:none;
 	cursor:pointer;
 }
-button:hover{
+button:hover:enabled{
 	background-color:$default-button-hover;
 }
 button a{
@@ -43,7 +43,7 @@ button a{
 	color:inherit;
 }
 
-button.disabled{
+button:disabled{
 	opacity:.6;
 }
 


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**

**What problem does this PR solve?**
Fixes issue #72 

**How did you solve this problem?**
Added the text "Private Key is not in proper WIF format." when entry to WIF input text box was not in proper format.  Also fixed the css so that the Login button would show disabled.

**How did you make sure your solution works?**
Tested with values of "foo", "a", "1", and a property formatted WIF private key generated by the neon-wallet.

**Are there any special changes in the code that we should be aware of?**
N/A
**Is there anything else we should know?**
N/A
- [ ] Unit tests written?