### PR TITLE
Introduce "Remember my login" feature to automatically load the dashboard

### DIFF
--- a/app/components/Login.js
+++ b/app/components/Login.js
@@ -1,9 +1,10 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
-import { login } from '../modules/account';
+import { login, setRememberLogin, getStoredPrivateKey } from '../modules/account';
 import CreateWallet from './CreateWallet.js'
 import { getWIFFromPrivateKey } from 'neon-js';
+import { withRouter } from 'react-router';
 
 const logo = require('../images/neon-logo2.png');
 
@@ -12,7 +13,24 @@ const onWifChange = (dispatch, value) => {
   dispatch(login(value));
 };
 
+const onRememberLoginChanged = (dispatch, value) => {
+  dispatch(setRememberLogin(value));
+};
+
 class Login extends Component {
+  componentDidMount = () => {
+    // If we have a previously stored private key
+    // then automatic login was chosen and we should login right away
+    var privateKey = getStoredPrivateKey();
+    if (privateKey) {
+      // Run through the login process
+      this.props.dispatch(login(privateKey));
+
+      // Perform a navigation to the dashboard
+      this.props.router.push('/dashboard');
+    }
+  }
+
   render = () => 
     <div id="loginPage">
       <div className="login">
@@ -22,6 +40,10 @@ class Login extends Component {
           {this.props.loggedIn ? <Link to="/dashboard"><button>Login</button></Link> : <button disabled="true">Login</button>}
           <Link to="/create"><button>New Wallet</button></Link>
         </div>
+        <div className="rememberLoginField">
+          <input id="rememberLogin" type="checkbox" onClick={(e) => onRememberLoginChanged(this.props.dispatch, e.target.checked)} />
+          <label htmlFor="rememberLogin"> Remember my private key and login automatically</label>
+        </div>
         <div id="footer">Created by Ethan Fast and COZ. Donations: Adr3XjZ5QDzVJrWvzmsTTchpLRRGSzgS5A</div>
       </div>
     </div>;
@@ -29,9 +51,10 @@ class Login extends Component {
 
 const mapStateToProps = (state) => ({
   loggedIn: state.account.loggedIn,
-  wif: state.account.wif
+  wif: state.account.wif,
+  rememberLogin: state.account.rememberLogin
 });
 
-Login = connect(mapStateToProps)(Login);
+Login = connect(mapStateToProps)(withRouter(Login));
 
 export default Login;

--- a/app/components/Login.js
+++ b/app/components/Login.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
 import { login } from '../modules/account';
@@ -12,18 +12,20 @@ const onWifChange = (dispatch, value) => {
   dispatch(login(value));
 };
 
-let Login = ({ dispatch, loggedIn, wif }) =>
-  <div id="loginPage">
-    <div className="login">
-      <div className="logo"><img src={logo} width="60px"/></div>
-      <input type="text" placeholder="Enter your private key here (WIF)" onChange={(e) => onWifChange(dispatch, e.target.value)} />
-      <div className="loginButtons">
-        {loggedIn ? <Link to="/dashboard"><button>Login</button></Link> : <button disabled="true">Login</button>}
-        <Link to="/create"><button>New Wallet</button></Link>
+class Login extends Component {
+  render = () => 
+    <div id="loginPage">
+      <div className="login">
+        <div className="logo"><img src={logo} width="60px"/></div>
+        <input type="text" placeholder="Enter your private key here (WIF)" onChange={(e) => onWifChange(this.props.dispatch, e.target.value)} />
+        <div className="loginButtons">
+          {this.props.loggedIn ? <Link to="/dashboard"><button>Login</button></Link> : <button disabled="true">Login</button>}
+          <Link to="/create"><button>New Wallet</button></Link>
+        </div>
+        <div id="footer">Created by Ethan Fast and COZ. Donations: Adr3XjZ5QDzVJrWvzmsTTchpLRRGSzgS5A</div>
       </div>
-      <div id="footer">Created by Ethan Fast and COZ. Donations: Adr3XjZ5QDzVJrWvzmsTTchpLRRGSzgS5A</div>
-    </div>
-  </div>;
+    </div>;
+}
 
 const mapStateToProps = (state) => ({
   loggedIn: state.account.loggedIn,

--- a/app/modules/account.js
+++ b/app/modules/account.js
@@ -1,10 +1,32 @@
 import { getAccountsFromWIFKey } from 'neon-js';
+const settings = require('electron-settings');
 
 // Constants
 const LOGIN = 'LOGIN';
 const LOGOUT = 'LOGOUT';
+const REMEMBER_LOGIN = 'REMEMBER_LOGIN';
+const SETTING_PRIVATE_KEY = 'account.privateKey';
 
 // Actions
+export function getStoredPrivateKey() {
+  return settings.get(SETTING_PRIVATE_KEY);
+}
+
+export function setStoredPrivateKey(value) {
+  return settings.set(SETTING_PRIVATE_KEY, value);
+}
+
+export function deleteStoredPrivateKey() {
+  return settings.delete(SETTING_PRIVATE_KEY);
+}
+
+export function setRememberLogin(value){
+  return {
+    type: REMEMBER_LOGIN,
+    value: value
+  }
+};
+
 export function login(wif){
   return {
     type: LOGIN,
@@ -19,8 +41,10 @@ export function logout(){
 };
 
 // Reducer that manages account state (account now = private key)
-export default (state = {wif: null, address:null, loggedIn: false}, action) => {
+export default (state = {wif: null, address:null, loggedIn: false, rememberLogin: false}, action) => {
   switch (action.type) {
+    case REMEMBER_LOGIN:
+      return {...state, rememberLogin: action.value};
     case LOGIN:
       let loadAccount;
       try {
@@ -30,8 +54,16 @@ export default (state = {wif: null, address:null, loggedIn: false}, action) => {
       if(loadAccount === -1 || loadAccount === -2 || loadAccount === undefined){
         return {...state, wif:action.wif,  loggedIn:false};
       }
+
+      // Store private key for automatic login?
+      if (state.rememberLogin)
+        setStoredPrivateKey(action.wif);
+
       return {...state, wif:action.wif, address:loadAccount.address, loggedIn:true};
     case LOGOUT:
+      // Delete our stored private key to forget any automatic login
+      deleteStoredPrivateKey();
+
       return {'wif': null, address: null, 'loggedIn': false};
     default:
       return state;

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -97,7 +97,7 @@ button.disabled{
 		margin:10px auto;
 		text-align: left;
 	}
-	input{
+	input[type=text]{
 		width:600px;
 		font-size:1.2em;
 		padding:7px 15px;
@@ -108,7 +108,7 @@ button.disabled{
 	}
 	margin-top:25%;
 	text-align:center;
-	.loginButtons{
+	.loginButtons, .rememberLoginField{
 		margin:10px auto;
 		width:630px;
 		text-align:left;

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "crypto-js": "^3.1.9-1",
     "ecurve": "^1.0.5",
     "electron-context-menu": "^0.9.1",
+    "electron-settings": "^3.1.1",
     "elliptic": "^6.4.0",
     "file-loader": "^0.9.0",
     "fs": "0.0.1-security",


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
#29 

**What problem does this PR solve?**
Introduces a new optional feature, "Remember my login", so that you don't need to re-paste the private key each time opening Neon wallet.

**How did you solve this problem?**
By storing the private key in a settings file, we can refer to it later upon app startup and perform an automatic login.

**How did you make sure your solution works?**
Manual testing.

**Are there any special changes in the code that we should be aware of?**
Yes. It's worth noting this is a simple implementation, and the storage of the private key is unencrypted.

**Is there anything else we should know?**
Yes. We should discuss appropriate storage of the private key. 

I investigated using https://github.com/atom/node-keytar to store the private key in the OS keychain, but there were complication/packaging issues. It also may be more prudent to require a password entry instead of using the keychain.

- [ ] Unit tests written?

![image](https://user-images.githubusercontent.com/229209/29663653-7e6955a0-890f-11e7-85f7-aa1f65e86223.png)
