### PR TITLE
Fixed issue with treating key read as success when it fails

### DIFF
--- a/app/components/DisplayWalletKeys.js
+++ b/app/components/DisplayWalletKeys.js
@@ -13,9 +13,14 @@ let key_name;
 
 const saveKey = (dispatch, encWifValue) => {
   storage.get('keys', (error, data) => {
-    data[key_name.value] = encWifValue
-    dispatch(sendEvent(true, "Saved key as "+key_name.value))
-    storage.set('keys', data);
+    if (error) {
+      dispatch(sendEvent(false, "Loading wallet keys failed"));
+    } else {
+      data[key_name.value] = encWifValue
+      dispatch(sendEvent(true, "Saved key as "+key_name.value))
+      storage.set('keys', data);
+    }
+
     setTimeout(() => dispatch(clearTransactionEvent()), 5000);
   });
 };

--- a/app/components/LoginLocalStorage.js
+++ b/app/components/LoginLocalStorage.js
@@ -37,7 +37,12 @@ class LoginLocalStorage extends Component {
 
   componentDidMount = () => {
     storage.get('keys', (error, data) => {
-      this.props.dispatch(setKeys(data));
+      if (error) {
+        this.props.dispatch(sendEvent(false, "Loading wallet keys failed"));
+        setTimeout(() => this.props.dispatch(clearTransactionEvent()), 5000);
+      } else {
+        this.props.dispatch(setKeys(data));
+      }
     });
   }
 


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
None that I know of.

**What problem does this PR solve?**
If keys fails to load from storage, it is still treated as a successful read and may result in saving of bad data, for example.

**How did you solve this problem?**
Check for error result and display a user-friendly error message.

**How did you make sure your solution works?**
TODO: I haven't yet.  I will add tests/smoke tests if this otherwise looks good.

**Are there any special changes in the code that we should be aware of?**
No.

**Is there anything else we should know?**
No.

- [ ] Unit tests written?
Not yet.