### PR TITLE
Remove requirement to globally install Webpack and Jest

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,24 +13,22 @@ A standalone app will be available soon. For now, you will need to build the wal
 ### Required Tools and Dependencies
 
   - Node (This project uses the current LTS node version, which is `v6.11.0`)
-  - `npm install -g webpack` Global Webpack 
-  - `npm install -g jest` Unit testing framework
 
 ### Developing and Running
 
 Execute these commands in the project's root directory:
 
   - `npm install` Installing node dependencies
-  - `webpack` or `webpack --watch` for live reload.
+  - `npm run assets` or `npm run assets-watch` for live reload.
   - `npm start` for running the project
-  - `npm test` or `npm test-watch` for live testing.
+  - `npm test` or `npm run test-watch` for live testing.
 
-### Support 
+### Support
 
-A gentle reminder, github issues is meant to be used by developers for maintaining and improving the codebase, and is not the proper location for support issues. Questions such as 
+A gentle reminder, github issues is meant to be used by developers for maintaining and improving the codebase, and is not the proper location for support issues. Questions such as
 
 - Why can't I log in?
 - I lost my private key, is there anyway to recover?
 - Why is my balance not showing?
 
-should be asked in proper support channels such as the [NEO subreddit](https://www.reddit.com/r/NEO/), or the official [NEO slack](https://neosmarteconomy.slack.com). 
+should be asked in proper support channels such as the [NEO subreddit](https://www.reddit.com/r/NEO/), or the official [NEO slack](https://neosmarteconomy.slack.com).

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
   "description": "Light wallet for NEO blockchain",
   "author": "Ethan Fast <ejhfast@gmail.com> (https://github.com/Ejhfast)",
   "scripts": {
-    "postinstall": "install-app-deps",
+    "postinstall": "electron-builder install-app-deps",
     "start": "electron .",
+    "assets": "webpack",
+    "assets-watch": "webpack --watch",
     "test": "jest",
     "test-watch": "jest --watch",
     "pack": "build --dir",


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
You shouldn't have to install global versions of Webpack and Jest since they already get installed via `npm install`. 

**How did you solve this problem?**
Move calls to webpack into `npm scripts` so that the dependency bundle can be accessed directly. 

I called the scripts `assets` and `assets-watch` to keep them resilient to a future in which another asset bundler is used instead of `webpack`. 

I also got rid of a console warning being sent from the `postinstall` script by changing `install-app-deps` to `electron-builder install-app-deps`

Updates README to reflect these changes. 

**How did you make sure your solution works?**
Manually ran `npm run assets` `npm run assets-watch`

**Are there any special changes in the code that we should be aware of?**
No. 

**Is there anything else we should know?**
No.

- [ ] Unit tests written? - N/A
