### PR TITLE
add tests for WalletInfo component

### DIFF
--- a/__tests__/components/TransactionHistory.test.js
+++ b/__tests__/components/TransactionHistory.test.js
@@ -29,7 +29,7 @@ const transactions = {
       },
       {
         type: 'GAS',
-        amount: '0.40000',
+        amount: '0.4',
         txid: '76938980'
       }
     ]

--- a/__tests__/components/WalletInfo.test.js
+++ b/__tests__/components/WalletInfo.test.js
@@ -1,0 +1,152 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { mount, shallow } from 'enzyme';
+import { SET_TRANSACTION_HISTORY, SET_BALANCE } from '../../app/modules/wallet';
+import { SEND_TRANSACTION, CLEAR_TRANSACTION } from '../../app/modules/transactions';
+import { SET_HEIGHT } from '../../app/modules/metadata';
+import { SET_CLAIM } from '../../app/modules/claim';
+import WalletInfo from '../../app/components/WalletInfo';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { clipboard } from 'electron';
+
+jest.mock('electron', () => ({
+  clipboard: {
+    writeText: jest.fn(),
+  },
+}));
+
+jest.unmock('qrcode');
+import QRCode from 'qrcode';
+QRCode.toCanvas = jest.fn();
+
+const initialState = {
+  account: {
+    address: 'ANqUrhv99rwCiFTL6N1An9NH5UVkPYxTuw'
+  },
+  metadata: {
+    network: 'TestNet'
+  },
+  wallet: {
+    Neo: 10,
+    Gas: 1.0001,
+    price: 25.48
+  },
+  claim: {
+    claimAmount: 0.5
+  }
+};
+
+const setup = (state = initialState, shallowRender = true) => {
+  const store = configureStore()(state);
+
+  let wrapper;
+  if (shallowRender) {
+    wrapper = shallow(<WalletInfo store={store} />);
+  } else {
+    wrapper = mount(
+      <Provider store={store}>
+        <WalletInfo />
+      </Provider>
+    );
+  }
+
+  return {
+    store,
+    wrapper
+  };
+};
+
+
+describe('WalletInfo', () => {
+  test('renders without crashing', (done) => {
+    const { wrapper } = setup();
+    expect(wrapper).toMatchSnapshot();
+    done();
+  });
+  test('correctly renders data from state', (done) => {
+    const { wrapper } = setup(initialState, false);
+
+    const addressField = wrapper.find('.address');
+    const fiatField = wrapper.find('.fiat');
+    const neoField = wrapper.find('.amountNeo');
+    const gasField = wrapper.find('.amountGas');
+
+    expect(fiatField.text()).toEqual(`US ${initialState.wallet.price}`);
+    expect(addressField.text().split('<')[0]).toEqual(initialState.account.address);
+    expect(neoField.text()).toEqual(`${initialState.wallet.Neo}`);
+    expect(gasField.text()).toEqual(`${Math.floor(initialState.wallet.Gas * 10000) / 10000}`);
+    done();
+  });
+  test('copy to clipboard is getting called on click', (done) => {
+    const { wrapper } = setup();
+    const deepWrapper = wrapper.dive();
+
+    expect(clipboard.writeText.mock.calls.length).toBe(0);
+    deepWrapper.find('.copyKey').simulate('click');
+    setTimeout(() => {
+      try {
+        expect(clipboard.writeText.mock.calls.length).toBe(1);
+        done();
+      } catch(e) {
+        done.fail(e);
+      }
+    }, 10)
+  });
+  test('refreshBalance is getting called on click', (done) => {
+    const { wrapper, store } = setup();
+    const state = store.getState();
+    const deepWrapper = wrapper.dive();
+
+    const actionTypes = [
+      SEND_TRANSACTION,
+      SET_TRANSACTION_HISTORY,
+      SET_HEIGHT,
+      SET_BALANCE,
+      CLEAR_TRANSACTION,
+      SET_CLAIM
+    ];
+    deepWrapper.find('.refreshBalance').simulate('click');
+    setTimeout(() => {
+      try {
+        const actions = store.getActions();
+        // TODO investigate why the actions length fluctuates here and test the length(s)
+        // Also, I got an error once so I suspect it might not always be 6 or 7 but I can't reproduce a different length
+        // console.log('actions.length', actions.length);
+        // expect(actions.length === 6 || actions.length === 7).toEqual(true);
+        actions.forEach(action => {
+          expect(actionTypes.indexOf(action.type) > -1).toEqual(true)
+        });
+        done();
+      } catch(e) {
+        done.fail(e);
+      }
+    }, 1500)
+  });
+  test('calls the correct number of actions after mounting', (done) => {
+    const mock = new MockAdapter(axios);
+    const data = { result: { Last: 24.50 } };
+    mock.onGet('https://bittrex.com/api/v1.1/public/getticker?market=USDT-NEO').reply(200, data);
+
+    const { wrapper, store } = setup(initialState, false);
+    const actionTypes = [
+      SET_TRANSACTION_HISTORY,
+      SET_HEIGHT,
+      SET_BALANCE,
+      SET_CLAIM
+    ];
+    setTimeout(() => {
+      try {
+        const actions = store.getActions();
+        expect(actions.length).toEqual(4);
+        actions.forEach(action => {
+          expect(actionTypes.indexOf(action.type) > -1).toEqual(true)
+        });
+        done();
+      } catch(e) {
+        done.fail(e);
+      }
+    }, 1500);
+  });
+});

--- a/__tests__/components/__snapshots__/WalletInfo.test.js.snap
+++ b/__tests__/components/__snapshots__/WalletInfo.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WalletInfo renders without crashing 1`] = `
+<WalletInfo
+  address="ANqUrhv99rwCiFTL6N1An9NH5UVkPYxTuw"
+  dispatch={[Function]}
+  gas={1.0001}
+  neo={10}
+  net="TestNet"
+  price={25.48}
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
+/>
+`;

--- a/app/components/WalletInfo.js
+++ b/app/components/WalletInfo.js
@@ -43,13 +43,13 @@ class WalletInfo extends Component {
         <div id="balance">
           <div className="split">
             <div className="label">NEO</div>
-            <div className="amountBig">{this.props.neo}</div>
+            <div className="amountBig amountNeo">{this.props.neo}</div>
           </div>
           <div className="split">
             <div className="label">GAS</div>
-            <div className="amountBig">{ Math.floor(this.props.gas * 10000) / 10000 }</div>
+            <div className="amountBig amountGas">{ Math.floor(this.props.gas * 10000) / 10000 }</div>
           </div>
-          <div onClick={() => refreshBalance(this.props.dispatch, this.props.net, this.props.address)} >
+          <div className="refreshBalance" onClick={() => refreshBalance(this.props.dispatch, this.props.net, this.props.address)} >
             <MdSync id="refresh" data-tip data-for="refreshBalanceTip"/>
             <ReactTooltip class="solidTip" id="refreshBalanceTip" place="bottom" type="dark" effect="solid">
               <span>Refresh account balance</span>

--- a/app/modules/account.js
+++ b/app/modules/account.js
@@ -1,11 +1,10 @@
 import { getAccountsFromWIFKey } from 'neon-js';
 
 // Constants
-const LOGIN = 'LOGIN';
-const LOGOUT = 'LOGOUT';
-const SET_DECRYPTING = 'SET_DECRYPTING';
-const SET_KEYS = 'SET_KEYS';
-
+export const LOGIN = 'LOGIN';
+export const LOGOUT = 'LOGOUT';
+export const SET_DECRYPTING = 'SET_DECRYPTING';
+export const SET_KEYS = 'SET_KEYS';
 
 // Actions
 export function login(wif){

--- a/app/modules/claim.js
+++ b/app/modules/claim.js
@@ -1,7 +1,9 @@
-const SET_CLAIM = 'SET_CLAIM';
-const SET_CLAIM_REQUEST = 'SET_CLAIM_REQUEST';
-const DISABLE_CLAIM = 'DISABLE_CLAIM';
+// Constants
+export const SET_CLAIM = 'SET_CLAIM';
+export const SET_CLAIM_REQUEST = 'SET_CLAIM_REQUEST';
+export const DISABLE_CLAIM = 'DISABLE_CLAIM';
 
+// Actions
 export function setClaim(available, unavailable){
   return {
     type: SET_CLAIM,

--- a/app/modules/dashboard.js
+++ b/app/modules/dashboard.js
@@ -1,5 +1,5 @@
 // Constants
-const TOGGLE_SEND_PANE = 'TOGGLE_SEND_PANE';
+export const TOGGLE_SEND_PANE = 'TOGGLE_SEND_PANE';
 
 // Actions
 export function togglePane(pane){

--- a/app/modules/generateWallet.js
+++ b/app/modules/generateWallet.js
@@ -2,11 +2,12 @@ import { getAccountsFromWIFKey, generatePrivateKey, getWIFFromPrivateKey } from 
 import { encrypt_wif, decrypt_wif } from 'neon-js';
 
 // Constants
-const NEW_WALLET_KEYS = 'NEW_WALLET_KEYS';
-const NEW_WALLET = 'NEW_WALLET';
-const SET_GENERATING = 'SET_GENERATING';
-const RESET_KEY = 'RESET_KEY';
+export const NEW_WALLET_KEYS = 'NEW_WALLET_KEYS';
+export const NEW_WALLET = 'NEW_WALLET';
+export const SET_GENERATING = 'SET_GENERATING';
+export const RESET_KEY = 'RESET_KEY';
 
+// Actions
 export function newWalletKeys(passphrase){
   return {
     type: NEW_WALLET_KEYS,

--- a/app/modules/metadata.js
+++ b/app/modules/metadata.js
@@ -1,7 +1,7 @@
 // Constants
-const SET_HEIGHT = 'SET_HEIGHT';
-const SET_NETWORK = 'SET_NETWORK';
-const SET_EXPLORER = 'SET_EXPLORER';
+export const SET_HEIGHT = 'SET_HEIGHT';
+export const SET_NETWORK = 'SET_NETWORK';
+export const SET_EXPLORER = 'SET_EXPLORER';
 
 // Actions
 export function setNetwork(net){

--- a/app/modules/transactions.js
+++ b/app/modules/transactions.js
@@ -1,7 +1,7 @@
 // Constants
-const SEND_TRANSACTION = 'SEND_TRANSACTION';
-const CLEAR_TRANSACTION = 'CLEAR_TRANSACTION';
-const TOGGLE_ASSET = 'TOGGLE_ASSET';
+export const SEND_TRANSACTION = 'SEND_TRANSACTION';
+export const CLEAR_TRANSACTION = 'CLEAR_TRANSACTION';
+export const TOGGLE_ASSET = 'TOGGLE_ASSET';
 
 // Actions
 export function sendEvent(success, message){

--- a/app/modules/wallet.js
+++ b/app/modules/wallet.js
@@ -1,8 +1,8 @@
 // Constants
-const SET_BALANCE = 'SET_BALANCE';
-const SET_MARKET_PRICE = 'SET_MARKET_PRICE';
-const RESET_PRICE = 'RESET_PRICE';
-const SET_TRANSACTION_HISTORY = 'SET_TRANSACTION_HISTORY';
+export const SET_BALANCE = 'SET_BALANCE';
+export const SET_MARKET_PRICE = 'SET_MARKET_PRICE';
+export const RESET_PRICE = 'RESET_PRICE';
+export const SET_TRANSACTION_HISTORY = 'SET_TRANSACTION_HISTORY';
 
 // Actions
 export function setBalance(neo, gas, price){

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "axios": "^0.16.2",
+    "axios-mock-adapter": "^1.9.0",
     "base-x": "^3.0.2",
     "bigi": "^1.4.2",
     "bs58check": "^2.0.2",


### PR DESCRIPTION
…to separate file

**What current issue(s) from Trello/Github does this address?**

testing the neon wallet WalletInfo component - I also exported the action type constants so they are easier to access for testing

**What problem does this PR solve?**

testing the WalletInfo component

**How did you solve this problem?**

writing functionality and snapshot tests

**How did you make sure your solution works?**

running npm test

**Are there any special changes in the code that we should be aware of?**

there is a need for a try/ catch in some of the async tests to solve a problem I was having with this error message:
"Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL."

Even though no errors were getting caught, the try/ catch blocks are needed and everything is working with them in place.

**Is there anything else we should know?**

In many of my pull requests, I often add classes to html elements instead of traversing the DOM to find children, siblings or specific elements, such as the third li in a list. this is because navigating the DOM from the shallow or mounted wrapper that I am using can be extremely annoying and it is much easier to use "element.find('.classname')", so anything I need to access is generally much easier with its own classname.

- [ ] Unit tests written?
