### PR TITLE
fix async issue with test

### DIFF
--- a/__tests__/components/WalletInfo.test.js
+++ b/__tests__/components/WalletInfo.test.js
@@ -102,7 +102,6 @@ describe('WalletInfo', () => {
   });
   test('refreshBalance is getting called on click', (done) => {
     const { wrapper, store } = setup();
-    const state = store.getState();
     const deepWrapper = wrapper.dive();
 
     const actionTypes = [
@@ -116,12 +115,12 @@ describe('WalletInfo', () => {
     deepWrapper.find('.refreshBalance').simulate('click');
     setTimeout(() => {
       const actions = store.getActions();
-      expect(actions.length === 6).toEqual(true);
+      expect(actions.length === 11).toEqual(true);
       actions.forEach(action => {
         expect(actionTypes.indexOf(action.type) > -1).toEqual(true)
       });
       done();
-    }, 0)
+    }, 1050)
   });
   test('calls the correct number of actions after mounting', (done) => {
     const { wrapper, store } = setup(initialState, false);


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**

testing Neon Wallet

**What problem does this PR solve?**

There is a setTimeout of 1 second for clearTransaction() that needed to execute at the end of refreshBalance, so the setTimeout in the test needed some extra time to run.

**How did you solve this problem?**

increasing the setTimeout length. also, the store.getActions() length increased to 11

**How did you make sure your solution works?**

I ran 'npm test' several times. I wanted to test different timeout lengths and make sure the number of returned actions was always 11.

**Are there any special changes in the code that we should be aware of?**

no

**Is there anything else we should know?**

- [ ] Unit tests written?
