### PR TITLE
Adds husky & prepush hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "pack": "build --dir",
     "dist": "build",
     "lint": "eslint -c .eslintrc ./app --ext .js,.jsx --ignore-pattern dist/",
-    "lint-fix": "eslint -c .eslintrc ./app --ext .js,.jsx --fix --ignore-pattern dist/"
+    "lint-fix": "eslint -c .eslintrc ./app --ext .js,.jsx --fix --ignore-pattern dist/",
+    "prepush": "echo 'running lint...' && yarn lint && echo 'running tests...' && yarn test"
   },
   "keywords": [],
   "license": "ISC",
@@ -114,11 +115,12 @@
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-node": "^5.2.0",
     "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-standard": "^3.0.1",        
     "eslint-plugin-react": "^7.4.0",
+    "eslint-plugin-standard": "^3.0.1",
     "extract-text-webpack-plugin": "^1.0.1",
     "history": "^4.7.2",
     "html-webpack-plugin": "^2.16.1",
+    "husky": "^0.14.3",
     "jest": "^20.0.4",
     "json-loader": "^0.5.4",
     "node-sass": "^3.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3532,6 +3532,14 @@ https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
 
+husky@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
+  dependencies:
+    is-ci "^1.0.10"
+    normalize-path "^1.0.0"
+    strip-indent "^2.0.0"
+
 hyphenate-style-name@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
@@ -4902,6 +4910,10 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-
     is-builtin-module "^1.0.0"
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
+
+normalize-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
 
 normalize-path@^2.0.0, normalize-path@^2.0.1:
   version "2.1.1"
@@ -6726,6 +6738,10 @@ strip-indent@^1.0.1:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
   dependencies:
     get-stdin "^4.0.1"
+
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
 
 strip-json-comments@~2.0.1:
   version "2.0.1"


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
This is part of a general refactor to enhance the developer experience with Neon Wallet.

**What problem does this PR solve?**
Adds a `prepush` command to the scripts using husky (https://github.com/typicode/husky).
It will run the lint & tests on each push.
Its possible to override this behaviour for a quick push using:
`git push ... --no-verify`

I think its great because it allows the developer to know that the commits were adhering to the tests/lint rules.

**How did you solve this problem?**
Added husky and the prepush command.

**How did you make sure your solution works?**
I tested it.