### PR TITLE
fix timing related issue with one of the tests in Send

### DIFF
--- a/__mocks__/neon-js.js
+++ b/__mocks__/neon-js.js
@@ -3,7 +3,7 @@ const neonjs = jest.genMockFromModule('neon-js')
 const promiseMockGen = (result, error = false) => {
   return jest.fn(() => {
     return new Promise((resolve, reject) => {
-      if (error) reject()
+      if (error) reject(error)
       resolve(result)
     })
   })
@@ -22,7 +22,7 @@ neonjs.doSendAsset = promiseMockGen({ result: true })
 neonjs.getAPIEndpoint = jest.fn(() => 'http://testnet-api.wallet.cityofzion.io')
 neonjs.decryptWIF = jest.fn((wif) => {
   return new Promise((resolve, reject) => {
-    if (!wif) reject()
+    if (!wif) reject(new Error())
     resolve(privateKey)
   })
 })

--- a/__tests__/components/Send.test.js
+++ b/__tests__/components/Send.test.js
@@ -221,24 +221,29 @@ describe('Send', () => {
 
     wrapper.find('#confirmPane').simulate('click')
 
-    jest.runAllTimers()
-    // NOTE: there should be an additional 2 actions here
-    // But I am unable to delay the store.getActions call
-    // in order to wait for the doSendAsset promise to resolve
-    // see Send.js ~line 80 where the issue is occuring.
-    // I tried adding a setTimeout here but couldn't get it to work
-    const actions = store.getActions()
-    expect(actions.length === 2).toEqual(true)
-    expect(actions[0]).toEqual({
-      type: SEND_TRANSACTION,
-      success: true,
-      message: 'Processing...'
-    })
-    expect(actions[1]).toEqual({
-      type: TOGGLE_SEND_PANE,
-      pane: 'confirmPane'
-    })
-    done()
+    Promise.resolve('pause').then(() => {
+      jest.runAllTimers()
+      const actions = store.getActions()
+      expect(actions.length === 4).toEqual(true)
+      expect(actions[0]).toEqual({
+        type: SEND_TRANSACTION,
+        success: true,
+        message: 'Processing...'
+      })
+      expect(actions[1]).toEqual({
+        type: TOGGLE_SEND_PANE,
+        pane: 'confirmPane'
+      })
+      expect(actions[2]).toEqual({
+        type: SEND_TRANSACTION,
+        success: true,
+        message: 'Transaction complete! Your balance will automatically update when the blockchain has processed it.'
+      })
+      expect(actions[3]).toEqual({
+        type: CLEAR_TRANSACTION
+      })
+      done()
+    }).catch(e => done.fail(e))
   })
 
   test('component is rendering correctly', (done) => {


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**

testing neon wallet

**What problem does this PR solve?**

Fixes an issue I was having with one of the tests in Send.test.js. Also, I handled some of the neon-js mock promise rejections differently after seeing some comments in my eslint recommendations not to have unhandled promises.

**How did you solve this problem?**

add a promise that resolves to give the event loop an extra cycle. nothing else like a standard setTimeout(() => {}, 0) or process.nextTick would work here

**How did you make sure your solution works?**

running npm test

**Are there any special changes in the code that we should be aware of?**

no

**Is there anything else we should know?**

- [ ] Unit tests written?
