### PR TITLE
Empty Field Checking and User Notification Messages

### DIFF
--- a/app/components/EncryptKey.js
+++ b/app/components/EncryptKey.js
@@ -26,24 +26,29 @@ const generateNewWallet = (dispatch) => {
     setTimeout(() => dispatch(clearTransactionEvent()), 5000)
     return
   }
-  if (validatePassphrase(currentPhrase)) {
-    // TODO: for some reason this blocks, so giving time to processes the earlier
-    // dispatch to display "generating" text, should fix this in future
-    dispatch(sendEvent(true, 'Generating encoded key...'))
-    setTimeout(() => {
-      encryptWifAccount(currentWif, currentPhrase).then((result) => {
-        dispatch(newWallet(result))
-        dispatch(clearTransactionEvent())
-      }).catch(() => {
-        dispatch(sendEvent(false, 'The private key is not valid'))
-        setTimeout(() => dispatch(clearTransactionEvent()), 5000)
-      })
-    }, 500)
+  if (currentWif) {
+    if (validatePassphrase(currentPhrase)) {
+      // TODO: for some reason this blocks, so giving time to processes the earlier
+      // dispatch to display "generating" text, should fix this in future
+      dispatch(sendEvent(true, 'Generating encoded key...'))
+      setTimeout(() => {
+        encryptWifAccount(currentWif, currentPhrase).then((result) => {
+          dispatch(newWallet(result))
+          dispatch(clearTransactionEvent())
+        }).catch(() => {
+          dispatch(sendEvent(false, 'The private key is not valid'))
+          setTimeout(() => dispatch(clearTransactionEvent()), 5000)
+        })
+      }, 500)
+    } else {
+      dispatch(sendEvent(false, 'Please choose a longer passphrase'))
+      setTimeout(() => dispatch(clearTransactionEvent()), 5000)
+      passphraseInput.value = ''
+      passphraseInput2.value = ''
+    }
   } else {
-    dispatch(sendEvent(false, 'Please choose a longer passphrase'))
+    dispatch(sendEvent(false, 'That is not a valid private key'))
     setTimeout(() => dispatch(clearTransactionEvent()), 5000)
-    passphraseInput.value = ''
-    passphraseInput2.value = ''
   }
 }
 

--- a/app/components/LoginLocalStorage.js
+++ b/app/components/LoginLocalStorage.js
@@ -37,6 +37,7 @@ const onWifChange = (dispatch, history) => {
     }, 500)
   } else {
     dispatch(sendEvent(false, 'Please select a wallet'))
+    setTimeout(() => dispatch(clearTransactionEvent()), 5000)
   }
 }
 

--- a/app/components/LoginTokenSale.js
+++ b/app/components/LoginTokenSale.js
@@ -25,7 +25,7 @@ const verifyPrivateKey = (wif) => {
 const onWifChange = (dispatch, history, wif) => {
   const value = wif.value
   // TODO: changed back to only WIF login for now, getting weird errors with private key hex login
-  if (verifyPrivateKey(value) === true) {
+  if (value && verifyPrivateKey(value) === true) {
     dispatch(login(value))
     history.push('/tokenSale')
   } else {


### PR DESCRIPTION
The wallet doesn't check for empty input fields and gives the user no notification message if a field is required or empty. This PR addresses several of those cases, but not necessarily all of them.

