### PR TITLE
Adds redux-logger (dev only)

### DIFF
--- a/app/store/configureStore.dev.js
+++ b/app/store/configureStore.dev.js
@@ -2,13 +2,19 @@ import { createStore, applyMiddleware, compose } from 'redux'
 import rootReducer from './reducers'
 import DevTools from '../containers/DevTools'
 import thunk from 'redux-thunk'
+import logger from 'redux-logger'
 
 export default function configureStore (initialState) {
+  const middlewares = [
+    thunk,
+    logger
+  ]
+
   const store = createStore(
     rootReducer,
     initialState,
     compose(
-      applyMiddleware(thunk),
+      applyMiddleware(...middlewares),
       DevTools.instrument()
     )
   )

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "react-syntax-highlighter": "^5.1.3",
     "react-tooltip": "^3.3.0",
     "redux": "^3.5.2",
+    "redux-logger": "^3.0.6",
     "redux-thunk": "^2.2.0",
     "secure-random": "^1.1.1",
     "wif": "^2.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2529,6 +2529,10 @@ decompress-zip@0.3.0:
     readable-stream "^1.1.8"
     touch "0.0.3"
 
+deep-diff@^0.3.5:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
+
 deep-equal@^1.0.0, deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
@@ -7295,6 +7299,12 @@ redux-devtools@^3.2.0:
     lodash "^4.2.0"
     prop-types "^15.5.7"
     redux-devtools-instrument "^1.0.1"
+
+redux-logger@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
+  dependencies:
+    deep-diff "^0.3.5"
 
 redux-mock-store@^1.2.3:
   version "1.3.0"


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Developer experience improvement.

**What problem does this PR solve?**
The end of console logging your actions/state.

**How did you solve this problem?**
Added the redux-logger package to the configureStore.dev file.

**How did you make sure your solution works?**
Tested it, currently there are some unrelated lint/flow errors. (Will be fixed soon)

<img width="1435" alt="screen shot 2017-10-18 at 10 02 48 pm" src="https://user-images.githubusercontent.com/254095/31715622-55f6ad36-b450-11e7-9290-ee6e79ea2fe8.png">
