### PR TITLE
Fixing spelling of GitHub menu item

### DIFF
--- a/main.js
+++ b/main.js
@@ -55,7 +55,7 @@ app.on('ready', () => {
         role: 'help',
         submenu: [
           {label: 'City of Zion', click () { shell.openExternal('https://cityofzion.io/') }},
-          {label: 'GithHub', click () { shell.openExternal('https://github.com/CityOfZion') }},
+          {label: 'GitHub', click () { shell.openExternal('https://github.com/CityOfZion') }},
           {label: 'NEO Reddit', click () { shell.openExternal('https://www.reddit.com/r/NEO/') }},
           {label: 'Slack', click () { shell.openExternal('https://neosmarteconomy.slack.com') }}
         ]


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
I don't think this has been reported previously.

**What problem does this PR solve?**
Fixes the spelling of the "GitHub" menu item.

**How did you solve this problem?**
Changed the hardcoded text in `main.js`.

**How did you make sure your solution works?**
Built and verified the app on my local.

**Are there any special changes in the code that we should be aware of?**
No

**Is there anything else we should know?**
No

- [ ] Unit tests written?
