### PR TITLE
Adding support for Neoscan explorer

### DIFF
--- a/__mocks__/electron.js
+++ b/__mocks__/electron.js
@@ -3,5 +3,10 @@ module.exports = {
     getPath: () => {
       return 'C:\\tmp\\mock_path'
     }
+  },
+  shell: {
+    openExternal: (url) => {
+      return true
+    }
   }
 }

--- a/__tests__/core/explorer.test.js
+++ b/__tests__/core/explorer.test.js
@@ -1,0 +1,68 @@
+import { getExplorerLink, openExplorer } from '../../app/core/explorer'
+import { NETWORK, EXPLORER } from '../../app/core/constants'
+import { shell } from 'electron'
+
+describe('explorer tests', () => {
+  describe('getExplorerLink tests', () => {
+    test('NeoTracker mainnet explorer test', () => {
+      const net = NETWORK.MAIN
+      const explorer = EXPLORER.NEO_TRACKER
+      const txid = '1234567890abcdef'
+      const expectedUrl = 'https://neotracker.io/tx/1234567890abcdef'
+      expect(getExplorerLink(net, explorer, txid)).toEqual(expectedUrl)
+    })
+
+    test('NeoTracker testnet explorer test', () => {
+      const net = NETWORK.TEST
+      const explorer = EXPLORER.NEO_TRACKER
+      const txid = '1234567890abcdef'
+      const expectedUrl = 'https://testnet.neotracker.io/tx/1234567890abcdef'
+      expect(getExplorerLink(net, explorer, txid)).toEqual(expectedUrl)
+    })
+
+    test('NeoScan mainnet explorer test', () => {
+      const net = NETWORK.MAIN
+      const explorer = EXPLORER.NEO_SCAN
+      const txid = '1234567890abcdef'
+      const expectedUrl = 'https://neoscan.io/transaction/1234567890abcdef'
+      expect(getExplorerLink(net, explorer, txid)).toEqual(expectedUrl)
+    })
+
+    test('NeoScan testnet explorer test', () => {
+      const net = NETWORK.TEST
+      const explorer = EXPLORER.NEO_SCAN
+      const txid = '1234567890abcdef'
+      const expectedUrl = 'https://neoscan-testnet.io/transaction/1234567890abcdef'
+      expect(getExplorerLink(net, explorer, txid)).toEqual(expectedUrl)
+    })
+
+    test('AntChain mainnet explorer test', () => {
+      const net = NETWORK.MAIN
+      const explorer = EXPLORER.ANT_CHAIN
+      const txid = '1234567890abcdef'
+      const expectedUrl = 'http://antcha.in/tx/hash/1234567890abcdef'
+      expect(getExplorerLink(net, explorer, txid)).toEqual(expectedUrl)
+    })
+
+    test('AntChain testnet explorer test', () => {
+      const net = NETWORK.TEST
+      const explorer = EXPLORER.ANT_CHAIN
+      const txid = '1234567890abcdef'
+      const expectedUrl = 'http://testnet.antcha.in/tx/hash/1234567890abcdef'
+      expect(getExplorerLink(net, explorer, txid)).toEqual(expectedUrl)
+    })
+  })
+
+  describe('openExplorer tests', () => {
+    test('open NeoTracker mainnet explorer test', () => {
+      const net = NETWORK.MAIN
+      const explorer = EXPLORER.NEO_TRACKER
+      const txid = '1234567890abcdef'
+      const expectedUrl = 'https://neotracker.io/tx/1234567890abcdef'
+      const spy = jest.spyOn(shell, 'openExternal')
+
+      openExplorer(net, explorer, txid)
+      expect(spy).toHaveBeenCalledWith(expectedUrl)
+    })
+  })
+})

--- a/app/components/Settings.js
+++ b/app/components/Settings.js
@@ -130,6 +130,7 @@ class Settings extends Component<Props, State> {
             <div className='itemTitle'>Block Explorer</div>
             <select value={explorer} onChange={this.updateSettings}>
               <option value={EXPLORER.NEO_TRACKER}>Neotracker</option>
+              <option value={EXPLORER.NEO_SCAN}>Neoscan</option>
               <option value={EXPLORER.ANT_CHAIN}>Antchain</option>
             </select>
           </div>

--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -6,6 +6,7 @@ export const NETWORK = {
 
 export const EXPLORER = {
   NEO_TRACKER: 'Neotracker',
+  NEO_SCAN: 'Neoscan',
   ANT_CHAIN: 'Antchain'
 }
 

--- a/app/core/explorer.js
+++ b/app/core/explorer.js
@@ -2,7 +2,6 @@
 import { openExternal } from './electron'
 import { NETWORK, EXPLORER } from '../core/constants'
 
-// TODO: make this a user setting
 export const getExplorerLink = (net: NetworkType, explorer: ExplorerType, txid: string) => {
   let base
   if (explorer === EXPLORER.NEO_TRACKER) {
@@ -10,6 +9,12 @@ export const getExplorerLink = (net: NetworkType, explorer: ExplorerType, txid: 
       base = 'https://neotracker.io/tx/'
     } else {
       base = 'https://testnet.neotracker.io/tx/'
+    }
+  } else if (explorer === EXPLORER.NEO_SCAN) {
+    if (net === NETWORK.MAIN) {
+      base = 'https://neoscan.io/transaction/'
+    } else {
+      base = 'https://neoscan-testnet.io/transaction/'
     }
   } else {
     if (net === NETWORK.MAIN) {


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
This PR supports the effort to add unit tests (#34).

**What problem does this PR solve?**
This adds support for the NeoScan explorer (alongside NeoTracker and AntChain). Since NeoScan is CoZ's tracker, it seems like it should be supported. Also, NeoTracker's testnet site has an HSTS error, so adding a third explorer option adds some redundancy.

Additionally, it adds full test coverage for the `app/core/explorer.js` file.

**How did you solve this problem?**
This PR adds an option for the NeoScan explorer following the model of the NeoTracker and AntChain explorers.

This PR also adds unit tests for explorer functionality in `__tests__/core/explorer.test.js`.

**How did you make sure your solution works?**
I manually tested explorer links for all three options on the testnet. Additionally, I added unit tests to ensure explorer URLs are generated correctly.

**Are there any special changes in the code that we should be aware of?**
No

**Is there anything else we should know?**
No

- [yes] Unit tests written?
