### PR TITLE
Adding flow check to CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
           key: neon-wallet-{{ checksum "yarn.lock" }}
       - run: yarn
       - run: yarn lint
+      - run: yarn flow
       - run: yarn dist
       - save_cache:
           key: neon-wallet-{{ checksum "yarn.lock" }}


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
I mentioned this idea in #251.

**What problem does this PR solve?**
Currently the flow checks are not performed as part of the CircleCI tasks, so a flow error does not trigger CI error reporting to GitHub.

**How did you solve this problem?**
Added the `yarn flow` command to the build job. I added it there because I thought it made sense to couple with `yarn lint`.

**How did you make sure your solution works?**
The CircleCI report for this PR will demonstrate it.

**Are there any special changes in the code that we should be aware of?**
no

**Is there anything else we should know?**
no

- [n/a] Unit tests written?
