### PR TITLE
Hides the token sale page for 0.0.7 release

### DIFF
--- a/app/components/Home/Home.jsx
+++ b/app/components/Home/Home.jsx
@@ -29,9 +29,9 @@ const Home = () =>
     <Link to={ROUTES.SETTINGS}>
       <div className={classNames('linkBox', styles.linkBox, styles.linkBoxAlt)}>Manage Neon settings</div>
     </Link>
-    <Link to={ROUTES.LOGIN_TOKEN_SALE}>
+    {/* <Link to={ROUTES.LOGIN_TOKEN_SALE}>
       <div className={classNames('linkBox', styles.linkBox, styles.linkBoxAlt)}>Participate in Token Sale</div>
-    </Link>
+    </Link> */}
   </Page>
 
 export default Home


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Token sale is currently broken

**What problem does this PR solve?**
Hides the button (does not remove the actual code)
