### PR TITLE
Add modal infrastructure + confirm modal for deleting a wallet

### DIFF
--- a/__tests__/components/Modals/ConfirmModal.test.js
+++ b/__tests__/components/Modals/ConfirmModal.test.js
@@ -1,0 +1,49 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import ConfirmModal from '../../../app/components/Modals/ConfirmModal/ConfirmModal'
+
+describe('ConfirmModal', () => {
+  const props = {
+    title: 'test modal',
+    text: 'text',
+    hideModal: jest.fn(),
+    onClick: jest.fn(),
+    onCancel: jest.fn()
+  }
+
+  test('should render without crashing', () => {
+    const wrapper = shallow(<ConfirmModal {...props} />)
+
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  test('should render the title correctly', () => {
+    const wrapper = shallow(<ConfirmModal {...props} />)
+
+    expect(wrapper.dive().find('.modalHeaderTitle').text()).toEqual(props.title)
+  })
+
+  test('should render the text correctly', () => {
+    const wrapper = shallow(<ConfirmModal {...props} />)
+
+    expect(wrapper.dive().find('.text').text()).toEqual(props.text)
+  })
+
+  test('should trigger the onCancel function followed by hideModal', () => {
+    const wrapper = shallow(<ConfirmModal {...props} />)
+
+    wrapper.dive().find('.cancelButton').simulate('click')
+
+    expect(props.onCancel).toHaveBeenCalled()
+    expect(props.hideModal).toHaveBeenCalled()
+  })
+
+  test('should trigger the onClick function followed by hideModal', () => {
+    const wrapper = shallow(<ConfirmModal {...props} />)
+
+    wrapper.dive().find('.actionButton').simulate('click')
+
+    expect(props.onClick).toHaveBeenCalled()
+    expect(props.hideModal).toHaveBeenCalled()
+  })
+})

--- a/__tests__/components/Modals/__snapshots__/ConfirmModal.test.js.snap
+++ b/__tests__/components/Modals/__snapshots__/ConfirmModal.test.js.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConfirmModal should render without crashing 1`] = `
+<BaseModal
+  height="450px"
+  hideModal={[Function]}
+  style={
+    Object {
+      "content": Object {
+        "height": "175px",
+        "width": "450px",
+      },
+    }
+  }
+  title="test modal"
+  width="450px"
+>
+  <div
+    className="textContainer"
+  >
+    <strong
+      className="text"
+    >
+      text
+    </strong>
+  </div>
+  <div
+    className="modalFooter"
+  >
+    <button
+      className="actionButton"
+      onClick={[Function]}
+    >
+      Confirm
+    </button>
+    <button
+      className="cancelButton"
+      onClick={[Function]}
+    >
+      Cancel
+    </button>
+  </div>
+</BaseModal>
+`;

--- a/__tests__/store/reducers.test.js
+++ b/__tests__/store/reducers.test.js
@@ -11,7 +11,8 @@ describe('root reducer', () => {
       metadata: expect.any(Object),
       notification: expect.any(Object),
       claim: expect.any(Object),
-      rpx: expect.any(Object)
+      rpx: expect.any(Object),
+      modal: expect.any(Object)
     })
   })
 })

--- a/app/components/Modals/BaseModal/BaseModal.jsx
+++ b/app/components/Modals/BaseModal/BaseModal.jsx
@@ -1,0 +1,61 @@
+// @flow
+import React from 'react'
+import type { Children } from 'react'
+import ReactModal from 'react-modal'
+import Close from 'react-icons/lib/md/close'
+import styles from './BaseModal.scss'
+
+type Props = {
+    title: string,
+    children: Children,
+    hideModal: Function,
+    width?: string,
+    height?: string,
+    className?: string,
+    style: {
+      content: Object,
+      overlay: Object
+    }
+}
+
+const BaseModal = ({ hideModal, title, children, width, height, className, style }: Props) => (
+  <ReactModal
+    isOpen
+    onRequestClose={hideModal}
+    style={{
+      content: {
+        width,
+        height,
+        margin: 'auto',
+        padding: 0,
+        boxShadow: 'rgba(0, 0, 0, 0.1) 0px 0px 4px',
+        border: 'none',
+        borderRadius: '4px',
+        ...style.content
+      },
+      overlay: {
+        backgroundColor: 'rgba(26, 54, 80, 0.25)',
+        margin: 'auto',
+        ...style.overlay
+      }
+    }}
+    className={className}
+  >
+    <div className={styles.modalHeader}>
+      <div className={styles.modalHeaderTitle}>{title}</div>
+      <div className={styles.modalHeaderCloseButton} onClick={hideModal}><Close /></div>
+    </div>
+    <div className={styles.modalBody}>{children}</div>
+  </ReactModal>
+)
+
+BaseModal.defaultProps = {
+  width: '450px',
+  height: '450px',
+  style: {
+    content: {},
+    overlay: {}
+  }
+}
+
+export default BaseModal

--- a/app/components/Modals/BaseModal/BaseModal.scss
+++ b/app/components/Modals/BaseModal/BaseModal.scss
@@ -1,0 +1,25 @@
+.modalHeader {
+    display: flex;
+    height: 45px;
+    padding: 0px 24px;
+    border-bottom: 1px solid #DAE1E9;
+    position: relative;
+    justify-content: center;
+    align-items: center;
+}
+
+.modalHeaderTitle {
+    font-size: 18px;
+}
+
+.modalHeaderCloseButton {
+    width: 18px;
+    height: 18px;
+    margin-left: auto;
+    fill: #9BA6B2;
+    cursor: pointer;
+}
+
+.modalBody {
+    padding: 0px 16px;
+}

--- a/app/components/Modals/BaseModal/index.js
+++ b/app/components/Modals/BaseModal/index.js
@@ -1,0 +1,1 @@
+export { default } from './BaseModal'

--- a/app/components/Modals/ConfirmModal/ConfirmModal.jsx
+++ b/app/components/Modals/ConfirmModal/ConfirmModal.jsx
@@ -1,0 +1,54 @@
+// @flow
+import React from 'react'
+import BaseModal from '../BaseModal'
+import styles from './ConfirmModal.scss'
+
+type Props = {
+    title: string,
+    text: string,
+    onClick: Function,
+    onCancel: Function,
+    hideModal: Function,
+    width: string,
+    height: string,
+}
+
+const ConfirmModal = ({ hideModal, title, onClick, onCancel, text, width, height }: Props) => (
+  <BaseModal
+    title={title}
+    hideModal={hideModal}
+    style={{
+      content: {
+        width,
+        height
+      }
+    }}
+  >
+    <div className={styles.textContainer}>
+      <strong className={styles.text}>{text}</strong>
+    </div>
+    <div className={styles.modalFooter}>
+      <button
+        className={styles.actionButton}
+        onClick={() => {
+          onClick()
+          hideModal()
+        }}>Confirm</button>
+      <button
+        className={styles.cancelButton}
+        onClick={() => {
+          hideModal()
+          if (onCancel) {
+            onCancel()
+          }
+        }}>Cancel</button>
+    </div>
+  </BaseModal>
+)
+
+ConfirmModal.defaultProps = {
+  width: '450px',
+  height: '175px'
+}
+
+export default ConfirmModal

--- a/app/components/Modals/ConfirmModal/ConfirmModal.scss
+++ b/app/components/Modals/ConfirmModal/ConfirmModal.scss
@@ -1,0 +1,24 @@
+.textContainer {
+    padding: 20px 0;
+}
+
+.modalFooter {
+    padding-top: 20px;
+    text-align: right;
+}
+
+.actionButton {
+    background-color: red;
+    &:hover {
+        background-color: red;
+    }
+}
+
+.cancelButton {
+    background: none;
+    border: 1px solid #999;
+    color: #000;
+    &:hover { 
+        background: none
+    }
+}

--- a/app/components/Modals/ConfirmModal/index.js
+++ b/app/components/Modals/ConfirmModal/index.js
@@ -1,0 +1,1 @@
+export { default } from './ConfirmModal'

--- a/app/containers/App/App.jsx
+++ b/app/containers/App/App.jsx
@@ -1,5 +1,6 @@
 // @flow
 import React, { Component } from 'react'
+import ModalRenderer from '../ModalRenderer'
 import Notification from '../../components/Notification'
 import classNames from 'classnames'
 import { NOTIFICATION_POSITIONS } from '../../core/constants'
@@ -29,6 +30,7 @@ class App extends Component<Props> {
           [styles.pushTop]: shouldPushTop,
           [styles.noAnimation]: noAnimation
         })}>{children}</div>
+        <ModalRenderer />
       </div>
     )
   }

--- a/app/containers/ModalRenderer/ModalRenderer.jsx
+++ b/app/containers/ModalRenderer/ModalRenderer.jsx
@@ -1,0 +1,32 @@
+// @flow
+import React from 'react'
+
+import { MODAL_TYPES } from '../../core/constants'
+import ConfirmModal from '../../components/Modals/ConfirmModal'
+
+const {
+  CONFIRM
+} = MODAL_TYPES
+
+const MODAL_COMPONENTS = {
+  [CONFIRM]: ConfirmModal
+}
+
+type Props = {
+    modalType?: ModalType,
+    modalProps: Object,
+    hideModal: Function
+}
+
+const ModalRenderer = (props: Props) => {
+  const { modalType, modalProps, hideModal } = props
+
+  if (modalType) {
+    const Modal = MODAL_COMPONENTS[modalType]
+    return <Modal {...modalProps} hideModal={hideModal} />
+  }
+
+  return null
+}
+
+export default ModalRenderer

--- a/app/containers/ModalRenderer/index.js
+++ b/app/containers/ModalRenderer/index.js
@@ -1,0 +1,18 @@
+// @flow
+import { connect } from 'react-redux'
+import { bindActionCreators } from 'redux'
+import ModalRenderer from './ModalRenderer'
+import { getModalType, getModalProps, hideModal } from '../../modules/modal'
+
+const mapStateToProps = (state) => ({
+  modalType: getModalType(state),
+  modalProps: getModalProps(state)
+})
+
+const actionCreators = {
+  hideModal
+}
+
+const mapDispatchToProps = dispatch => bindActionCreators(actionCreators, dispatch)
+
+export default connect(mapStateToProps, mapDispatchToProps)(ModalRenderer)

--- a/app/containers/Settings/Settings.jsx
+++ b/app/containers/Settings/Settings.jsx
@@ -6,14 +6,16 @@ import storage from 'electron-json-storage'
 import Delete from 'react-icons/lib/md/delete'
 import Page from '../../components/Page'
 import HomeButtonLink from '../../components/HomeButtonLink'
-import { EXPLORER } from '../../core/constants'
+import { EXPLORER, MODAL_TYPES } from '../../core/constants'
+
 const { dialog } = require('electron').remote
 
 type Props = {
   setKeys: Function,
   setBlockExplorer: Function,
   explorer: string,
-  wallets: any
+  wallets: any,
+  showModal: Function
 }
 
 type State = {
@@ -105,15 +107,19 @@ export default class Settings extends Component<Props, State> {
   }
 
   deleteWallet = (key: string) => {
-    const { setKeys } = this.props
-    if (window.confirm(`Please confirm deleting saved wallet - ${key}`)) {
-      // eslint-disable-next-line
-      storage.get('keys', (error, data) => {
-        delete data[key]
-        storage.set('keys', data)
-        setKeys(data)
-      })
-    }
+    const { setKeys, showModal } = this.props
+    showModal(MODAL_TYPES.CONFIRM, {
+      title: 'Confirm Delete',
+      text: `Please confirm deleting saved wallet - ${key}`,
+      onClick: () => {
+        // eslint-disable-next-line
+        storage.get('keys', (error, data) => {
+          delete data[key]
+          storage.set('keys', data)
+          setKeys(data)
+        })
+      }
+    })
   }
 
   render () {

--- a/app/containers/Settings/index.js
+++ b/app/containers/Settings/index.js
@@ -4,6 +4,7 @@ import { bindActionCreators } from 'redux'
 import Settings from './Settings'
 import { setKeys, getAccountKeys } from '../../modules/account'
 import { setBlockExplorer, getBlockExplorer } from '../../modules/metadata'
+import { showModal } from '../../modules/modal'
 
 const mapStateToProps = (state: Object) => ({
   explorer: getBlockExplorer(state),
@@ -12,7 +13,8 @@ const mapStateToProps = (state: Object) => ({
 
 const actionCreators = {
   setKeys,
-  setBlockExplorer
+  setBlockExplorer,
+  showModal
 }
 
 const mapDispatchToProps = dispatch => bindActionCreators(actionCreators, dispatch)

--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -56,3 +56,8 @@ export const BIP44_PATH =
   '80000000' +
   '00000000' +
   '00000000'
+
+export const MODAL_TYPES = {
+  SEND_TRANSACTION: 'SEND_TRANSACTION',
+  CONFIRM: 'CONFIRM'
+}

--- a/app/core/time.js
+++ b/app/core/time.js
@@ -1,3 +1,2 @@
 export const ONE_SECOND_MS = 1000
 export const FIVE_MINUTES_MS = 300000
-export const THIRTY_SECONDS = 3000

--- a/app/core/time.js
+++ b/app/core/time.js
@@ -1,2 +1,3 @@
 export const ONE_SECOND_MS = 1000
 export const FIVE_MINUTES_MS = 300000
+export const THIRTY_SECONDS = 3000

--- a/app/flow-typed/declarations.js
+++ b/app/flow-typed/declarations.js
@@ -1,31 +1,45 @@
 // @flow
 
-import { NETWORK, EXPLORER, ROUTES, NOTIFICATION_TYPES, NOTIFICATION_POSITIONS } from '../core/constants'
+import { 
+  NETWORK,
+  EXPLORER,
+  ROUTES,
+  NOTIFICATION_TYPES,
+  NOTIFICATION_POSITIONS,
+  MODAL_TYPES
+} from '../core/constants'
 
 declare type ActionCreatorType = any
+
 declare type DispatchType = (actionCreator: ActionCreatorType) => Promise<*>
+
 declare type GetStateType = () => Object
 
 declare type NetworkType = $Values<typeof NETWORK>
+
 declare type ExplorerType = $Values<typeof EXPLORER>
+
 declare type RouteType = $Values<typeof ROUTES>
+
 declare type NotificationType = {
-    type: $Values<typeof NOTIFICATION_TYPES>,
-    title: ?string,
-    message: string,
-    width: string,
-    position: $Values<typeof NOTIFICATION_POSITIONS>,
-    isShown: boolean,
-    noAnimation: boolean,
-    html: boolean,
-    onClick: ?Function
+  type: $Values<typeof NOTIFICATION_TYPES>,
+  title: ?string,
+  message: string,
+  width: string,
+  position: $Values<typeof NOTIFICATION_POSITIONS>,
+  isShown: boolean,
+  noAnimation: boolean,
+  html: boolean,
+  onClick: ?Function
 }
+
 declare type TransactionHistoryType = {
-    NEO: number,
-    GAS: number,
-    txid: number,
-    block_index: number,
-    neo_sent: number,
-    neo_gas: number
-  }
-  
+  NEO: number,
+  GAS: number,
+  txid: number,
+  block_index: number,
+  neo_sent: number,
+  neo_gas: number
+}
+
+declare type ModalType = $Values<typeof MODAL_TYPES>

--- a/app/modules/modal.js
+++ b/app/modules/modal.js
@@ -1,0 +1,43 @@
+// @flow
+
+export const getModalType = (state) => state.modal.modalType
+export const getModalProps = (state) => state.modal.modalProps
+
+// Constants
+export const SHOW_MODAL = 'SHOW_MODAL'
+export const HIDE_MODAL = 'HIDE_MODAL'
+
+// Actions
+export const showModal = (modalType: ModalType, modalProps: Object) => {
+  return {
+    type: SHOW_MODAL,
+    payload: {
+      modalType,
+      modalProps
+    }
+  }
+}
+
+export const hideModal = () => ({
+  type: HIDE_MODAL
+})
+
+const initialState = {
+  modalType: null,
+  modalProps: {}
+}
+
+export default (state: Object = initialState, action: Object) => {
+  switch (action.type) {
+    case SHOW_MODAL:
+      const { modalType, modalProps } = action.payload
+      return {
+        modalType,
+        modalProps
+      }
+    case HIDE_MODAL:
+      return initialState
+    default:
+      return state
+  }
+}

--- a/app/store/reducers.js
+++ b/app/store/reducers.js
@@ -8,6 +8,7 @@ import claim from '../modules/claim'
 import dashboard from '../modules/dashboard'
 import rpx from '../modules/rpx'
 import notification from '../modules/notification'
+import modal from '../modules/modal'
 
 export default combineReducers({
   account,
@@ -18,5 +19,6 @@ export default combineReducers({
   metadata,
   claim,
   rpx,
-  notification
+  notification,
+  modal
 })

--- a/app/styles/main.global.scss
+++ b/app/styles/main.global.scss
@@ -1,4 +1,5 @@
 @import './variables';
+
 @media print {
     #newWallet {
         font-size: .8em;
@@ -409,5 +410,18 @@ input {
     &.solidTip {
         background-color: rgba(0, 0, 0, 1);
         z-index: $z-index-tooltip;
+    }
+}
+
+.ReactModalPortal {
+    .ReactModal__Overlay {
+        opacity: 0;
+        transition: opacity 200ms ease-in-out;
+        &--after-open {            
+            opacity: 1;
+        }
+        &--before-close {
+            opacity: 0;
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "react-dom": "15.6.2",
     "react-hot-loader": "3.1.1",
     "react-icons": "2.2.7",
+    "react-modal": "^3.1.2",
     "react-redux": "5.0.6",
     "react-router-dom": "4.2.2",
     "react-split-pane": "0.1.68",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3564,6 +3564,10 @@ execa@^0.7.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+exenv@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
+
 expand-brackets@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
@@ -7289,6 +7293,13 @@ react-icons@2.2.7:
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-2.2.7.tgz#d7860826b258557510dac10680abea5ca23cf650"
   dependencies:
     react-icon-base "2.1.0"
+
+react-modal@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.1.2.tgz#6e1fd656315d6fc62a1edda2b5aecc9752ac6bca"
+  dependencies:
+    exenv "^1.2.0"
+    prop-types "^15.5.10"
 
 react-proxy@^3.0.0-alpha.0:
   version "3.0.0-alpha.1"


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Modals will be used for both NEP5 and Address Book.

**What problem does this PR solve?**
Adds a modal infrastructure with two generic modals.
BaseModal which should be the base modal for all modals, and a ConfirmModal (which uses BaseModal).

**How did you solve this problem?**
I used ReactModal + Tiny reducer for managing the state of modals.

**How did you make sure your solution works?**
Ensured all tests work + manual QA.

**Is there anything else we should know?**
I replaced the `window.confirm...` we had in Settings for saved wallet deletion in favour of the ConfirmModal.
Maybe we will need to redesign it.

- [x] Tests written?
Yep.

<img width="460" alt="screen shot 2017-11-09 at 11 15 15 pm" src="https://user-images.githubusercontent.com/254095/32606205-8b497888-c5a8-11e7-9469-329cd92d7143.png">
