### PR TITLE
Clear state after logout

### DIFF
--- a/app/modules/claim.js
+++ b/app/modules/claim.js
@@ -4,7 +4,7 @@ import { log } from '../util/Logs'
 import { ASSETS } from '../core/constants'
 import { showErrorNotification, showSuccessNotification, showInfoNotification } from './notifications'
 import { FIVE_MINUTES_MS } from '../core/time'
-import { getWif, getAddress, getSigningFunction, getPublicKey } from './account'
+import { getWif, getAddress, getSigningFunction, getPublicKey, LOGOUT } from './account'
 import { getNetwork } from './metadata'
 import { getNeo } from './wallet'
 import asyncWrap from '../core/asyncHelper'
@@ -164,6 +164,8 @@ export default (state: Object = initialState, action: Object) => {
         ...state,
         disableClaimButton
       }
+    case LOGOUT:
+      return initialState
     default:
       return state
   }

--- a/app/modules/dashboard.js
+++ b/app/modules/dashboard.js
@@ -1,4 +1,5 @@
 // @flow
+import { LOGOUT } from './account'
 
 // Constants
 export const TOGGLE_SEND_PANE = 'TOGGLE_SEND_PANE'
@@ -30,6 +31,8 @@ export default (state: Object = initialState, action: Object) => {
         ...state,
         ...newState
       }
+    case LOGOUT:
+      return initialState
     default:
       return state
   }

--- a/app/modules/rpx.js
+++ b/app/modules/rpx.js
@@ -1,10 +1,9 @@
 // @flow
 import { getTokenBalance, getAccountFromWIFKey, doMintTokens } from 'neon-js'
 import { showErrorNotification, showInfoNotification, showSuccessNotification } from './notifications'
-import { getAddress, getWif } from './account'
+import { getAddress, getWif, LOGOUT } from './account'
 import { getNetwork } from './metadata'
 import { getNeo } from './wallet'
-import { LOGOUT } from './account'
 
 // Constants
 export const UPDATE_RPX_BALANCE = 'UPDATE_RPX_BALANCE'

--- a/app/modules/rpx.js
+++ b/app/modules/rpx.js
@@ -4,6 +4,7 @@ import { showErrorNotification, showInfoNotification, showSuccessNotification } 
 import { getAddress, getWif } from './account'
 import { getNetwork } from './metadata'
 import { getNeo } from './wallet'
+import { LOGOUT } from './account'
 
 // Constants
 export const UPDATE_RPX_BALANCE = 'UPDATE_RPX_BALANCE'
@@ -93,6 +94,8 @@ export default (state: Object = initialState, action: Object) => {
         ...state,
         RPX
       }
+    case LOGOUT:
+      return initialState
     default:
       return state
   }

--- a/app/modules/transactions.js
+++ b/app/modules/transactions.js
@@ -10,6 +10,7 @@ import { showErrorNotification, showInfoNotification, showSuccessNotification } 
 import { getWif, getPublicKey, getSigningFunction, getAddress } from './account'
 import { getNetwork } from './metadata'
 import asyncWrap from '../core/asyncHelper'
+import { LOGOUT } from './account'
 
 // Constants
 export const TOGGLE_ASSET = 'TOGGLE_ASSET'
@@ -89,6 +90,8 @@ export default (state: Object = initialState, action: Object) => {
         ...state,
         selectedAsset: state.selectedAsset === ASSETS_LABELS.NEO ? ASSETS_LABELS.GAS : ASSETS_LABELS.NEO
       }
+    case LOGOUT:
+      return initialState
     default:
       return state
   }

--- a/app/modules/transactions.js
+++ b/app/modules/transactions.js
@@ -7,10 +7,9 @@ import { getTransactionHistory, doSendAsset, hardwareDoSendAsset } from 'neon-js
 import { setTransactionHistory, getNeo, getGas } from './wallet'
 import { log } from '../util/Logs'
 import { showErrorNotification, showInfoNotification, showSuccessNotification } from './notifications'
-import { getWif, getPublicKey, getSigningFunction, getAddress } from './account'
+import { getWif, getPublicKey, getSigningFunction, getAddress, LOGOUT } from './account'
 import { getNetwork } from './metadata'
 import asyncWrap from '../core/asyncHelper'
-import { LOGOUT } from './account'
 
 // Constants
 export const TOGGLE_ASSET = 'TOGGLE_ASSET'

--- a/app/modules/wallet.js
+++ b/app/modules/wallet.js
@@ -6,6 +6,7 @@ import { syncTransactionHistory } from './transactions'
 import { syncAvailableClaim } from './claim'
 import { syncBlockHeight } from './metadata'
 import asyncWrap from '../core/asyncHelper'
+import { LOGOUT } from './account'
 
 // Constants
 export const SET_BALANCE = 'SET_BALANCE'
@@ -126,6 +127,8 @@ export default (state: Object = initialState, action: Object) => {
         ...state,
         transactions
       }
+    case LOGOUT:
+      return initialState
     default:
       return state
   }


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
General wallet improvements

**What problem does this PR solve?**
When a user logged out and then logged in again (maybe with a different wallet), there would be a flash of "old" values. This is because it was not cleared when the user logged out.

**How did you solve this problem?**
Cleared (back to initialState) the states of: wallet/claim/dashboard/rpx/transactions

**How did you make sure your solution works?**
I tried logging in using various wallets, and now the state is clean and there is no flash of old values.
