### PR TITLE
Add loader to transaction history (WIP)

### DIFF
--- a/__tests__/components/NetworkSwitch.test.js
+++ b/__tests__/components/NetworkSwitch.test.js
@@ -5,6 +5,7 @@ import { shallow } from 'enzyme'
 import { SET_HEIGHT, SET_NETWORK } from '../../app/modules/metadata'
 import { SET_CLAIM } from '../../app/modules/claim'
 import { SET_BALANCE, SET_TRANSACTION_HISTORY } from '../../app/modules/wallet'
+import { LOADING_TRANSACTIONS } from '../../app/modules/transactions'
 import NetworkSwitch from '../../app/containers/NetworkSwitch'
 
 // TODO research how to move the axios mock code which is repeated in NetworkSwitch to a helper or config file
@@ -67,15 +68,16 @@ describe('NetworkSwitch', () => {
       SET_HEIGHT,
       SET_CLAIM,
       SET_TRANSACTION_HISTORY,
-      SET_BALANCE
+      SET_BALANCE,
+      LOADING_TRANSACTIONS
     ]
     deepWrapper.find('.netName').simulate('click')
 
     await Promise.resolve().then().then().then()
     const actions = store.getActions()
+    expect(actions.length).toEqual(7)
     actions.forEach(action => {
       expect(actionTypes.indexOf(action.type) > -1).toEqual(true)
     })
-    expect(actions.length).toEqual(5)
   })
 })

--- a/__tests__/components/TransactionHistory.test.js
+++ b/__tests__/components/TransactionHistory.test.js
@@ -18,6 +18,9 @@ const initialState = {
   },
   wallet: {
     transactions: []
+  },
+  transactions: {
+    isLoadingTransactions: false
   }
 }
 

--- a/__tests__/components/TransactionHistory.test.js
+++ b/__tests__/components/TransactionHistory.test.js
@@ -4,6 +4,7 @@ import { Provider } from 'react-redux'
 import thunk from 'redux-thunk'
 import { shallow, mount } from 'enzyme'
 import { setTransactionHistory } from '../../app/modules/wallet'
+import { setIsLoadingTransaction } from '../../app/modules/transactions'
 
 import TransactionHistory from '../../app/containers/TransactionHistory'
 
@@ -68,17 +69,17 @@ describe('TransactionHistory', () => {
     done()
   })
 
-  test('calls syncTransactionHistory after rendering', (done) => {
+  test('calls syncTransactionHistory after rendering', async () => {
     const { store } = setup(initialState, false)
-    const state = store.getState()
-    setTimeout(() => {
-      expect(store.getActions()[0]).toEqual(setTransactionHistory(initialState.wallet.transactions))
-      done()
-    }, 0)
+    await Promise.resolve('Pause').then().then().then()
+    const actions = store.getActions()
+    expect(actions[0]).toEqual(setIsLoadingTransaction(true))
+    expect(actions[1]).toEqual(setIsLoadingTransaction(false))
+    expect(actions[2]).toEqual(setTransactionHistory(initialState.wallet.transactions))
   })
 
   test('correctly renders no transaction history', (done) => {
-    const { store, wrapper } = setup(initialState, false)
+    const { wrapper } = setup(initialState, false)
 
     const columnHeader = wrapper.find('.columnHeader')
     expect(columnHeader.text()).toEqual('Transaction History')
@@ -90,7 +91,7 @@ describe('TransactionHistory', () => {
 
   test('correctly renders with NEO and GAS transaction history', (done) => {
     const transactionState = Object.assign({}, initialState, transactions)
-    const { store, wrapper } = setup(transactionState, false)
+    const { wrapper } = setup(transactionState, false)
 
     const transactionList = wrapper.find('#transactionList')
     expect(transactionList.children().length).toEqual(2)

--- a/__tests__/components/WalletInfo.test.js
+++ b/__tests__/components/WalletInfo.test.js
@@ -33,7 +33,7 @@ jest.mock('electron', () => ({
     writeText: jest.fn()
   }
 }))
-jest.mock('neon-js')
+jest.useFakeTimers()
 
 jest.unmock('qrcode')
 import QRCode from 'qrcode/lib/browser' // eslint-disable-line
@@ -105,16 +105,16 @@ describe('WalletInfo', () => {
     expect(gasField.text()).toEqual('1.0001')
     done()
   })
-  test('copy to clipboard is getting called on click', (done) => {
+  test('copy to clipboard is getting called on click', async () => {
     const { wrapper } = setup()
     const deepWrapper = wrapper.dive()
 
     expect(clipboard.writeText.mock.calls.length).toBe(0)
     deepWrapper.find('.copyKey').simulate('click')
+    await Promise.resolve('Pause').then()
     expect(clipboard.writeText.mock.calls.length).toBe(1)
-    done()
   })
-  test('refreshBalance is getting called on click', (done) => {
+  test('refreshBalance is getting called on click', async () => {
     const { wrapper, store } = setup()
     const deepWrapper = wrapper.dive()
 
@@ -130,33 +130,31 @@ describe('WalletInfo', () => {
       SET_CLAIM
     ]
     deepWrapper.find('.refreshBalance').simulate('click')
-    setTimeout(() => {
-      const actions = store.getActions()
-      // expect(actions.length).toEqual(12)
-      actions.forEach(action => {
-        expect(actionTypes.indexOf(action.type) > -1).toEqual(true)
-      })
-      done()
-    }, 1050)
+    jest.runAllTimers()
+    await Promise.resolve('Pause').then().then().then().then()
+    const actions = store.getActions()
+    expect(actions.length).toEqual(16)
+    // expect(actions.length).toEqual(12)
+    actions.forEach(action => {
+      expect(actionTypes.indexOf(action.type) > -1).toEqual(true)
+    })
   })
-  test('calls the correct number of actions after mounting', (done) => {
+  test('calls the correct number of actions after mounting', async () => {
     const { store } = setup(initialState, false)
     const actionTypes = [
       SET_TRANSACTION_HISTORY,
       SET_HEIGHT,
       SET_CLAIM,
       SET_BALANCE,
-      SET_NEO_PRICE,
-      SET_GAS_PRICE
+      LOADING_TRANSACTIONS
     ]
 
-    setTimeout(() => {
-      const actions = store.getActions()
-      expect(actions.length).toEqual(6)
-      actions.forEach(action => {
-        expect(actionTypes.indexOf(action.type) > -1).toEqual(true)
-      })
-      done()
-    }, 1050)
+    jest.runAllTimers()
+    await Promise.resolve('Pause').then().then().then()
+    const actions = store.getActions()
+    expect(actions.length).toEqual(6)
+    actions.forEach(action => {
+      expect(actionTypes.indexOf(action.type) > -1).toEqual(true)
+    })
   })
 })

--- a/__tests__/components/WalletInfo.test.js
+++ b/__tests__/components/WalletInfo.test.js
@@ -5,6 +5,7 @@ import thunk from 'redux-thunk'
 import { mount, shallow } from 'enzyme'
 import { SET_TRANSACTION_HISTORY, SET_BALANCE, SET_GAS_PRICE, SET_NEO_PRICE } from '../../app/modules/wallet'
 import { SHOW_NOTIFICATION, HIDE_NOTIFICATIONS } from '../../app/modules/notifications'
+import { LOADING_TRANSACTIONS } from '../../app/modules/transactions'
 import { SET_HEIGHT } from '../../app/modules/metadata'
 import { SET_CLAIM } from '../../app/modules/claim'
 import WalletInfo from '../../app/containers/WalletInfo'
@@ -120,6 +121,7 @@ describe('WalletInfo', () => {
     const actionTypes = [
       HIDE_NOTIFICATIONS,
       SHOW_NOTIFICATION,
+      LOADING_TRANSACTIONS,
       SET_TRANSACTION_HISTORY,
       SET_HEIGHT,
       SET_NEO_PRICE,

--- a/__tests__/components/__snapshots__/TransactionHistory.test.js.snap
+++ b/__tests__/components/__snapshots__/TransactionHistory.test.js.snap
@@ -3,6 +3,7 @@
 exports[`TransactionHistory renders without crashing 1`] = `
 <TransactionHistory
   address="AWy7RNBVr9vDadRMK9p7i7Z1tL7GrLAxoh"
+  isLoadingTransactions={false}
   net="TestNet"
   store={
     Object {

--- a/__tests__/modules/transactions.test.js
+++ b/__tests__/modules/transactions.test.js
@@ -3,7 +3,8 @@ import transactionReducer, { toggleAsset, TOGGLE_ASSET } from '../../app/modules
 describe('transactions module tests', () => {
   const newAsset = 'Gas'
   const initialState = {
-    selectedAsset: 'Neo'
+    selectedAsset: 'Neo',
+    isLoadingTransactions: false
   }
 
   describe('toggleAsset tests', () => {

--- a/app/components/Loader/Loader.jsx
+++ b/app/components/Loader/Loader.jsx
@@ -1,0 +1,20 @@
+// @flow
+import React from 'react'
+import styles from './Loader.scss'
+import classNames from 'classnames'
+
+type Props = {
+  className?: string,
+}
+
+const Loader = ({ className }: Props) => (
+  <div className={classNames(styles.loader, className)}>
+    <div />
+    <div className={styles.rect2} />
+    <div className={styles.rect3} />
+    <div className={styles.rect4} />
+    <div className={styles.rect5} />
+  </div>
+)
+
+export default Loader

--- a/app/components/Loader/Loader.scss
+++ b/app/components/Loader/Loader.scss
@@ -1,0 +1,44 @@
+@import '../../styles/variables';
+
+.loader {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%);
+    width: 50px;
+    height: 40px;
+    text-align: center;
+    font-size: 10px;
+    > div {
+        background-color: $primary-color;
+        height: 100%;
+        width: 6px;
+        display: inline-block;
+        animation: sk-stretchdelay 1.2s infinite ease-in-out;
+        margin-right: 2px;
+    }
+}
+
+.rect2 {
+    animation-delay: -1.1s;
+  }
+  
+.rect3 {
+    animation-delay: -1.0s;
+}
+
+.rect4 {
+    animation-delay: -0.9s;
+}
+
+.rect5 {
+    animation-delay: -0.8s;
+}
+  
+@keyframes sk-stretchdelay {
+    0%, 40%, 100% { 
+        transform: scaleY(0.4);
+    }  20% { 
+        transform: scaleY(1.0);
+    }
+}

--- a/app/components/Loader/Loader.scss
+++ b/app/components/Loader/Loader.scss
@@ -17,22 +17,22 @@
         animation: sk-stretchdelay 1.2s infinite ease-in-out;
         margin-right: 2px;
     }
-}
-
-.rect2 {
-    animation-delay: -1.1s;
-  }
   
-.rect3 {
-    animation-delay: -1.0s;
-}
-
-.rect4 {
-    animation-delay: -0.9s;
-}
-
-.rect5 {
-    animation-delay: -0.8s;
+    .rect2 {
+        animation-delay: -1.1s;
+      }
+      
+    .rect3 {
+        animation-delay: -1.0s;
+    }
+    
+    .rect4 {
+        animation-delay: -0.9s;
+    }
+    
+    .rect5 {
+        animation-delay: -0.8s;
+    }
 }
   
 @keyframes sk-stretchdelay {

--- a/app/components/Loader/index.js
+++ b/app/components/Loader/index.js
@@ -1,0 +1,1 @@
+export { default } from './Loader'

--- a/app/containers/NetworkSwitch/NetworkSwitch.scss
+++ b/app/containers/NetworkSwitch/NetworkSwitch.scss
@@ -1,4 +1,5 @@
 @import '../../styles/variables';
+
 .container {
     position: absolute;
     font-size: .8em;

--- a/app/containers/TransactionHistory/TransactionHistory.jsx
+++ b/app/containers/TransactionHistory/TransactionHistory.jsx
@@ -1,15 +1,17 @@
 // @flow
 import React, { Component } from 'react'
-import { ASSETS } from '../../core/constants'
-import { openExplorer } from '../../core/explorer'
-import { formatGAS, formatNEO } from '../../core/formatters'
+import Loader from '../../components/Loader'
+import Transactions from './Transactions'
+import styles from './TransactionHistory.scss'
+import classNames from 'classnames'
 
 type Props = {
   address: string,
   net: NetworkType,
   transactions: Object,
   explorer: ExplorerType,
-  syncTransactionHistory: Function
+  syncTransactionHistory: Function,
+  isLoadingTransactions: boolean
 }
 
 export default class TransactionHistory extends Component<Props> {
@@ -19,25 +21,19 @@ export default class TransactionHistory extends Component<Props> {
   }
 
   render () {
-    const { transactions, net, explorer } = this.props
+    const { transactions, net, explorer, isLoadingTransactions } = this.props
     return (
-      <div id='transactionInfo'>
-        <div className='columnHeader'>Transaction History</div>
-        <div className='headerSpacer' />
-        <ul id='transactionList'>
-          {transactions.map((t) => {
-            let formatAmount = t.type === ASSETS.NEO ? formatNEO(t.amount) : formatGAS(t.amount)
-            return (
-              <li key={t.txid}>
-                <div
-                  className='txid'
-                  onClick={() => openExplorer(net, explorer, t.txid)}>
-                  {t.txid.substring(0, 32)}
-                </div>
-                <div className='amount'>{formatAmount} {t.type}</div>
-              </li>)
-          })}
-        </ul>
+      <div id='transactionInfo' className={styles.transactionInfo}>
+        <div className={classNames(styles.columnHeader, 'columnHeader')}>Transaction History</div>
+        <div className={classNames(styles.headerSpacer, 'headerSpacer')} />
+        {isLoadingTransactions
+          ? <Loader />
+          : <Transactions
+            transactions={transactions}
+            net={net}
+            explorer={explorer}
+          />
+        }
       </div>
     )
   }

--- a/app/containers/TransactionHistory/TransactionHistory.scss
+++ b/app/containers/TransactionHistory/TransactionHistory.scss
@@ -1,0 +1,19 @@
+@import '../../styles/variables';
+
+.transactionInfo {
+    padding: 14px 0px;
+    text-align: center;
+    position: relative;
+    min-height: 600px;
+}
+
+.columnHeader {
+    font-size: 1.2em;
+    font-weight: 200;
+}
+
+.headerSpacer {
+    width: 84%;
+    margin: 15px 8%;
+    border-top: 3px solid $spacer-color;
+}

--- a/app/containers/TransactionHistory/Transactions.jsx
+++ b/app/containers/TransactionHistory/Transactions.jsx
@@ -1,0 +1,40 @@
+// @flow
+import React from 'react'
+import { ASSETS } from '../../core/constants'
+import { openExplorer } from '../../core/explorer'
+import { formatGAS, formatNEO } from '../../core/formatters'
+import styles from './Transactions.scss'
+import classNames from 'classnames'
+
+type Props = {
+  net: NetworkType,
+  transactions: Object,
+  explorer: ExplorerType,
+}
+
+const Transactions = ({ transactions, net, explorer }: Props) => {
+  if (transactions.length === 0) {
+    return <div className={styles.noTransactions}>No transactions</div>
+  }
+
+  return (
+    <ul id='transactionList' className={styles.transactionList}>
+      {
+        transactions.map((t) => {
+          let formatAmount = t.type === ASSETS.NEO ? formatNEO(t.amount) : formatGAS(t.amount)
+          return (
+            <li key={t.txid} className={styles.row}>
+              <div
+                className={classNames(styles.txid, 'txid')}
+                onClick={() => openExplorer(net, explorer, t.txid)}>
+                {t.txid.substring(0, 32)}
+              </div>
+              <div className={classNames(styles.amount, 'amount')}>{formatAmount} {t.type}</div>
+            </li>
+          )
+        })}
+    </ul>
+  )
+}
+
+export default Transactions

--- a/app/containers/TransactionHistory/Transactions.scss
+++ b/app/containers/TransactionHistory/Transactions.scss
@@ -1,0 +1,43 @@
+@import '../../styles/variables';
+
+.noTransactions {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%)
+}
+
+.transactionList {
+    margin: 0;
+    padding: 0;
+    overflow-y: auto;
+    height: 600px;
+}
+
+.row {
+    list-style-type: none;
+    font-weight: 200;
+    border-bottom: 1px solid $spacer-color;
+    padding-bottom: 10px;
+    margin-bottom: 10px;
+}
+
+.txid {
+    position: relative;
+    top: 2px;
+    display: inline-block;
+    width: 44%;
+    margin-left: 4%;
+    text-align: left;
+    font-family: 'courier new';
+    font-size: .7em;
+    cursor: pointer;
+}
+
+.amount {
+    display: inline-block;
+    width: 44%;
+    margin-right: 4%;
+    text-align: right;
+    color: $thin-text-color;
+}

--- a/app/containers/TransactionHistory/index.js
+++ b/app/containers/TransactionHistory/index.js
@@ -2,7 +2,7 @@
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import TransactionHistory from './TransactionHistory'
-import { syncTransactionHistory } from '../../modules/transactions'
+import { syncTransactionHistory, getIsLoadingTransactions } from '../../modules/transactions'
 import { getAddress } from '../../modules/account'
 import { getBlockExplorer, getNetwork } from '../../modules/metadata'
 import { getTransactions } from '../../modules/wallet'
@@ -11,7 +11,8 @@ const mapStateToProps = (state: Object) => ({
   address: getAddress(state),
   net: getNetwork(state),
   transactions: getTransactions(state),
-  explorer: getBlockExplorer(state)
+  explorer: getBlockExplorer(state),
+  isLoadingTransactions: getIsLoadingTransactions(state)
 })
 
 const actionCreators = {

--- a/app/styles/main.global.scss
+++ b/app/styles/main.global.scss
@@ -330,50 +330,6 @@ input {
             }
         }
     }
-    #transactionInfo {
-        padding: 14px 0px;
-        text-align: center;
-        .columnHeader {
-            font-size: 1.2em;
-            font-weight: 200;
-        }
-        .headerSpacer {
-            width: 84%;
-            margin: 15px 8%;
-            border-top: 3px solid $spacer-color;
-        }
-    }
-    ul#transactionList {
-        margin: 0;
-        padding: 0;
-        overflow-y: auto;
-        height: 600px;
-        li {
-            list-style-type: none;
-            font-weight: 200;
-            border-bottom: 1px solid $spacer-color;
-            padding-bottom: 10px;
-            margin-bottom: 10px;
-            .txid {
-                position: relative;
-                top: 2px;
-                display: inline-block;
-                width: 44%;
-                margin-left: 4%;
-                text-align: left;
-                font-family: 'courier new';
-                font-size: .7em;
-                cursor: pointer;
-            }
-            .amount {
-                display: inline-block;
-                width: 44%;
-                margin-right: 4%;
-                text-align: right;
-                color: $thin-text-color;
-            }
-        }
-    }
 }
 
 .leftSplit {

--- a/app/styles/variables.scss
+++ b/app/styles/variables.scss
@@ -1,6 +1,7 @@
 // backgrounds and buttons
 $main-background: #FFF;
-$default-button: #4D933B;
+$primary-color: #4D933B;
+$default-button: $primary-color;
 $default-button-hover: #5EB248;
 $dark-button: #236312;
 $dark-button-hover: #33881C;


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
None

**What problem does this PR solve?**
Add a loading indicator + an empty state message when there are no transactions.

**How did you solve this problem?**
I added a Loader component, isLoading state to the transactions reducer, and split the transactions into their own component.

**How did you make sure your solution works?**
Currently, some tests fail. This is a WIP.

<img width="995" alt="screen shot 2017-11-17 at 10 49 43 pm" src="https://user-images.githubusercontent.com/254095/32973301-cd77ecb4-cc4a-11e7-8066-7a66e8277434.png">
<img width="998" alt="screen shot 2017-11-17 at 11 07 15 pm" src="https://user-images.githubusercontent.com/254095/32973302-cda6e33e-cc4a-11e7-9572-3f1769d86f5d.png">
