### PR TITLE
Fix for: Give warning when API is down or wallet lacks connectivity #265

### DIFF
--- a/__tests__/components/WalletInfo.test.js
+++ b/__tests__/components/WalletInfo.test.js
@@ -9,6 +9,7 @@ import { LOADING_TRANSACTIONS } from '../../app/modules/transactions'
 import { SET_HEIGHT } from '../../app/modules/metadata'
 import { SET_CLAIM } from '../../app/modules/claim'
 import WalletInfo from '../../app/containers/WalletInfo'
+import * as neonjs from 'neon-js'
 
 // TODO research how to move the axios mock code which is repeated in NetworkSwitch to a helper or config file
 import axios from 'axios'
@@ -133,7 +134,7 @@ describe('WalletInfo', () => {
     jest.runAllTimers()
     await Promise.resolve('Pause').then().then().then().then()
     const actions = store.getActions()
-    expect(actions.length).toEqual(16)
+    expect(actions.length).toEqual(20)
     // expect(actions.length).toEqual(12)
     actions.forEach(action => {
       expect(actionTypes.indexOf(action.type) > -1).toEqual(true)
@@ -142,6 +143,8 @@ describe('WalletInfo', () => {
   test('calls the correct number of actions after mounting', async () => {
     const { store } = setup(initialState, false)
     const actionTypes = [
+      HIDE_NOTIFICATIONS,
+      SHOW_NOTIFICATION,
       SET_TRANSACTION_HISTORY,
       SET_HEIGHT,
       SET_CLAIM,
@@ -152,9 +155,32 @@ describe('WalletInfo', () => {
     jest.runAllTimers()
     await Promise.resolve('Pause').then().then().then()
     const actions = store.getActions()
-    expect(actions.length).toEqual(6)
+    expect(actions.length).toEqual(10)
     actions.forEach(action => {
       expect(actionTypes.indexOf(action.type) > -1).toEqual(true)
     })
+  })
+  test('network error is shown with connectivity error', async () => {
+    neonjs.getBalance = jest.fn(() => {
+      return new Promise((resolve, reject) => {
+        reject(new Error())
+      })
+    })
+    const { wrapper, store } = setup()
+    wrapper.dive()
+
+    jest.runAllTimers()
+    await Promise.resolve('Pause').then().then().then().then()
+
+    const actions = store.getActions()
+    let notifications = []
+    actions.forEach(action => {
+      if (action.type === SHOW_NOTIFICATION) {
+        notifications.push(action)
+      }
+    })
+
+    // let's make sure the last notification show was an error.
+    expect(notifications.pop().payload.level).toEqual('error')
   })
 })

--- a/app/containers/WalletInfo/WalletInfo.jsx
+++ b/app/containers/WalletInfo/WalletInfo.jsx
@@ -27,8 +27,8 @@ export default class WalletInfo extends Component<Props> {
   canvas: ?HTMLCanvasElement
 
   componentDidMount () {
-    const { initiateGetBalance, net, address } = this.props
-    initiateGetBalance(net, address)
+    const { net, address } = this.props
+    this.refreshBalance(net, address)
     QRCode.toCanvas(this.canvas, address, { version: 5 }, (err) => {
       if (err) console.log(err)
     })


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Github #265

**What problem does this PR solve?**
Shows an error if the app can't get wallet balance

**How did you solve this problem?**
On init, it's using the standard refresh method which already has the correct error checking

**How did you make sure your solution works?**
Disconnect internet.

**Are there any special changes in the code that we should be aware of?**
No

**Is there anything else we should know?**
No

- [x] Unit tests written?
Yes!
