### PR TITLE
Fix for: Password is displayed as visible text when creating wallet #342

### DIFF
--- a/__tests__/components/Login.test.js
+++ b/__tests__/components/Login.test.js
@@ -1,15 +1,29 @@
 import React from 'react'
 import configureStore from 'redux-mock-store'
-import { shallow } from 'enzyme'
+import { Provider } from 'react-redux'
+import { BrowserRouter } from 'react-router-dom'
+import { shallow, mount } from 'enzyme'
 
 import Login from '../../app/containers/LoginPrivateKey/LoginPrivateKey'
 
-const setup = (state = { account: {
+const setup = (shallowRender = true, state = { account: {
   loggedIn: true,
   wif: undefined
 }}) => {
   const store = configureStore()(state)
-  const wrapper = shallow(<Login store={store} />)
+
+  let wrapper
+  if (shallowRender) {
+    wrapper = shallow(<Login store={store} />)
+  } else {
+    wrapper = mount(
+      <Provider store={store}>
+        <BrowserRouter>
+          <Login store={store} />
+        </BrowserRouter>
+      </Provider>
+    )
+  }
 
   return {
     store,
@@ -24,15 +38,16 @@ describe('Login', () => {
   })
 
   test('clicking show key icon toggles private key visibility', () => {
-    const { wrapper } = setup()
+    const { wrapper } = setup(false)
 
-    expect(wrapper.state('showKey')).toEqual(false)
+    expect(wrapper.find('input').get(0).props.type).toEqual('password')
 
     wrapper
       .find('.viewKey')
+      .first()
       .simulate('click')
 
-    expect(wrapper.state('showKey')).toEqual(true)
+    expect(wrapper.find('input').get(0).props.type).toEqual('text')
   })
 
   // test('private key field input onChange dispatches LOGIN action', () => {

--- a/__tests__/components/LoginNep2.test.js
+++ b/__tests__/components/LoginNep2.test.js
@@ -45,13 +45,18 @@ describe('LoginNep2', () => {
   test('renders correctly with initial state', (done) => {
     const { wrapper } = setup(false)
 
-    const passwordField = wrapper.find('input[type="password"]')
-    const keyField = wrapper.find('input[type="text"]')
+    const fields = wrapper.find('input[type="password"]')
+    expect(fields.length).toEqual(2)
 
-    expect(passwordField.text()).toEqual('')
-    expect(passwordField.html().includes('Enter your passphrase here')).toEqual(true)
-    expect(keyField.text()).toEqual('')
-    expect(keyField.html().includes('Enter your encrypted key here')).toEqual(true)
+    const passwordField = fields.get(0)
+    const keyField = fields.get(1)
+
+    expect(passwordField.props.value).toEqual('')
+    expect(passwordField.props.placeholder).toEqual('Enter your passphrase here')
+    expect(passwordField.props.type).toEqual('password')
+    expect(keyField.props.value).toEqual('')
+    expect(keyField.props.placeholder).toEqual(('Enter your encrypted key here'))
+    expect(keyField.props.type).toEqual('password')
     done()
   })
   test('the login button is working correctly with no passphrase or wif', (done) => {

--- a/__tests__/components/__snapshots__/Login.test.js.snap
+++ b/__tests__/components/__snapshots__/Login.test.js.snap
@@ -13,15 +13,10 @@ exports[`Login renders without crashing 1`] = `
   <div
     className="loginForm"
   >
-    <input
+    <PasswordField
       autoFocus={true}
       onChange={[Function]}
       placeholder="Enter your private key here (WIF)"
-      type="password"
-    />
-    <FaEye
-      className="viewKey"
-      onClick={[Function]}
     />
   </div>
   <div>

--- a/app/components/PasswordField/PasswordField.jsx
+++ b/app/components/PasswordField/PasswordField.jsx
@@ -1,0 +1,40 @@
+// @flow
+import React, { Component } from 'react'
+
+import FaEye from 'react-icons/lib/fa/eye'
+import FaEyeSlash from 'react-icons/lib/fa/eye-slash'
+import passwordFieldStyles from './PasswordField.scss'
+
+type State = {
+  showKey: boolean
+}
+
+class PasswordField extends Component<Props, State> {
+  state = {
+    showKey: false
+  }
+
+  toggleVisibility = () => {
+    this.setState(prevState => ({
+      showKey: !prevState.showKey
+    }))
+  }
+
+  render () {
+    const { showKey } = this.state
+    return (
+      <div className={passwordFieldStyles.passwordField}>
+        <input
+          type={showKey ? 'text' : 'password'}
+          {...this.props}
+        />
+        { showKey
+          ? <FaEyeSlash className={passwordFieldStyles.viewKey} onClick={this.toggleVisibility} />
+          : <FaEye className={passwordFieldStyles.viewKey} onClick={this.toggleVisibility} />
+        }
+      </div>
+    )
+  }
+}
+
+export default PasswordField

--- a/app/components/PasswordField/PasswordField.scss
+++ b/app/components/PasswordField/PasswordField.scss
@@ -1,0 +1,17 @@
+.passwordField {
+    width: 100%;
+    display: inline-block;
+
+    input {
+        width: 95%;
+        float: left;
+        margin-bottom: 10px;
+    }
+
+    .viewKey {
+        position: relative;
+        cursor: pointer;
+        margin-left: -25px;
+        margin-top: 10px;
+    }
+}

--- a/app/components/PasswordField/index.js
+++ b/app/components/PasswordField/index.js
@@ -1,0 +1,1 @@
+export { default } from './PasswordField'

--- a/app/containers/CreateWallet/CreateWallet.jsx
+++ b/app/containers/CreateWallet/CreateWallet.jsx
@@ -1,6 +1,7 @@
 // @flow
 import React, { Component } from 'react'
 import { isNil } from 'lodash'
+import PasswordField from '../../components/PasswordField'
 import DisplayWalletKeys from '../../components/DisplayWalletKeys'
 import Page from '../../components/Page'
 import HomeButtonLink from '../../components/HomeButtonLink'
@@ -53,15 +54,13 @@ export default class CreateWallet extends Component<Props, State> {
         <div className='info'>
           Choose a passphrase to encrypt your private key:
         </div>
-        <input
-          type='text'
+        <PasswordField
           placeholder='Enter passphrase here'
           value={passphrase}
           onChange={(e) => this.setState({ passphrase: e.target.value })}
           autoFocus
         />
-        <input
-          type='text'
+        <PasswordField
           placeholder='Repeat passphrase here'
           value={passphrase2}
           onChange={(e) => this.setState({ passphrase2: e.target.value })}

--- a/app/containers/EncryptKey/EncryptKey.jsx
+++ b/app/containers/EncryptKey/EncryptKey.jsx
@@ -1,6 +1,7 @@
 // @flow
 import React, { Component } from 'react'
 import { isNil } from 'lodash'
+import PasswordField from '../../components/PasswordField'
 import DisplayWalletKeys from '../../components/DisplayWalletKeys'
 import Page from '../../components/Page'
 import HomeButtonLink from '../../components/HomeButtonLink'
@@ -57,21 +58,18 @@ export default class EncryptKey extends Component<Props, State> {
         <div className='info'>
           Choose a passphrase to encrypt your existing private key:
         </div>
-        <input
-          type='text'
+        <PasswordField
           value={passphrase}
           onChange={(e) => this.setState({ passphrase: e.target.value })}
           placeholder='Enter passphrase here'
           autoFocus
         />
-        <input
-          type='text'
+        <PasswordField
           value={passphrase2}
           onChange={(e) => this.setState({ passphrase2: e.target.value })}
           placeholder='Enter passphrase again'
         />
-        <input
-          type='text'
+        <PasswordField
           value={wif}
           onChange={(e) => this.setState({ wif: e.target.value })}
           placeholder='Enter existing WIF here'

--- a/app/containers/LoginLocalStorage/LoginLocalStorage.jsx
+++ b/app/containers/LoginLocalStorage/LoginLocalStorage.jsx
@@ -2,8 +2,7 @@
 import React, { Component } from 'react'
 import storage from 'electron-json-storage'
 import { map } from 'lodash'
-import FaEye from 'react-icons/lib/fa/eye'
-import FaEyeSlash from 'react-icons/lib/fa/eye-slash'
+import PasswordField from '../../components/PasswordField'
 import Page from '../../components/Page'
 import HomeButtonLink from '../../components/HomeButtonLink'
 import styles from './LoginLocalStorage.scss'
@@ -17,14 +16,12 @@ type Props = {
 }
 
 type State = {
-  showKey: boolean,
   passphrase: string,
   wif: string,
 }
 
 export default class LoginLocalStorage extends Component<Props, State> {
   state = {
-    showKey: false,
     passphrase: '',
     wif: ''
   }
@@ -37,20 +34,14 @@ export default class LoginLocalStorage extends Component<Props, State> {
     })
   }
 
-  toggleKeyVisibility = () => {
-    this.setState(prevState => ({
-      showKey: !prevState.showKey
-    }))
-  }
-
   render () {
     const { accountKeys, history, loginNep2 } = this.props
-    const { showKey, passphrase, wif } = this.state
+    const { passphrase, wif } = this.state
     const loginButtonDisabled = Object.keys(accountKeys).length === 0 || wif === '' || passphrase === ''
 
     return (
       <Page id='loginPage' className={loginStyles.loginPage}>
-        <div className={loginStyles.title}>Login using a saved wallet:</div>
+        <div className={loginStyles.title}>Login using a saved wallet!:</div>
         <select
           className={styles.selectWallet}
           value={wif}
@@ -60,18 +51,12 @@ export default class LoginLocalStorage extends Component<Props, State> {
           {map(accountKeys, (value, key) => <option value={value} key={`wallet${key}`}>{key}</option>)}
         </select>
         <div className={loginStyles.loginForm}>
-          <input
-            type={showKey ? 'text' : 'password'}
+          <PasswordField
             placeholder='Enter your passphrase here'
             value={passphrase}
             onChange={(e) => this.setState({ passphrase: e.target.value })}
             autoFocus
           />
-
-          {showKey
-            ? <FaEyeSlash className={loginStyles.viewKey} onClick={this.toggleKeyVisibility} />
-            : <FaEye className={loginStyles.viewKey} onClick={this.toggleKeyVisibility} />
-          }
         </div>
         <div>
           <button

--- a/app/containers/LoginNep2/LoginNep2.jsx
+++ b/app/containers/LoginNep2/LoginNep2.jsx
@@ -1,9 +1,8 @@
 // @flow
 import React, { Component } from 'react'
-import FaEye from 'react-icons/lib/fa/eye'
-import FaEyeSlash from 'react-icons/lib/fa/eye-slash'
 import Page from '../../components/Page'
 import HomeButtonLink from '../../components/HomeButtonLink'
+import PasswordField from '../../components/PasswordField'
 import classNames from 'classnames'
 import loginStyles from '../../styles/login.scss'
 
@@ -13,46 +12,32 @@ type Props = {
 }
 
 type State = {
-  showKey: boolean,
   wif: string,
   passphrase: string
 }
 
 export default class LoginNep2 extends Component<Props, State> {
   state = {
-    showKey: false,
     wif: '',
     passphrase: ''
   }
 
-  toggleKeyVisibility = () => {
-    this.setState(prevState => ({
-      showKey: !prevState.showKey
-    }))
-  }
-
   render () {
     const { loginNep2, history } = this.props
-    const { showKey, wif, passphrase } = this.state
+    const { wif, passphrase } = this.state
     const loginButtonDisabled = wif === '' || passphrase === ''
 
     return (
       <Page id='loginPage' className={loginStyles.loginPage}>
         <div className={loginStyles.title}>Login using an encrypted key:</div>
         <div className={loginStyles.loginForm}>
-          <input
-            type={showKey ? 'text' : 'password'}
+          <PasswordField
             placeholder='Enter your passphrase here'
             onChange={(e) => this.setState({ passphrase: e.target.value })}
             value={passphrase}
             autoFocus
           />
-          {showKey
-            ? <FaEyeSlash className={loginStyles.viewKey} onClick={this.toggleKeyVisibility} />
-            : <FaEye className={loginStyles.viewKey} onClick={this.toggleKeyVisibility} />
-          }
-          <input
-            type='text'
+          <PasswordField
             placeholder='Enter your encrypted key here'
             onChange={(e) => this.setState({ wif: e.target.value })}
             value={wif}

--- a/app/containers/LoginPrivateKey/LoginPrivateKey.jsx
+++ b/app/containers/LoginPrivateKey/LoginPrivateKey.jsx
@@ -1,7 +1,6 @@
 // @flow
 import React, { Component } from 'react'
-import FaEye from 'react-icons/lib/fa/eye'
-import FaEyeSlash from 'react-icons/lib/fa/eye-slash'
+import PasswordField from '../../components/PasswordField'
 import Page from '../../components/Page'
 import HomeButtonLink from '../../components/HomeButtonLink'
 import loginStyles from '../../styles/login.scss'
@@ -12,42 +11,28 @@ type Props = {
 }
 
 type State = {
-  showKey: boolean,
   wif: string,
 }
 
 export default class LoginPrivateKey extends Component<Props, State> {
   state = {
-    showKey: false,
     wif: ''
-  }
-
-  toggleKeyVisibility = () => {
-    this.setState(prevState => ({
-      showKey: !prevState.showKey
-    }))
   }
 
   render () {
     const { history, loginWithPrivateKey } = this.props
-    const { showKey, wif } = this.state
+    const { wif } = this.state
     const loginButtonDisabled = wif === ''
 
     return (
       <Page id='loginPage' className={loginStyles.loginPage}>
         <div className={loginStyles.title}>Login using a private key:</div>
         <div className={loginStyles.loginForm}>
-          <input
-            type={showKey ? 'text' : 'password'}
+          <PasswordField
             placeholder='Enter your private key here (WIF)'
             onChange={(e) => this.setState({ wif: e.target.value })}
             autoFocus
           />
-
-          {showKey
-            ? <FaEyeSlash className={loginStyles.viewKey} onClick={this.toggleKeyVisibility} />
-            : <FaEye className={loginStyles.viewKey} onClick={this.toggleKeyVisibility} />
-          }
         </div>
         <div>
           <button

--- a/app/styles/login.scss
+++ b/app/styles/login.scss
@@ -21,20 +21,8 @@
             text-align: left;
         }
 
-        input {
-            width: 95%;
-            float: left;
-            margin-bottom: 10px;
-        }
-        
         select {
             margin-bottom: 10px;
         }
-        
-        .viewKey {
-            cursor: pointer;
-            margin-left: -25px;
-            margin-top: 10px;
-        }          
-    }      
+    }
 }


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Github #342

**What problem does this PR solve?**
Some fields that should default to type "password" don't and they also need the password/text (eye logo) toggle

**How did you solve this problem?**
Made a new reusable component

**How did you make sure your solution works?**
Try out all the wallet login screens

**Are there any special changes in the code that we should be aware of?**
No

**Is there anything else we should know?**
No

- [x] Unit tests written?
