### PR TITLE
Add Cut/Copy/Paste context menus on input fields (#336)

### DIFF
--- a/main.js
+++ b/main.js
@@ -81,10 +81,7 @@ app.on('ready', () => {
     }
 
     const inputMenu = Menu.buildFromTemplate([
-      {label : 'Cut', accelerator : 'CmdOrCtrl+X', click() { mainWindow.webContents.cut(); }},
-      {label : 'Copy', accelerator : 'CmdOrCtrl+C', click() { mainWindow.webContents.copy(); }},
-      {label : 'Paste', accelerator : 'CmdOrCtrl+V', click() { mainWindow.webContents.paste(); }},
-      {label : 'Select All', accelerator : 'CmdOrCtrl+A', click() { mainWindow.webContents.selectAll(); }}
+      {label : 'Paste', accelerator : 'CmdOrCtrl+V', click() { mainWindow.webContents.paste(); }}
     ]);
 
     mainWindow.webContents.on('context-menu', (event, params) => {

--- a/main.js
+++ b/main.js
@@ -80,6 +80,17 @@ app.on('ready', () => {
       Menu.setApplicationMenu(menu)
     }
 
+    const inputMenu = Menu.buildFromTemplate([
+      {label : 'Cut', accelerator : 'CmdOrCtrl+X', click() { mainWindow.webContents.cut(); }},
+      {label : 'Copy', accelerator : 'CmdOrCtrl+C', click() { mainWindow.webContents.copy(); }},
+      {label : 'Paste', accelerator : 'CmdOrCtrl+V', click() { mainWindow.webContents.paste(); }},
+      {label : 'Select All', accelerator : 'CmdOrCtrl+A', click() { mainWindow.webContents.selectAll(); }}
+    ]);
+
+    mainWindow.webContents.on('context-menu', (event, params) => {
+      inputMenu.popup(mainWindow);
+    });
+
     if (process.env.START_HOT) {
       mainWindow.loadURL(`http://localhost:${port}/dist`)
     } else {


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
#336

**What problem does this PR solve?**
Right Click on input doesn't do anything. You should see a menu with cut / copy / past / select all options

**How did you solve this problem?**
Add Electron menu input config

**How did you make sure your solution works?**
Tests

**Are there any special changes in the code that we should be aware of?**

**Is there anything else we should know?**


