### PR TITLE
Load settings on app init

### DIFF
--- a/__tests__/components/App.test.js
+++ b/__tests__/components/App.test.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import { Provider } from 'react-redux'
+import thunk from 'redux-thunk'
+import storage from 'electron-json-storage'
+import configureStore from 'redux-mock-store'
+import { shallow, mount } from 'enzyme'
+import App from '../../app/containers/App'
+
+const setup = (state, shallowRender = true) => {
+  const store = configureStore([thunk])(state)
+
+  let wrapper
+  if (shallowRender) {
+    wrapper = shallow(<App store={store} />)
+  } else {
+    wrapper = mount(
+      <Provider store={store}>
+        <App />
+      </Provider>
+    )
+  }
+
+  return { wrapper, store }
+}
+
+describe('App', () => {
+  test('app initializes settings', (done) => {
+    storage.get = jest.fn((settingsKey, callback) => {
+      expect(settingsKey).toEqual('settings')
+      done()
+    })
+    setup({ modal: {} }, false)
+  })
+})

--- a/__tests__/components/WalletInfo.test.js
+++ b/__tests__/components/WalletInfo.test.js
@@ -16,7 +16,6 @@ import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 import { clipboard } from 'electron'
 import { version } from '../../package.json'
-import { formatFiat } from '../../app/core/formatters'
 
 const axiosMock = new MockAdapter(axios)
 axiosMock
@@ -30,6 +29,11 @@ axiosMock
   .reply(200, [ { price_usd: 18.20 } ])
 
 jest.mock('electron', () => ({
+  app: {
+    getPath: () => {
+      return 'C:\\tmp\\mock_path'
+    }
+  },
   clipboard: {
     writeText: jest.fn()
   }

--- a/app/containers/App/App.jsx
+++ b/app/containers/App/App.jsx
@@ -6,13 +6,16 @@ import Notifications from '../Notifications'
 
 type Props = {
   children: Children,
-  checkVersion: Function
+  checkVersion: Function,
+  initSettings: Function
 }
 
 class App extends Component<Props> {
   componentDidMount () {
-    const { checkVersion } = this.props
+    const { checkVersion, initSettings } = this.props
+
     checkVersion()
+    initSettings()
   }
 
   render () {

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -1,11 +1,12 @@
 // @flow
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
-import { checkVersion } from '../../modules/metadata'
+import { checkVersion, initSettings } from '../../modules/metadata'
 import App from './App'
 
 const actionCreators = {
-  checkVersion
+  checkVersion,
+  initSettings
 }
 
 const mapDispatchToProps = dispatch => bindActionCreators(actionCreators, dispatch)

--- a/app/containers/Settings/Settings.jsx
+++ b/app/containers/Settings/Settings.jsx
@@ -33,7 +33,6 @@ export default class Settings extends Component<Props, State> {
     storage.get('keys', (error, data) => {
       setKeys(data)
     })
-    this.loadSettings()
   }
 
   saveKeyRecovery = (keys: Object) => {
@@ -86,16 +85,6 @@ export default class Settings extends Component<Props, State> {
     storage.set('settings', settings)
   }
 
-  loadSettings = () => {
-    const { setBlockExplorer } = this.props
-    // eslint-disable-next-line
-    storage.get('settings', (error, settings) => {
-      if (settings.blockExplorer !== null && settings.blockExplorer !== undefined) {
-        setBlockExplorer(settings.blockExplorer)
-      }
-    })
-  }
-
   updateSettings = (e: Object) => {
     const { setBlockExplorer } = this.props
     const explorer = e.target.value
@@ -123,8 +112,7 @@ export default class Settings extends Component<Props, State> {
   }
 
   render () {
-    const { wallets } = this.props
-    const { explorer } = this.state
+    const { wallets, explorer } = this.props
     return (
       <Page id='settings'>
         <div className='description'>Manage your Neon wallet keys and settings</div>

--- a/app/modules/metadata.js
+++ b/app/modules/metadata.js
@@ -5,6 +5,7 @@ import { version } from '../../package.json'
 import { showWarningNotification } from './notifications'
 import { NETWORK, EXPLORER, NEON_WALLET_RELEASE_LINK, NOTIFICATION_POSITIONS } from '../core/constants'
 import asyncWrap from '../core/asyncHelper'
+import storage from 'electron-json-storage'
 
 // Constants
 export const SET_HEIGHT = 'SET_HEIGHT'
@@ -52,6 +53,15 @@ export const checkVersion = () => async (dispatch: DispatchType, getState: GetSt
       position: NOTIFICATION_POSITIONS.BOTTOM_CENTER
     }))
   }
+}
+
+export const initSettings = () => async (dispatch: DispatchType) => {
+  // eslint-disable-next-line
+  storage.get('settings', (error, settings) => {
+    if (settings.blockExplorer !== null && settings.blockExplorer !== undefined) {
+      dispatch(setBlockExplorer(settings.blockExplorer))
+    }
+  })
 }
 
 export const syncBlockHeight = (net: NetworkType) => async (dispatch: DispatchType) => {


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
None

**What problem does this PR solve?**
Settings currently only load if you go to the settings page. Otherwise, if you go to wallet first thing for example, you'll always be using the default blockchain explorer.

**How did you solve this problem?**
This changes the code to make settings load on App init. It also fixes the settings container to get the settings automatically from props.

**How did you make sure your solution works?**
There's a test plus you can set your blockchain explorer to non-default, completely close and reopen the app and go immediately to the wallet. Links should be to the correct explorer

**Are there any special changes in the code that we should be aware of?**
no

**Is there anything else we should know?**
no

- [x] Unit tests written?
