### PR TITLE
Send modal ui fixes

### DIFF
--- a/app/components/Modals/SendModal/ConfirmDisplay.jsx
+++ b/app/components/Modals/SendModal/ConfirmDisplay.jsx
@@ -29,9 +29,7 @@ const ConfirmDisplay = ({
   <div>
     <p>Please confirm the following transaction:</p>
     <p>You are sending <strong>{formatBalance(symbol, sendAmount)} {symbol}</strong> to:</p>
-    <div onClick={() => openExplorerAddress(net, explorer, sendAddress)}>
-      <div className={styles.externalLink}>{sendAddress}</div>
-    </div>
+    <div className={styles.externalLink} onClick={() => openExplorerAddress(net, explorer, sendAddress)}>{sendAddress}</div>
     <div>
       <Button onClick={confirmTransaction}>Confirm</Button>
       <Button cancel onClick={cancelTransaction}>Cancel</Button>

--- a/app/components/Modals/SendModal/SendDisplay.jsx
+++ b/app/components/Modals/SendModal/SendDisplay.jsx
@@ -6,6 +6,7 @@ import NumberInput from '../../NumberInput'
 
 import { ASSETS } from '../../../core/constants'
 import { formatBalance, toFixedDecimals, COIN_DECIMAL_LENGTH } from '../../../core/formatters'
+import { isToken } from '../../../core/wallet'
 
 import styles from './SendModal.scss'
 
@@ -75,6 +76,7 @@ const SendDisplay = ({
             <option value={ASSETS.GAS}>{ASSETS.GAS}</option>
             {Object.keys(tokens).map((symbol) => <option key={symbol} value={symbol}>{symbol}</option>)}
           </select>
+          {isToken(symbol) && <span className={styles.tokenInfoMessage}>Sending NEP5 tokens requires holding at least 1 drop of GAS</span>}
         </div>
       </div>
       <div id='sendAmount' className={styles.column}>

--- a/app/components/Modals/SendModal/SendDisplay.jsx
+++ b/app/components/Modals/SendModal/SendDisplay.jsx
@@ -71,6 +71,7 @@ const SendDisplay = ({
           <select
             onChange={(e) => onChangeHandler('symbol', e.target.value, true)}
             className={styles.sendAmountSelect}
+            value={symbol}
           >
             <option value={ASSETS.NEO}>{ASSETS.NEO}</option>
             <option value={ASSETS.GAS}>{ASSETS.GAS}</option>

--- a/app/components/Modals/SendModal/SendModal.scss
+++ b/app/components/Modals/SendModal/SendModal.scss
@@ -24,6 +24,9 @@
 
 .percentButton {
     width: 100%;
+    &:last-child {
+        margin: 0
+    }
 }
 
 .label {

--- a/app/components/Modals/SendModal/SendModal.scss
+++ b/app/components/Modals/SendModal/SendModal.scss
@@ -15,7 +15,6 @@
     flex-direction: row;
 }
 
-
 .percentRow {
     display: flex;
     flex-direction: row;
@@ -33,6 +32,7 @@
 
 .sendAmount {
     display: flex;
+    align-items: center;
 }
 
 .sendAmountSelect {
@@ -42,9 +42,14 @@
 .sendButton {
     margin-top: 20px;
 }
+
 .externalLink {
     color: $link-color;
     margin-top: 20px;
     margin-bottom: 20px;
     cursor: pointer;
+}
+
+.tokenInfoMessage {
+    font-size: 13px;
 }


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
UI Touch ups

**What problem does this PR solve?**
Send modal touch ups:
1. Add an info message when selecting a NEP5 token, indicating that there is a need for at least 1 drop of gas when sending a token.
2. Remove the margin from the last percent button.
3. Remember selected value of assets (when returning from confirm display)
3. Remove extra div in confirm display.

**How did you make sure your solution works?**
Tested

- [ ] Unit tests written?
No