### PR TITLE
Token balance ui fixes

### DIFF
--- a/app/containers/WalletInfo/TokensBalance.jsx
+++ b/app/containers/WalletInfo/TokensBalance.jsx
@@ -2,6 +2,7 @@
 import React from 'react'
 
 import Table from '../../components/Table'
+import Tooltip from '../../components/Tooltip'
 
 import { MODAL_TYPES } from '../../core/constants'
 import { formatBalance } from '../../core/formatters'
@@ -27,14 +28,14 @@ const tokens = ({ tokens, showModal }: Props) => (
       {tokens && Object.keys(tokens).map((symbol) => {
         const token = tokens[symbol]
         const { balance } = token
+        const formattedBalance = formatBalance(symbol, balance)
+        const formattedBalanceDisplay = formatBalance(symbol, balance, true)
         return (
           <tr key={symbol}>
-            <td
-              className={styles.symbol}
-              onClick={() => showModal(MODAL_TYPES.TOKEN_INFO, { token })}>
-              <InfoOutline className={styles.symbolIcon} />{symbol}
+            <td onClick={() => showModal(MODAL_TYPES.TOKEN_INFO, { token })}>
+              <span className={styles.symbol}><InfoOutline className={styles.symbolIcon} />{symbol}</span>
             </td>
-            <td>{formatBalance(symbol, balance, true)}</td>
+            <td><Tooltip title={formattedBalance} disable={balance === 0}>{formattedBalanceDisplay}</Tooltip></td>
           </tr>
         )
       })}

--- a/app/containers/WalletInfo/TokensBalance.scss
+++ b/app/containers/WalletInfo/TokensBalance.scss
@@ -8,6 +8,7 @@
     display: flex;
     align-items: center;
     cursor: pointer;
+    justify-content: center;
 }
 
 .symbolIcon {


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
UI Touch ups

**What problem does this PR solve?**
Token balance touch ups:
1. Add a tooltip displaying the full balance of the token balance.
2. Correct the height issue with the table cell. (one was 28px, the other 29px)
3. Center the token symbol.

**How did you make sure your solution works?**
Tested

- [ ] Unit tests written?
No