### PR TITLE
Warn user when address being sent to has no transaction history

### DIFF
--- a/app/components/Modals/SendModal/ConfirmDisplay.jsx
+++ b/app/components/Modals/SendModal/ConfirmDisplay.jsx
@@ -6,6 +6,7 @@ import Button from '../../Button'
 import Loader from '../../Loader'
 import { formatBalance } from '../../../core/formatters'
 import { openExplorerAddress } from '../../../core/explorer'
+import asyncWrap from '../../../core/asyncHelper'
 
 import styles from './SendModal.scss'
 
@@ -30,20 +31,19 @@ class ConfirmDisplay extends React.Component<Props, State> {
     addressCheckedMessage: ''
   }
 
-  checkTransactionHistory = (net, address) => {
-    api.neonDB.getTransactionHistory(net, address).then((transactions) => {
-      this.setState({ addressChecked: true })
+  async checkTransactionHistory (net: NetworkType, address: string) {
+    const [err, transactions] = await asyncWrap(api.neonDB.getTransactionHistory(net, address))
 
-      if (!transactions || !transactions.length) {
-        this.setState({
-          addressCheckedMessage: 'Warning: recipient address has no activity in its transaction history. Please be sure the address is correct before sending.'
-        })
-      }
-    }).catch((e) => {
-      this.setState({
-        addressChecked: true,
-        addressCheckedMessage: 'Warning: there was an error verifying the recipient address has activity in its transaction history.'
-      })
+    let message = ''
+    if (err) {
+      message = 'Warning: there was an error verifying the recipient address has activity in its transaction history.'
+    } else if (!transactions || !transactions.length) {
+      message = 'Warning: recipient address has no activity in its transaction history. Please be sure the address is correct before sending.'
+    }
+
+    this.setState({
+      addressChecked: true,
+      addressCheckedMessage: message
     })
   }
 

--- a/app/components/Modals/SendModal/ConfirmDisplay.jsx
+++ b/app/components/Modals/SendModal/ConfirmDisplay.jsx
@@ -1,7 +1,9 @@
 // @flow
 import React from 'react'
+import { api } from 'neon-js'
 import Button from '../../Button'
 
+import Loader from '../../Loader'
 import { formatBalance } from '../../../core/formatters'
 import { openExplorerAddress } from '../../../core/explorer'
 
@@ -17,24 +19,60 @@ type Props = {
   net: NetworkType,
 }
 
-const ConfirmDisplay = ({
-  sendAddress,
-  sendAmount,
-  symbol,
-  confirmTransaction,
-  cancelTransaction,
-  explorer,
-  net
-}: Props) => (
-  <div>
-    <p>Please confirm the following transaction:</p>
-    <p>You are sending <strong>{formatBalance(symbol, sendAmount)} {symbol}</strong> to:</p>
-    <div className={styles.externalLink} onClick={() => openExplorerAddress(net, explorer, sendAddress)}>{sendAddress}</div>
-    <div>
-      <Button onClick={confirmTransaction}>Confirm</Button>
-      <Button cancel onClick={cancelTransaction}>Cancel</Button>
-    </div>
-  </div>
-)
+type State = {
+  addressChecked: boolean,
+  addressCheckedMessage: string
+}
+
+class ConfirmDisplay extends React.Component<Props> {
+  state = {
+    addressChecked: false,
+    addressCheckedMessage: ''
+  }
+
+  checkTransactionHistory = (net, address) => {
+    api.neonDB.getTransactionHistory(net, address).then((transactions) => {
+      this.setState({ addressChecked: true })
+
+      if (!transactions || !transactions.length) {
+        this.setState({
+          addressCheckedMessage: 'Warning: recipient address has no activity in its transaction history. Please be sure the address is correct before sending.'
+        })
+      }
+    }).catch((e) => {
+      this.setState({
+        addressChecked: true,
+        addressCheckedMessage: 'Warning: there was an error verifying the recipient address has activity in its transaction history.'
+      })
+    })
+  }
+
+  componentDidMount () {
+    const { sendAddress, net } = this.props
+    this.checkTransactionHistory(net, sendAddress)
+  }
+
+  render () {
+    const { sendAddress, sendAmount, symbol, confirmTransaction, cancelTransaction, explorer, net } = this.props
+    const { addressChecked, addressCheckedMessage } = this.state
+
+    if (!addressChecked) {
+      return (<Loader />)
+    } else {
+      return (
+        <div>
+          <p>Please confirm the following transaction:</p>
+          <p>You are sending <strong>{formatBalance(symbol, sendAmount)} {symbol}</strong> to:</p>
+          <div className={styles.externalLink} onClick={() => openExplorerAddress(net, explorer, sendAddress)}>{sendAddress}</div>
+          <div>
+            <Button onClick={confirmTransaction}>Confirm</Button>
+            <Button cancel onClick={cancelTransaction}>Cancel</Button>
+          </div>
+          { addressCheckedMessage && <div className={styles.addressWarning}>{addressCheckedMessage}</div> }
+        </div>
+      )
+    }
+  }
+}
 
 export default ConfirmDisplay

--- a/app/components/Modals/SendModal/ConfirmDisplay.jsx
+++ b/app/components/Modals/SendModal/ConfirmDisplay.jsx
@@ -24,7 +24,7 @@ type State = {
   addressCheckedMessage: string
 }
 
-class ConfirmDisplay extends React.Component<Props> {
+class ConfirmDisplay extends React.Component<Props, State> {
   state = {
     addressChecked: false,
     addressCheckedMessage: ''

--- a/app/components/Modals/SendModal/SendModal.scss
+++ b/app/components/Modals/SendModal/SendModal.scss
@@ -56,3 +56,9 @@
 .tokenInfoMessage {
     font-size: 13px;
 }
+
+.addressWarning {
+    margin-top: 20px;
+    font-size: 11px;
+    color: red;
+}


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
https://github.com/CityOfZion/neon-wallet/issues/271

**How did you solve this problem?**
Check NeonDB tx history for recipient address transactions. If there are none, show warning

**How did you make sure your solution works?**
Check the UI sending to fresh throwaway address.

<img width="468" alt="screen shot 2017-12-05 at 9 53 26 am" src="https://user-images.githubusercontent.com/327999/33613626-1affd388-d9a3-11e7-8a15-6f23714114c8.png">

- [ ] Unit tests written?
