### PR TITLE
Show a warning when trying to save a key with the same name

### DIFF
--- a/app/containers/DisplayWalletKeys/DisplayWalletKeys.jsx
+++ b/app/containers/DisplayWalletKeys/DisplayWalletKeys.jsx
@@ -2,13 +2,16 @@
 import React, { Component } from 'react'
 import { Link } from 'react-router-dom'
 import QRCode from 'qrcode/lib/browser'
+import storage from 'electron-json-storage'
 
 import Page from '../../components/Page'
 import CopyToClipboard from '../../components/CopyToClipboard'
+import { MODAL_TYPES } from '../../core/constants'
 
 type Props = {
   resetKey: Function,
   saveKey: Function,
+  showModal: Function,
   address: string,
   wif: string,
   encryptedWIF: string,
@@ -37,8 +40,36 @@ class DisplayWalletKeys extends Component<Props, State> {
     })
   }
 
+  handleSaveKey = (keyName, encryptedWIF) => {
+    const { showModal, saveKey } = this.props
+
+    // eslint-disable-next-line
+    storage.get('keys', (error, data) => {
+      if (data[keyName]) {
+        const text = (
+          <div>
+            <p>A wallet with this name already exists.</p>
+            <p>Please confirm overwriting saved wallet "{keyName}".</p>
+            <p>Cancel to choose a different name.</p>
+          </div>
+        )
+
+        showModal(MODAL_TYPES.CONFIRM, {
+          title: 'Confirm Overwrite',
+          text: text,
+          onClick: () => {
+            saveKey(keyName, encryptedWIF)
+          },
+          height: '280px'
+        })
+      } else {
+        saveKey(keyName, encryptedWIF)
+      }
+    })
+  }
+
   render () {
-    const { passphrase, address, encryptedWIF, wif, resetKey, saveKey } = this.props
+    const { passphrase, address, encryptedWIF, wif, resetKey } = this.props
     const { keyName } = this.state
     return (
       <Page id='newWallet'>
@@ -80,7 +111,7 @@ class DisplayWalletKeys extends Component<Props, State> {
         </div>
         <div className='saveKey'>
           <input autoFocus type='text' placeholder='Name this key' value={keyName} onChange={(e) => this.setState({ keyName: e.target.value })} />
-          <button onClick={() => saveKey(keyName, encryptedWIF)}>Save Key</button>
+          <button onClick={() => this.handleSaveKey(keyName, encryptedWIF)}>Save Key</button>
         </div>
         <Link onClick={() => resetKey()} to='/'><button>Back</button></Link>
         <button onClick={() => window.print()}>Print</button>

--- a/app/containers/DisplayWalletKeys/index.js
+++ b/app/containers/DisplayWalletKeys/index.js
@@ -2,6 +2,8 @@
 import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 
+import { showModal } from '../../modules/modal'
+
 import {
   saveKey,
   resetKey,
@@ -22,7 +24,8 @@ const mapStateToProps = (state: Object) => ({
 
 const actionCreators = {
   saveKey,
-  resetKey
+  resetKey,
+  showModal
 }
 
 const mapDispatchToProps = dispatch => bindActionCreators(actionCreators, dispatch)


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
https://github.com/CityOfZion/neon-wallet/issues/396

**What problem does this PR solve?**
Currently you can accidentally save over preexisting keys by using a key name you've used before.

**How did you solve this problem?**
Warn the user in a confirmation overlay. They can confirm overwriting the key or cancel and choose a different name.

**How did you make sure your solution works?**
Save a new key "test". Create another key and try to name it "test"

**Are there any special changes in the code that we should be aware of?**
no

**Is there anything else we should know?**
no

- [ ] Unit tests written?


Overlay looks like this in case language/design changes are needed:
<img width="455" alt="key-overlay" src="https://user-images.githubusercontent.com/327999/33636693-47c5321c-d9eb-11e7-9bd3-a460840d4034.png">

