### PR TITLE
Bugfix: [Receive Modal] - Increase the height to hide the scroll

### DIFF
--- a/app/components/Modals/ReceiveModal/ReceiveModal.jsx
+++ b/app/components/Modals/ReceiveModal/ReceiveModal.jsx
@@ -30,7 +30,7 @@ class ReceiveModal extends Component<Props> {
         style={{
           content: {
             width: '420px',
-            height: '420px'
+            height: '460px'
           }
         }}
       >


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
None

**What problem does this PR solve?**
Increase height to remove the scroll (See screenshot)

<img width="496" alt="screen shot 2017-12-09 at 10 16 26 pm" src="https://user-images.githubusercontent.com/254095/33795124-ae87f0c0-dd2e-11e7-9479-70305e3d17ea.png">

