### PR TITLE
Replaced readme slack link with discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ A gentle reminder, github issues is meant to be used by developers for maintaini
 - *"I lost my private key, is there anyway to recover it?"*
 - *"Why is my balance not showing?"*
 
-should be asked in proper support channels such as the [NEO subreddit](https://www.reddit.com/r/NEO/), or the official [NEO slack](https://neosmarteconomy.slack.com). You should also check the list of [frequently asked questions (FAQ)](https://github.com/CityOfZion/awesome-NEO/blob/master/resources/faq.md) to see if your question has been answered there already.
+should be asked in proper support channels such as the [NEO subreddit](https://www.reddit.com/r/NEO/), or the official [NEO Discord Channel](https://discord.gg/R8v48YA). You should also check the list of [frequently asked questions (FAQ)](https://github.com/CityOfZion/awesome-NEO/blob/master/resources/faq.md) to see if your question has been answered there already.


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
The README still linked to Slack instead of Discord.

**How did you solve this problem?**
I replaced the Slack link and text with Discord link and text.

**How did you make sure your solution works?**
I clicked the link.

**Are there any special changes in the code that we should be aware of?**
No.

**Is there anything else we should know?**
No.

- [ ] Unit tests written?
N/A