### PR TITLE
Fixed claim button formatting

### DIFF
--- a/__tests__/components/__snapshots__/Claim.test.js.snap
+++ b/__tests__/components/__snapshots__/Claim.test.js.snap
@@ -14,7 +14,7 @@ exports[`Claim should not render claim GAS button when claim button is disabled 
       onClick={[Function]}
     >
       Claim 
-      10
+      10.00000000
        GAS
     </button>
   </Tooltip>
@@ -35,7 +35,7 @@ exports[`Claim should render claim GAS button when claim button is not disabled 
       onClick={[Function]}
     >
       Claim 
-      10
+      10.00000000
        GAS
     </button>
   </Tooltip>

--- a/app/containers/Claim/Claim.jsx
+++ b/app/containers/Claim/Claim.jsx
@@ -2,6 +2,7 @@
 import React, { Component } from 'react'
 
 import Tooltip from '../../components/Tooltip'
+import { formatGAS } from '../../core/formatters'
 
 type Props = {
   doClaimNotify: Function,
@@ -25,6 +26,7 @@ export default class Claim extends Component<Props> {
   render () {
     const { claimAmount, disableClaimButton, doGasClaim } = this.props
     const shouldDisableButton = disableClaimButton || claimAmount === 0
+    const formattedAmount = formatGAS(claimAmount)
     return (
       <div id='claim'>
         <Tooltip
@@ -34,7 +36,7 @@ export default class Claim extends Component<Props> {
           <button
             disabled={shouldDisableButton}
             onClick={() => doGasClaim()}
-            className={shouldDisableButton ? 'disabled' : ''}>Claim {claimAmount} GAS</button>
+            className={shouldDisableButton ? 'disabled' : ''}>Claim {formattedAmount} GAS</button>
         </Tooltip>
       </div>
     )


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
The "Claim GAS" button was showing exponential values.

Before:
![Claim GAS Before](https://user-images.githubusercontent.com/169093/34284945-40b7f006-e69b-11e7-90ae-31eca58d35c6.png)

After:
![Claim GAS After](https://user-images.githubusercontent.com/169093/34284948-56163516-e69b-11e7-8e20-d8f00d6272c3.png)

**How did you solve this problem?**
Used the existing `formatGAS` helper function.

**How did you make sure your solution works?**
Smoke tested it, compared output to snapshot in tests.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [x] Unit tests written?
