### PR TITLE
Address redux state

### DIFF
--- a/__tests__/components/Blockchain/Address/Address.test.js
+++ b/__tests__/components/Blockchain/Address/Address.test.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import Address from '../../../../app/components/Blockchain/Address/Address'
+import { NETWORK, EXPLORERS } from '../../../../app/core/constants'
+
+describe('Address', () => {
+  const props = {
+    address: 'AW4FD7bz6PF2QadFKF8qXUT7tNmWgvXZc4',
+    net: NETWORK.TEST,
+    explorer: EXPLORERS.NEO_SCAN
+  }
+
+  test('should render without crashing', () => {
+    const wrapper = shallow(<Address {...props} />)
+    expect(wrapper).toMatchSnapshot()
+  })
+})

--- a/__tests__/components/Blockchain/Address/__snapshots__/Address.test.js.snap
+++ b/__tests__/components/Blockchain/Address/__snapshots__/Address.test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Address should render without crashing 1`] = `
+<span
+  className="address"
+  onClick={[Function]}
+>
+  AW4FD7bz6PF2QadFKF8qXUT7tNmWgvXZc4
+</span>
+`;

--- a/app/components/Blockchain/Address/Address.jsx
+++ b/app/components/Blockchain/Address/Address.jsx
@@ -2,7 +2,7 @@
 import React from 'react'
 import classNames from 'classnames'
 
-import { openExplorerAddress } from '../../core/explorer'
+import { openExplorerAddress } from '../../../core/explorer'
 import styles from './Address.scss'
 
 type Props = {

--- a/app/components/Blockchain/Address/Address.scss
+++ b/app/components/Blockchain/Address/Address.scss
@@ -1,4 +1,4 @@
-@import '../../styles/variables';
+@import '../../../styles/variables';
 
 .address {
     color: $link-color;

--- a/app/components/Blockchain/Address/index.js
+++ b/app/components/Blockchain/Address/index.js
@@ -1,0 +1,12 @@
+// @flow
+import { connect } from 'react-redux'
+
+import Address from './Address'
+import { getBlockExplorer, getNetwork } from '../../../modules/metadata'
+
+const mapStateToProps = (state: Object) => ({
+  net: getNetwork(state),
+  explorer: getBlockExplorer(state)
+})
+
+export default connect(mapStateToProps)(Address)

--- a/app/components/Modals/ReceiveModal/ReceiveModal.jsx
+++ b/app/components/Modals/ReceiveModal/ReceiveModal.jsx
@@ -8,17 +8,15 @@ import CopyToClipboard from '../../CopyToClipboard'
 import { Address } from '../../Blockchain'
 
 type Props = {
-    address: string,
-    hideModal: Function,
-    net: NetworkType,
-    explorer: ExplorerType,
+  address: string,
+  hideModal: Function
 }
 
 export default class ReceiveModal extends Component<Props> {
   canvas: ?HTMLCanvasElement
 
   render () {
-    const { hideModal, address, net, explorer } = this.props
+    const { hideModal, address } = this.props
     return (
       <BaseModal
         onAfterOpen={() => {
@@ -38,7 +36,7 @@ export default class ReceiveModal extends Component<Props> {
         <div className={styles.textContainer}>
           <div>Your Public NEO Address:</div>
           <div className={styles.address}>
-            <Address className={styles.externalLink} net={net} explorer={explorer} address={address} />
+            <Address className={styles.externalLink} address={address} />
             <CopyToClipboard text={address} tooltip='Copy Public Address' />
           </div>
           <div className={styles.canvas}><canvas ref={(node) => { this.canvas = node }} /></div>

--- a/app/components/Modals/SendModal/ConfirmDisplay.jsx
+++ b/app/components/Modals/SendModal/ConfirmDisplay.jsx
@@ -9,8 +9,6 @@ import { formatBalance } from '../../../core/formatters'
 import styles from './ConfirmDisplay.scss'
 
 type Props = {
-  net: NetworkType,
-  explorer: ExplorerType,
   address: string,
   entries: Array<SendEntryType>,
   message: string,
@@ -29,7 +27,7 @@ export default class ConfirmDisplay extends React.Component<Props, State> {
   }
 
   render () {
-    const { onConfirm, onCancel, explorer, net, entries, address, message } = this.props
+    const { onConfirm, onCancel, entries, address, message } = this.props
     const { agree } = this.state
 
     return (
@@ -46,7 +44,7 @@ export default class ConfirmDisplay extends React.Component<Props, State> {
               {entries.map((entry, i) => (
                 <tr key={`entry-${i}`}>
                   <td>{formatBalance(entry.symbol, entry.amount)} {entry.symbol}</td>
-                  <td><Address net={net} explorer={explorer} address={entry.address} /></td>
+                  <td><Address address={entry.address} /></td>
                 </tr>
               ))}
             </tbody>
@@ -65,7 +63,7 @@ export default class ConfirmDisplay extends React.Component<Props, State> {
           <input id='agree' type='checkbox' checked={agree} onChange={() => this.setState({ agree: !agree })} />
           <label htmlFor='agree'>
             I agree to transfer the above assets & tokens from{' '}
-            <Address net={net} explorer={explorer} address={address} />.
+            <Address address={address} />.
           </label>
         </div>
 

--- a/app/components/Modals/SendModal/SendModal.jsx
+++ b/app/components/Modals/SendModal/SendModal.jsx
@@ -25,8 +25,6 @@ type Props = {
   showErrorNotification: Function,
   hideModal: Function,
   sendTransaction: Function,
-  explorer: ExplorerType,
-  net: NetworkType,
   address: string,
   isHardwareLogin: boolean,
 }
@@ -67,7 +65,7 @@ export default class SendModal extends Component<Props, State> {
   }
 
   renderDisplay = () => {
-    const { explorer, net, address, isHardwareLogin } = this.props
+    const { address, isHardwareLogin } = this.props
     const { display, balances, entries } = this.state
 
     if (display === DISPLAY_MODES.ADD_RECIPIENT) {
@@ -81,8 +79,6 @@ export default class SendModal extends Component<Props, State> {
     } else {
       return (
         <ConfirmDisplayContainer
-          net={net}
-          explorer={explorer}
           address={address}
           entries={entries}
           onConfirm={this.handleConfirmTransaction}

--- a/app/containers/Dashboard/Dashboard.jsx
+++ b/app/containers/Dashboard/Dashboard.jsx
@@ -27,7 +27,6 @@ type Props = {
   tokens: Object,
   loaded: boolean,
   loadWalletData: Function,
-  explorer: ExplorerType,
   isHardwareLogin: boolean,
 }
 
@@ -57,8 +56,6 @@ export default class Dashboard extends Component<Props> {
       showErrorNotification,
       sendTransaction,
       loaded,
-      explorer,
-      net,
       isHardwareLogin
     } = this.props
 
@@ -73,12 +70,12 @@ export default class Dashboard extends Component<Props> {
             <div className={styles.walletButtons}>
               <div
                 className={classNames(styles.walletButton, styles.sendButton)}
-                onClick={() => showModal(MODAL_TYPES.SEND, { NEO, GAS, tokens, showErrorNotification, sendTransaction, explorer, net, address, isHardwareLogin })}>
+                onClick={() => showModal(MODAL_TYPES.SEND, { NEO, GAS, tokens, showErrorNotification, sendTransaction, address, isHardwareLogin })}>
                 <FaArrowUpward className={styles.walletButtonIcon} /><span className={styles.walletButtonText}>Send</span>
               </div>
               <div
                 className={styles.walletButton}
-                onClick={() => showModal(MODAL_TYPES.RECEIVE, { address, net, explorer })}>
+                onClick={() => showModal(MODAL_TYPES.RECEIVE, { address })}>
                 <FaArrowDownward className={styles.walletButtonIcon} /><span className={styles.walletButtonText}>Receive</span>
               </div>
             </div>

--- a/app/containers/Dashboard/index.js
+++ b/app/containers/Dashboard/index.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 
 import { logout, getAddress, getIsHardwareLogin } from '../../modules/account'
-import { getBlockExplorer, getNetwork } from '../../modules/metadata'
+import { getNetwork } from '../../modules/metadata'
 import { getNotifications, showErrorNotification } from '../../modules/notifications'
 import { getNEO, getGAS, getTokens, getIsLoaded, loadWalletData } from '../../modules/wallet'
 import { showModal } from '../../modules/modal'
@@ -19,7 +19,6 @@ const mapStateToProps = (state: Object) => ({
   GAS: getGAS(state),
   tokens: getTokens(state),
   loaded: getIsLoaded(state),
-  explorer: getBlockExplorer(state),
   isHardwareLogin: getIsHardwareLogin(state)
 })
 


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
It cleans up `net` and `explorer` props being passed down a chain of react components just to feed them into the `Address` component.  Instead, we can fetch these from the redux store when rendering this component.

I also added a simple test for the `Address` component itself.

**How did you solve this problem?**
I removed the excess props being passed to individual components, and I added a store lookup for the `Address` component itself.

**How did you make sure your solution works?**
I smoke tested the app and clicked the address link anywhere it's used.  It took me to the correct explorer running on the correct network.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [x] Unit tests written?
