### PR TITLE
Fixed assets linking to wrong URL

### DIFF
--- a/app/core/explorer.js
+++ b/app/core/explorer.js
@@ -81,4 +81,4 @@ export const openExplorerAddress = (net: NetworkType, explorer: ExplorerType, ad
   openExternal(getExplorerAddressLink(net, explorer, address))
 
 export const openExplorerAsset = (net: NetworkType, explorer: ExplorerType, assetId: string) =>
-  openExternal(getExplorerTxLink(net, explorer, assetId))
+  openExternal(getExplorerAssetLink(net, explorer, assetId))


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
The function for opening asset links in a block explorer was using the wrong method internally, which would cause a transaction page to be loaded with an invalid txid.

**How did you solve this problem?**
I swapped out the wrong internal function call with the correct one.

**How did you make sure your solution works?**
N/A because it's not being used anywhere yet.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
