### PR TITLE
Fixed net being undefined sometimes when fetching transaction history

### DIFF
--- a/__tests__/components/__snapshots__/TransactionHistory.test.js.snap
+++ b/__tests__/components/__snapshots__/TransactionHistory.test.js.snap
@@ -4,6 +4,7 @@ exports[`TransactionHistory renders without crashing 1`] = `
 <TransactionHistory
   address="AWy7RNBVr9vDadRMK9p7i7Z1tL7GrLAxoh"
   isLoadingTransactions={false}
+  net="TestNet"
   store={
     Object {
       "clearActions": [Function],

--- a/app/containers/TransactionHistory/index.js
+++ b/app/containers/TransactionHistory/index.js
@@ -3,11 +3,13 @@ import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 
 import { syncTransactionHistory, getIsLoadingTransactions } from '../../modules/transactions'
+import { getNetwork } from '../../modules/metadata'
 import { getAddress } from '../../modules/account'
 import { getTransactions } from '../../modules/wallet'
 import TransactionHistory from './TransactionHistory'
 
 const mapStateToProps = (state: Object) => ({
+  net: getNetwork(state),
   address: getAddress(state),
   transactions: getTransactions(state),
   isLoadingTransactions: getIsLoadingTransactions(state)


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
Fetching the transaction sometimes fails, hitting localhost instead of the intended API endpoint based upon the current network.

**How did you solve this problem?**
I added the `net` prop to the `TransactionHistory` component since it was missing.

**How did you make sure your solution works?**
I'm not confident because I could not reproduce.  My change is based upon some insight from @dvdschwrtz where he stated that a call to `syncTransactionHistory` is receiving `undefined` for the network argument.  The `TransactionHistory` component is the only place that function is called, and we are incorrectly not passing the `net` prop to that component.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [x] Unit tests written?
