### PR TITLE
Fix MAX button

### DIFF
--- a/app/components/Modals/SendModal/AddRecipientDisplay.jsx
+++ b/app/components/Modals/SendModal/AddRecipientDisplay.jsx
@@ -46,7 +46,7 @@ export default class AddRecipientDisplay extends React.Component<Props, State> {
             <div id='sendAmount' className={styles.column}>
               <label className={styles.label}>Amount:</label>
               <NumberInput
-                max={max}
+                max={balance}
                 value={amount}
                 placeholder='Amount'
                 options={{ numeralDecimalScale: COIN_DECIMAL_LENGTH }}

--- a/app/core/math.js
+++ b/app/core/math.js
@@ -7,4 +7,4 @@ export const truncateNumber = (num: number, places: number): number =>
 
 // https://github.com/MikeMcl/bignumber.js/issues/11
 export const toBigNumber = (value: number | string) =>
-  new BigNumber(String(value).replace(/,/g, ''))
+  new BigNumber(String(value))


### PR DESCRIPTION
Fixes max button, a formatted string was passed instead of the actual balance.

This is a quick fix for now, but will add more defensive coding and tests for this.