### PR TITLE
Delete send recipients

### DIFF
--- a/app/components/Modals/SendModal/ConfirmDisplay.jsx
+++ b/app/components/Modals/SendModal/ConfirmDisplay.jsx
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react'
 import Button from '../../Button'
+import Delete from 'react-icons/lib/md/delete'
 
 import Table from '../../Table'
 import { Address } from '../../Blockchain'
@@ -13,6 +14,7 @@ type Props = {
   entries: Array<SendEntryType>,
   message: string,
   onAddRecipient: Function,
+  onDelete: Function,
   onConfirm: Function,
   onCancel: Function
 }
@@ -38,6 +40,7 @@ export default class ConfirmDisplay extends React.Component<Props, State> {
               <tr>
                 <th>Asset</th>
                 <th>Recipient</th>
+                <th>Actions</th>
               </tr>
             </thead>
             <tbody>
@@ -45,6 +48,9 @@ export default class ConfirmDisplay extends React.Component<Props, State> {
                 <tr key={`entry-${i}`}>
                   <td>{formatBalance(entry.symbol, entry.amount)} {entry.symbol}</td>
                   <td><Address address={entry.address} /></td>
+                  <td>
+                    <Delete className={styles.entryAction} onClick={this.handleDelete(entry)} />
+                  </td>
                 </tr>
               ))}
             </tbody>
@@ -73,5 +79,9 @@ export default class ConfirmDisplay extends React.Component<Props, State> {
         </div>
       </div>
     )
+  }
+
+  handleDelete = (entry: SendEntryType) => {
+    return () => this.props.onDelete(entry)
   }
 }

--- a/app/components/Modals/SendModal/ConfirmDisplay.scss
+++ b/app/components/Modals/SendModal/ConfirmDisplay.scss
@@ -26,6 +26,10 @@
         }
     }
 
+    .entryAction {
+        cursor: pointer;
+    }
+
     .addRecipient {
         margin-top: 10px;
         text-align: right;

--- a/app/components/Modals/SendModal/ConfirmDisplay.scss
+++ b/app/components/Modals/SendModal/ConfirmDisplay.scss
@@ -36,6 +36,7 @@
 
         a {
             color: $link-color;
+            cursor: pointer;
         }
     }
 }

--- a/app/components/Modals/SendModal/SendModal.jsx
+++ b/app/components/Modals/SendModal/SendModal.jsx
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from 'react'
-import { mapValues } from 'lodash'
+import { mapValues, without } from 'lodash'
 
 import BaseModal from '../BaseModal'
 import AddRecipientDisplay from './AddRecipientDisplay'
@@ -84,6 +84,7 @@ export default class SendModal extends Component<Props, State> {
           onConfirm={this.handleConfirmTransaction}
           onCancel={this.handleCancelTransaction}
           onAddRecipient={this.handleAddRecipient}
+          onDelete={this.handleDeleteEntry}
           {...this.state} />
       )
     }
@@ -91,6 +92,19 @@ export default class SendModal extends Component<Props, State> {
 
   handleAddRecipient = () => {
     this.setState({ display: DISPLAY_MODES.ADD_RECIPIENT })
+  }
+
+  handleDeleteEntry = (entry: SendEntryType) => {
+    const { balances } = this.state
+
+    const entries = without(this.state.entries, entry)
+    const newBalance = toBigNumber(balances[entry.symbol]).plus(entry.amount).toString()
+
+    this.setState({
+      entries,
+      balances: { ...balances, [entry.symbol]: newBalance },
+      display: entries.length > 0 ? DISPLAY_MODES.CONFIRM : DISPLAY_MODES.ADD_RECIPIENT
+    })
   }
 
   handleConfirmAddRecipient = (entry: SendEntryType) => {

--- a/app/components/Modals/SendModal/withAddressCheck.jsx
+++ b/app/components/Modals/SendModal/withAddressCheck.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react'
 import { api } from 'neon-js'
-import { uniq, pickBy } from 'lodash'
+import { uniq, pickBy, isEqual } from 'lodash'
 
 import Loader from '../../Loader'
 import asyncWrap from '../../../core/asyncHelper'
@@ -24,7 +24,13 @@ const withAddressCheck = () => (Component: React$ElementType) => {
     }
 
     componentDidMount () {
-      this.getAddresses().forEach(this.checkTransactionHistory)
+      this.checkTransactionHistories()
+    }
+
+    componentWillReceiveProps (nextProps: Props) {
+      if (!isEqual(this.props.entries, nextProps.entries)) {
+        this.setState({ addressHasActivity: {} }, this.checkTransactionHistories)
+      }
     }
 
     render = () => {
@@ -33,6 +39,10 @@ const withAddressCheck = () => (Component: React$ElementType) => {
       } else {
         return <Loader />
       }
+    }
+
+    checkTransactionHistories = () => {
+      this.getAddresses().forEach(this.checkTransactionHistory)
     }
 
     checkTransactionHistory = async (address: string) => {


### PR DESCRIPTION
![delete-send-entry](https://user-images.githubusercontent.com/169093/34642531-0a7b7198-f2da-11e7-8475-00b496ba3b51.gif)

**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
* Adds a delete icon for removing a recipient from the "Send" modal.
* Fixes the cursor for the "Add Recipient" link.

**How did you solve this problem?**
I added a trash can icon that, when clicked, removes the "send entry" from the array of entries tracked in the `SendModal` component state.  I also updated the balance that is tracked for the asset/token when an entry is deleted to ensure that the available amount accurately reflects what isn't accounted for by entries.

**How did you make sure your solution works?**
Smoke tested adding single/multiple entries, removing them, and validating that the available balance displayed in the modal (below the `NumberInput`) matches the expected amount.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?

  