### PR TITLE
Add RHT token (Redeemable HashPuppy Token)

### DIFF
--- a/__tests__/modules/wallet.test.js
+++ b/__tests__/modules/wallet.test.js
@@ -27,6 +27,11 @@ describe('wallet module tests', () => {
         balance: '0',
         scriptHash: 'ecc6b20d3ccac1ee9ef109af5a7cdb85706b1df9',
         symbol: 'RPX'
+      },
+      RHT: {
+        balance: '0',
+        scriptHash: '2328008e6f6c7bd157a342e789389eb034d9cbc4',
+        symbol: 'RHT'
       }
     },
     transactions: []

--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -74,6 +74,7 @@ export const TOKENS_TEST = {
 export const TOKENS = {
   DBC: 'b951ecbbc5fe37a9c280a76cb0ce0014827294cf',
   RPX: 'ecc6b20d3ccac1ee9ef109af5a7cdb85706b1df9',
+  RHT: '2328008e6f6c7bd157a342e789389eb034d9cbc4',
   QLC: '0d821bd7b6d53f5c2b40e217c6defc8bbe896cf5'
 }
 


### PR DESCRIPTION
DISCLAIMER:

I am not affiliated with RHT. I just happen to [discover it recently](https://steemit.com/cryptocurrency/@weppos/rht-token-redeemable-hashpuppy-token) and being a NEO user and developer, I was curious to see how complicated would be to add the token to the wallet.

Feel free to close/reject the PR if this is not in line with the current dev roadmap.

---

**What current issue(s) from Trello/Github does this address?**

No existing ticket.

**What problem does this PR solve?**

This PR adds the new RHT token. See https://neotracker.io/asset/2328008e6f6c7bd157a342e789389eb034d9cbc4

**How did you solve this problem?**

I added the token to the token list.

**How did you make sure your solution works?**

I tested it manually compiling the app. I also run the test suite with `yarn test`.

**Are there any special changes in the code that we should be aware of?**

Nope.

**Is there anything else we should know?**

- [x] Unit tests written?

**Notes**

I was not able to find a reliable test token. There are several tests in the TestNet (e.g. https://testnet.neotracker.io/asset/f9572c5b119a6b5775a6af07f1cef5d310038f55) but none of them seems to be the final one.

Therefore, I did not include the token in the TestNet list.

I also tried to find if there was any convention for tokens (e.g. alphabetically) but it looks like there wasn't. I added the token in alpha order compared to the existing entries.