### PR TITLE
Fixed transaction history verbosity

### DIFF
--- a/app/containers/TransactionHistory/Transactions.jsx
+++ b/app/containers/TransactionHistory/Transactions.jsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 
 import Transaction from '../../components/Blockchain/Transaction'
 import { ASSETS } from '../../core/constants'
+import { toBigNumber } from '../../core/math'
 import { formatBalance } from '../../core/formatters'
 
 import styles from './Transactions.scss'
@@ -11,6 +12,10 @@ import styles from './Transactions.scss'
 type Props = {
   className?: string,
   transactions: Array<Object>
+}
+
+const isZero = (amount) => {
+  return toBigNumber(amount).equals(0)
 }
 
 export default class Transactions extends React.Component<Props> {
@@ -34,7 +39,7 @@ export default class Transactions extends React.Component<Props> {
   }
 
   renderAmounts (tx: Object) {
-    const forceRenderNEO = tx[ASSETS.NEO] !== 0 || tx[ASSETS.GAS] === 0
+    const forceRenderNEO = !isZero(tx[ASSETS.NEO]) || isZero(tx[ASSETS.GAS])
 
     return (
       <div className={styles.amounts}>
@@ -47,7 +52,7 @@ export default class Transactions extends React.Component<Props> {
   renderAmount (tx: Object, symbol: SymbolType, forceRender: boolean = false) {
     const amount = tx[symbol]
 
-    if (forceRender || amount !== 0) {
+    if (forceRender || !isZero(amount)) {
       return (
         <div className={classNames(styles.amount, `amount${symbol}`)}>
           {formatBalance(symbol, amount)} {symbol}


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
The transaction history was unintentially very verbose for 0-asset transactions.  This was caused by a change to use BigNumber that wasn't accounted for in the transaction history component.

*Before:*
![screen shot 2018-01-10 at 8 46 49 am](https://user-images.githubusercontent.com/169093/34779997-80c59d00-f5e7-11e7-830f-ae327c8ef86e.png)

*After:*
![screen shot 2018-01-10 at 9 16 04 am](https://user-images.githubusercontent.com/169093/34780004-84d20d84-f5e7-11e7-9db4-6bc3c0bd911f.png)

**How did you solve this problem?**
I changed the equality check for numbers to use BigNumber's `equals` function instead of JS `===`.

**How did you make sure your solution works?**
Smoke tested (see attached before/after screenshots).

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?