### PR TITLE
 FIX: application gets in bad state if incorrect json filed is used when restoring wallet

### DIFF
--- a/app/containers/Settings/Settings.jsx
+++ b/app/containers/Settings/Settings.jsx
@@ -128,7 +128,7 @@ export default class Settings extends Component<Props, State> {
       onClick: () => {
         storage.get('userWallet', (readError, data) => {
           if (readError) {
-            showErrorNotification({ message: `An error occurred reading previosly stored wallet: ${readError.message}` })
+            showErrorNotification({ message: `An error occurred reading previously stored wallet: ${readError.message}` })
           }
 
           data.accounts = reject(data.accounts, { key })

--- a/app/core/schemas.js
+++ b/app/core/schemas.js
@@ -1,0 +1,19 @@
+// @flow
+export const Account = (account: Object) => {
+  const {
+    address,
+    label,
+    isDefault,
+    key
+  } = account
+
+  return {
+    address,
+    label,
+    isDefault: isDefault || false,
+    lock: false,
+    key,
+    contract: {},
+    extra: null
+  }
+}

--- a/app/modules/generateWallet.js
+++ b/app/modules/generateWallet.js
@@ -112,9 +112,7 @@ export const upgradeUserWalletNEP6 = (): Promise<*> => {
 }
 
 export const walletHasKey = (wallet: Object, key: string) =>
-  wallet.accounts.some(account => {
-    return account.key === key
-  })
+  wallet.accounts.some(account => account.key === key)
 
 export const recoverWallet = (wallet: Object): Promise<*> => {
   return new Promise((resolve, reject) => {

--- a/app/modules/generateWallet.js
+++ b/app/modules/generateWallet.js
@@ -7,6 +7,7 @@ import { showErrorNotification, showInfoNotification, hideNotification, showSucc
 
 import { validatePassphraseLength } from '../core/wallet'
 import { ROUTES, DEFAULT_WALLET } from '../core/constants'
+import { Account } from '../core/schemas'
 
 // Constants
 export const NEW_WALLET_ACCOUNT = 'NEW_WALLET_ACCOUNT'
@@ -35,15 +36,11 @@ export function resetKey () {
 export const saveAccount = (label: string, address: string, key: string) => (dispatch: DispatchType) => {
   if (!label || !address || !key) { return null }
 
-  const newAccount = {
-    address: address,
-    label: label,
-    isDefault: false,
-    lock: false,
-    key: key,
-    contract: {},
-    extra: null
-  }
+  const newAccount = new Account({
+    address,
+    label,
+    key
+  })
 
   return storage.get('userWallet', (readError, data) => {
     if (readError) {
@@ -61,15 +58,13 @@ export const saveAccount = (label: string, address: string, key: string) => (dis
 }
 
 export const convertOldWalletAccount = (label: string, key: string, isDefault: boolean) => {
-  return {
+  if (!key || typeof key !== 'string') return
+  return new Account({
     address: '', // Unfortunately all we have is the encrypted private keys, so no way to get this for now.
-    label: label,
-    isDefault: isDefault, // Make the first account the default
-    lock: false,
-    key: key,
-    contract: {},
-    extra: null
-  }
+    label,
+    isDefault, // Make the first account the default
+    key
+  })
 }
 
 export const upgradeUserWalletNEP6 = (): Promise<*> => {
@@ -92,7 +87,10 @@ export const upgradeUserWalletNEP6 = (): Promise<*> => {
           } else {
             const accounts = []
             Object.keys(keyData).map((label: string) => {
-              accounts.push(convertOldWalletAccount(label, keyData[label], accounts.length === 0))
+              const newAccount = convertOldWalletAccount(label, keyData[label], accounts.length === 0)
+              if (newAccount) {
+                accounts.push(newAccount)
+              }
             })
 
             wallet.accounts = accounts
@@ -114,7 +112,9 @@ export const upgradeUserWalletNEP6 = (): Promise<*> => {
 }
 
 export const walletHasKey = (wallet: Object, key: string) =>
-  wallet.accounts.some(account => account.key === key)
+  wallet.accounts.some(account => {
+    return account.key === key
+  })
 
 export const recoverWallet = (wallet: Object): Promise<*> => {
   return new Promise((resolve, reject) => {
@@ -134,7 +134,10 @@ export const recoverWallet = (wallet: Object): Promise<*> => {
         // Load the old wallet type
         Object.keys(wallet).map((label: string) => {
           const isDefault = accounts.length === 0 && wallet.length === 0
-          accounts.push(convertOldWalletAccount(label, wallet[label], isDefault))
+          const newAccount = convertOldWalletAccount(label, wallet[label], isDefault)
+          if (newAccount && newAccount.key) {
+            accounts.push(newAccount)
+          }
         })
       } else {
         accounts = wallet.accounts
@@ -145,7 +148,7 @@ export const recoverWallet = (wallet: Object): Promise<*> => {
       }
 
       accounts.some((account) => {
-        if (!walletHasKey(data, account.key)) {
+        if (account.key && !walletHasKey(data, account.key)) {
           data.accounts.push(account)
         }
       })


### PR DESCRIPTION
… recovery method

**What current issue(s) from Trello/Github does this address?**
Does not fix any open issues

**What problem does this PR solve?**
Application gets in an unusable state if an invalid JSON file is imported into wallet recovery in the Settings page. The code is assuming a String type for the account keys and does not handle some other types.

**How did you solve this problem?**
A basic schema approach to new accounts which checks for a valid type when setting keys. Instead of the current approach which accepts the import and then crashes on an Array.slice method if an incorrect type appears in the account.key it only accepts string key types and uses the Constructor to generate a new account object which has all of the relevant properties either passed through or defaults are set

**How did you make sure your solution works?**
Tested importing various JSON files that were not Neon wallet files. A good test example is just the project's package.json file

**Are there any special changes in the code that we should be aware of?**
No special changes.

**Is there anything else we should know?**
I will look into validating the file import at a later stage and verifying file is of correct format and adding notices if file is incorrect if this is desired. For now this just prevents a crash

Fixed small typo in notification Settings.jsx

- [ ] Unit tests written?
TBC