### PR TITLE
Replace parseFloat calls with BigNumber

### DIFF
--- a/app/core/math.js
+++ b/app/core/math.js
@@ -9,7 +9,7 @@ export const truncateNumber = (num: number, places: number): number =>
 export const toBigNumber = (value: number | string) =>
   new BigNumber(String(value))
 
-export const toNumber = (value: string) =>
+export const toNumber = (value: string | number) =>
   toBigNumber(value).toNumber()
 
 export const isZero = (amount: string | number) =>

--- a/app/core/wallet.js
+++ b/app/core/wallet.js
@@ -1,6 +1,8 @@
 // @flow
-import { ASSETS } from './constants'
 import { wallet } from 'neon-js'
+
+import { ASSETS } from './constants'
+import { toBigNumber } from './math'
 
 const MIN_PASSPHRASE_LEN = 4
 
@@ -37,15 +39,15 @@ export const validateTransactionBeforeSending = (balance: number, sendEntry: Sen
     return 'The address you entered was not valid.'
   }
 
-  if (symbol === ASSETS.NEO && parseFloat(amount) !== parseInt(amount)) { // check for fractional NEO
+  if (symbol === ASSETS.NEO && !toBigNumber(amount).isInteger()) { // check for fractional NEO
     return 'You cannot send fractional amounts of NEO.'
   }
 
-  if (parseFloat(amount) > balance) {
+  if (toBigNumber(amount).gt(balance)) {
     return `You do not have enough ${symbol} to send.`
   }
 
-  if (parseFloat(amount) <= 0) { // check for negative/zero asset
+  if (toBigNumber(amount).lte(0)) { // check for negative/zero asset
     return 'You cannot send zero or negative amounts of an asset.'
   }
 

--- a/app/modules/sale.js
+++ b/app/modules/sale.js
@@ -5,22 +5,23 @@ import { showErrorNotification, showInfoNotification, showSuccessNotification } 
 import { getWIF, LOGOUT } from './account'
 import { getNetwork } from './metadata'
 import { getNEO } from './wallet'
+import { toBigNumber, toNumber } from '../core/math'
 import asyncWrap from '../core/asyncHelper'
 
 // TODO: Rewrite this function
 
-export const participateInSale = (neoToSend: number, scriptHash: string) => async (dispatch: DispatchType, getState: GetStateType) => {
+export const participateInSale = (neoToSend: string, scriptHash: string) => async (dispatch: DispatchType, getState: GetStateType) => {
   const state = getState()
   const wif = getWIF(state)
   const NEO = getNEO(state)
   const net = getNetwork(state)
 
   const account = new wallet.Account(wif)
-  if (parseFloat(neoToSend) !== parseInt(neoToSend)) {
+  if (!toBigNumber(neoToSend).isInteger()) {
     dispatch(showErrorNotification({ message: 'You cannot send fractional NEO to a token sale.' }))
     return false
   }
-  const toMint = parseInt(neoToSend)
+  const toMint = toNumber(neoToSend)
   // $FlowFixMe
   if (toMint > NEO) {
     dispatch(showErrorNotification({ message: 'You do not have enough NEO to send.' }))


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
It replaces several remaining `parseFloat` calls to ensure we use BigNumber instead.

**How did you solve this problem?**
I reused our existing `toBigNumber` and `toNumber` calls.

**How did you make sure your solution works?**
I ran the test suite and sent transactions.  I did not test the sale changes since this is dependent on #528.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?