### PR TITLE
Fixed token filtering & asset input bug in token sale modal

### DIFF
--- a/__tests__/components/Inputs/AddressInput/__snapshots__/AddressInput.test.js.snap
+++ b/__tests__/components/Inputs/AddressInput/__snapshots__/AddressInput.test.js.snap
@@ -4,6 +4,7 @@ exports[`AddressInput should render without crashing 1`] = `
 <SelectInput
   className="addressInput"
   getItemValue={[Function]}
+  getSearchResults={[Function]}
   items={
     Array [
       Object {

--- a/app/components/Inputs/AddressInput/AddressInput.jsx
+++ b/app/components/Inputs/AddressInput/AddressInput.jsx
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react'
+import Sifter from 'sifter'
 import Delete from 'react-icons/lib/md/delete'
 import { wallet } from 'neon-js'
 import { noop, omit, map, values, trim } from 'lodash'
@@ -47,7 +48,8 @@ export default class AddressInput extends React.Component<Props> {
         items={this.getItems()}
         renderAfter={this.renderAfter}
         renderItem={this.renderItem}
-        getItemValue={this.getItemValue} />
+        getItemValue={this.getItemValue}
+        getSearchResults={this.getSearchResults} />
     )
   }
 
@@ -95,7 +97,7 @@ export default class AddressInput extends React.Component<Props> {
     }
   }
 
-  getItems = () => {
+  getItems = (): Array<ItemType> => {
     const { addresses } = this.props
     if (!addresses) {
       return []
@@ -106,11 +108,20 @@ export default class AddressInput extends React.Component<Props> {
     }))
   }
 
-  getItemValue = (item: ItemType) => {
+  getItemValue = (item: ItemType): string => {
     return item.value
   }
 
-  canSave = () => {
+  getSearchResults = (items: Array<ItemType>, term: string): Array<ItemType> => {
+    const sifter = new Sifter(items)
+    const result = sifter.search(term, {
+      fields: ['label', 'value'],
+      sort: [{ field: 'label', direction: 'asc' }]
+    })
+    return result.items.map((resultItem) => items[resultItem.id])
+  }
+
+  canSave = (): boolean => {
     const address = this.props.value
     const { addresses } = this.props
 

--- a/app/components/Inputs/AssetInput/AssetInput.jsx
+++ b/app/components/Inputs/AssetInput/AssetInput.jsx
@@ -1,25 +1,78 @@
 // @flow
 import React from 'react'
 import classNames from 'classnames'
-import { omit } from 'lodash'
+import { omit, noop } from 'lodash'
 
 import SelectInput from '../SelectInput'
 import styles from './AssetInput.scss'
 
 type Props = {
   className?: string,
-  symbols: Array<SymbolType>
+  value?: string,
+  symbols: Array<SymbolType>,
+  onChange: Function,
+  onFocus: Function,
+  onBlur: Function
 }
 
-export default class AssetInput extends React.Component<Props> {
+type State = {
+  typingValue: string
+}
+
+export default class AssetInput extends React.Component<Props, State> {
+  static defaultProps = {
+    onChange: noop,
+    onFocus: noop,
+    onBlur: noop
+  }
+
+  state = {
+    typingValue: this.props.value || ''
+  }
+
   render = () => {
     const passDownProps = omit(this.props, 'symbols')
+    const { typingValue } = this.state
 
     return (
       <SelectInput
         {...passDownProps}
+        value={typingValue}
         className={classNames(styles.assetInput, this.props.className)}
-        items={this.props.symbols} />
+        items={this.props.symbols}
+        onChange={this.handleChange}
+        onFocus={this.handleFocus}
+        onBlur={this.handleBlur} />
     )
+  }
+
+  handleChange = (value: string) => {
+    const { symbols, onChange } = this.props
+
+    this.setState({ typingValue: value }, () => {
+      if (symbols.includes(value)) {
+        onChange(value)
+      }
+    })
+  }
+
+  handleFocus = (event: Object) => {
+    const { value, onFocus } = this.props
+
+    this.setState({ typingValue: value })
+    event.persist()
+    onFocus()
+  }
+
+  handleBlur = (event: Object) => {
+    const { symbols, value, onBlur } = this.props
+    const { typingValue } = this.state
+
+    if (!symbols.includes(typingValue)) {
+      this.setState({ typingValue: value })
+    }
+
+    event.persist()
+    onBlur(event)
   }
 }


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
This fixes two issues in the token sale modal:

1. Typing into the token `SelectInput` did not filter token symbols as expected.
2. Pressing the backspace key in the `AssetInput` caused a JS error that made the page reload.

**How did you solve this problem?**
For the first problem, I fixed the `SelectInput` search to accept a custom `getSearchResults` prop that can search against `items` of any shape.  It was hardcoded to work against arrays of objects, but not arrays of strings.

For the second problem, I made the `AssetInput` maintain a search string in its component state, which gets reset on blur.  The `onChange` prop is only called if a valid asset it selected, rather than being called for any text change.

**How did you make sure your solution works?**
Smoke tested.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
