### PR TITLE
Allow NEP5 transfer to use the SC decimals

### DIFF
--- a/app/core/nep5.js
+++ b/app/core/nep5.js
@@ -1,6 +1,5 @@
 // @flow
-import { COIN_DECIMAL_LENGTH } from './formatters'
 import { toBigNumber } from './math'
 
-export const adjustDecimalAmountForTokenTransfer = (value: string): string =>
-  toBigNumber(value).times(10 ** COIN_DECIMAL_LENGTH).round().toNumber()
+export const adjustDecimalAmountForTokenTransfer = (value: string, decimals: number): string =>
+  toBigNumber(value).times(10 ** decimals).round().toNumber()

--- a/app/modules/transactions.js
+++ b/app/modules/transactions.js
@@ -119,11 +119,11 @@ const buildTransferScript = (
 
   tokenEntries.forEach(({ address, amount, symbol }) => {
     const toAcct = new wallet.Account(address)
-    const scriptHash = tokensBalanceMap[symbol].scriptHash
+    const { scriptHash, decimals } = tokensBalanceMap[symbol]
     const args = [
       u.reverseHex(fromAcct.scriptHash),
       u.reverseHex(toAcct.scriptHash),
-      adjustDecimalAmountForTokenTransfer(amount)
+      adjustDecimalAmountForTokenTransfer(amount, decimals)
     ]
 
     scriptBuilder.emitAppCall(scriptHash, 'transfer', args)


### PR DESCRIPTION
This small fix allows the NEP5 transfer to use the decimals supplied by the SC.