### PR TITLE
Fixed claimable GAS calculation

### DIFF
--- a/app/modules/claim.js
+++ b/app/modules/claim.js
@@ -20,7 +20,8 @@ import asyncWrap from '../core/asyncHelper'
 import { FIVE_MINUTES_MS } from '../core/time'
 
 import { log } from '../util/Logs'
-import { toNumber } from '../core/math'
+import { toBigNumber, toNumber } from '../core/math'
+import { COIN_DECIMAL_LENGTH } from '../core/formatters'
 
 // Constants
 export const SET_CLAIM = 'SET_CLAIM'
@@ -210,7 +211,7 @@ export default (state: Object = initialState, action: ReduxAction) => {
       }
       return {
         ...state,
-        claimAmount: (claimAvailable + claimUnavailable) / 100000000,
+        claimAmount: toBigNumber(claimAvailable + claimUnavailable).div(10 ** COIN_DECIMAL_LENGTH).toNumber(),
         claimAvailable,
         claimUnavailable,
         claimWasUpdated


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
#522 (among others)

**What problem does this PR solve?**
Calculating claimable GAS can be off due to bad floating point math.

**How did you solve this problem?**
I replaced floating points with bignumber.js math.

**How did you make sure your solution works?**
Although this calculation is used for display only, I verified that claiming still works as expected.

I observed the redux store to ensure the calculation is correct.  I also claimed to ensure it works as expected.  (See screenshot below.)  The transaction in the blockchain confirms the correct amount was claimed: http://testnet.neoverse.io/transactions/1a7874a8158eaa84d4cb1180d4196e6d0c5ef450525358e0daa65bf745478f1b

![screen shot 2018-01-25 at 11 26 45 pm](https://user-images.githubusercontent.com/169093/35426343-ecff5348-0227-11e8-99a4-f76d8ca3166d.png)

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
