### PR TITLE
Fixed refreshing dashboard data

### DIFF
--- a/app/containers/Dashboard/Dashboard.jsx
+++ b/app/containers/Dashboard/Dashboard.jsx
@@ -22,7 +22,6 @@ type Props = {
   NEO: string,
   GAS: string,
   tokenBalances: Array<TokenBalanceType>,
-  networkId: string,
   loadWalletData: Function,
 }
 
@@ -32,21 +31,18 @@ export default class Dashboard extends Component<Props> {
   walletDataInterval: ?number
 
   componentDidMount () {
-    const { loadWalletData, net, address } = this.props
-
-    log(net, 'LOGIN', address) // only logging public information here
-    this.walletDataInterval = setInterval(loadWalletData, REFRESH_INTERVAL_MS)
+    log(this.props.net, 'LOGIN', this.props.address) // only logging public information here
+    this.addPolling()
   }
 
   componentWillUnmount () {
-    if (this.walletDataInterval) {
-      clearInterval(this.walletDataInterval)
-    }
+    this.removePolling()
   }
 
   componentWillReceiveProps (nextProps: Props) {
-    if (this.props.networkId !== nextProps.networkId) {
-      this.props.loadWalletData()
+    if (this.props.loadWalletData !== nextProps.loadWalletData) {
+      this.removePolling()
+      this.addPolling()
     }
   }
 
@@ -100,5 +96,15 @@ export default class Dashboard extends Component<Props> {
         </div>
       </div>
     )
+  }
+
+  addPolling = () => {
+    this.walletDataInterval = setInterval(this.props.loadWalletData, REFRESH_INTERVAL_MS)
+  }
+
+  removePolling = () => {
+    if (this.walletDataInterval) {
+      clearInterval(this.walletDataInterval)
+    }
   }
 }


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
With some recent changes I made to introduce new redux architecture, I accidentally broke the polling/refreshing on the dashboard when the user switches networks.  The polling function was fetching based upon an old network because the interval was not properly being cleared before setting a new one.

**How did you solve this problem?**
I checked to see if the function used for polling changed, and if it does, then clear the old poll before creating a new one.

**How did you make sure your solution works?**
Smoke tested.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
