### PR TITLE
Added error handling when an invalid token scriptHash is entered

### DIFF
--- a/app/actions/balancesActions.js
+++ b/app/actions/balancesActions.js
@@ -21,11 +21,17 @@ async function getBalances ({ net, address, tokens }: Props) {
   // token balances
   const promises = tokens.map(async (token) => {
     const { scriptHash } = token
-    const response = await api.nep5.getToken(endpoint, scriptHash, address)
-    const balance = toBigNumber(response.balance || 0).round(response.decimals).toString()
 
-    return {
-      [scriptHash]: { ...response, balance }
+    try {
+      const response = await api.nep5.getToken(endpoint, scriptHash, address)
+      const balance = toBigNumber(response.balance || 0).round(response.decimals).toString()
+
+      return {
+        [scriptHash]: { ...response, balance }
+      }
+    } catch (err) {
+      // invalid scriptHash
+      return {}
     }
   })
 


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
This fixes an issue where, if the user enters an invalid NEP-5 scriptHash in their settings, it gracefully loads the valid tokens without dying on the invalid ones.

**How did you solve this problem?**
I added a simply try/catch around the problematic code, allowing the valid responses to be returned and provided to the front-end wherever needed (e.g.: on the dashboard).

**How did you make sure your solution works?**
I smoke tested it with valid & invalid scriptHash values.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
