### PR TITLE
Fixed passing token balances to send modal

### DIFF
--- a/app/components/Modals/SendModal/SendModal.jsx
+++ b/app/components/Modals/SendModal/SendModal.jsx
@@ -21,7 +21,7 @@ const DISPLAY_MODES = {
 type Props = {
   NEO: string,
   GAS: string,
-  tokenBalances: Array<TokenBalanceType>,
+  tokenBalances: { [key: string]: TokenBalanceType },
   showErrorNotification: Function,
   hideModal: Function,
   sendTransaction: Function,
@@ -30,7 +30,7 @@ type Props = {
 }
 
 type BalancesType = {
-  [key: SymbolType]: any
+  [key: SymbolType]: string
 }
 
 type State = {

--- a/app/containers/Dashboard/index.js
+++ b/app/containers/Dashboard/index.js
@@ -26,7 +26,7 @@ const mapStateToProps: MapStateToProps<*, *, *> = (state: Object) => ({
   notification: getNotifications(state)
 })
 
-const mapBalanceDataToProps = (balances) => ({
+const mapAccountDataToProps = ({ balances }) => ({
   NEO: balances.NEO,
   GAS: balances.GAS,
   tokenBalances: omit(balances, 'NEO', 'GAS')
@@ -54,7 +54,7 @@ export default compose(
   }, {
     strategy: alreadyLoaded
   }),
-  withData(accountActions, mapBalanceDataToProps),
+  withData(accountActions, mapAccountDataToProps),
   withReload(accountActions, ['networkId']),
   withActions(accountActions, mapAccountActionsToProps)
 )(Dashboard)

--- a/app/core/wallet.js
+++ b/app/core/wallet.js
@@ -1,6 +1,6 @@
 // @flow
 import { wallet } from 'neon-js'
-import { extend } from 'lodash'
+import { map, extend } from 'lodash'
 
 import { ASSETS } from './constants'
 import { toBigNumber } from './math'
@@ -17,12 +17,12 @@ export const obtainBalance = (balances: Object, symbol: SymbolType) => {
   return balances[symbol] || 0
 }
 
-export const getTokenBalancesMap = (tokenBalances: Array<TokenBalanceType>) => {
-  return extend({}, ...tokenBalances.map(({ symbol, balance }) => ({ [symbol]: balance })))
+export const getTokenBalancesMap = (tokenBalances: { [key: string]: TokenBalanceType }) => {
+  return extend({}, ...map(tokenBalances, ({ symbol, balance }) => ({ [symbol]: balance })))
 }
 
 export const validateTransactionBeforeSending = (
-  balance: number,
+  balance: number | string,
   sendEntry: SendEntryType
 ) => {
   const { address, amount, symbol } = sendEntry


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
This fixes a bug that I created when I introduced the accountActions as a batch action wrapper for balancesActions (among others).  When I replaced passing balance data into the component with account data, I failed to update the method signature to accept the new arguments.

**How did you solve this problem?**
I fixed the way arguments are received with regards to the balance data coming from that accountActions.

**How did you make sure your solution works?**
I smoke tested opening and using the send modal while inspecting the data being passed in.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
