### PR TITLE
Fixed signing function assignment for ledger login

### DIFF
--- a/app/actions/authActions.js
+++ b/app/actions/authActions.js
@@ -5,6 +5,7 @@ import { noop } from 'lodash'
 import createRequestActions from '../util/api/createRequestActions'
 import { upgradeNEP6AddAddresses } from '../core/account'
 import { validatePassphraseLength } from '../core/wallet'
+import { ledgerNanoSCreateSignatureAsync } from '../ledger/ledgerNanoS'
 
 type WifLoginProps = {
   wif: string
@@ -53,11 +54,11 @@ export const nep2LoginActions = createRequestActions(ID, ({ passphrase, encrypte
   return { wif, address: account.address, isHardwareLogin: false }
 })
 
-export const ledgerLoginActions = createRequestActions(ID, ({ publicKey, signingFunction }: LedgerLoginProps) => (state: Object): AccountType => {
+export const ledgerLoginActions = createRequestActions(ID, ({ publicKey }: LedgerLoginProps) => (state: Object): AccountType => {
   const publicKeyEncoded = wallet.getPublicKeyEncoded(publicKey)
   const account = new wallet.Account(publicKeyEncoded)
 
-  return { address: account.address, publicKey, signingFunction, isHardwareLogin: true }
+  return { publicKey, address: account.address, signingFunction: ledgerNanoSCreateSignatureAsync, isHardwareLogin: true }
 })
 
 export const logoutActions = createRequestActions(ID, () => (state: Object): AccountType => {


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
When I refactored the login actions, I neglected to set the signing function for ledger logins.  I wasn't able to test this since I don't have a ledger yet, but I happened to notice that it has no way of being set since it's not being passed in as an argument.  This should fix it.

**How did you solve this problem?**
I set the signing function to the function defined in the ledger module, which matches the way `master` branch sets the signing function.

**How did you make sure your solution works?**
I can't since I don't have a ledger.  Ledger login may be broken regardless of this change, someone needs to test it out on the `dev` branch.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
