### PR TITLE
Added NEO/GAS price chart to dashboard

### DIFF
--- a/app/actions/appActions.js
+++ b/app/actions/appActions.js
@@ -3,6 +3,7 @@ import createBatchActions from '../util/api/createBatchActions'
 import accountsActions from './accountsActions'
 import blockHeightActions from './blockHeightActions'
 import pricesActions from './pricesActions'
+import priceHistoryActions from './priceHistoryActions'
 import settingsActions from './settingsActions'
 
 export const ID = 'APP'
@@ -11,5 +12,6 @@ export default createBatchActions(ID, {
   accounts: accountsActions,
   blockHeight: blockHeightActions,
   prices: pricesActions,
+  priceHistory: priceHistoryActions,
   settings: settingsActions
 })

--- a/app/actions/priceHistoryActions.js
+++ b/app/actions/priceHistoryActions.js
@@ -1,0 +1,49 @@
+// @flow
+import axios from 'axios'
+import { toUpper } from 'lodash'
+
+import createRequestActions from '../util/api/createRequestActions'
+import { ASSETS, DEFAULT_CURRENCY_CODE } from '../core/constants'
+
+type Duration = '1m' | '1w' | '1d'
+
+type Props = {
+  currency?: string,
+  duration: Duration
+}
+
+export const ID = 'PRICE_HISTORY'
+
+const createFetch = (symbol: SymbolType, currency: string, call: string, options: Object) => {
+  return axios.get(`https://min-api.cryptocompare.com/data/${call}`, {
+    params: {
+      ...options,
+      fsym: toUpper(symbol),
+      tsym: toUpper(currency)
+    }
+  })
+}
+
+const fetchPriceHistory = (symbol: SymbolType, currency: string, duration: Duration): Promise<Object> => {
+  switch (duration) {
+    case '1d':
+      return createFetch(symbol, currency, 'histohour', { limit: 24 })
+    case '1w':
+      return createFetch(symbol, currency, 'histohour', { limit: 168 })
+    case '1m':
+    default:
+      return createFetch(symbol, currency, 'histoday', { limit: 30 })
+  }
+}
+
+export default createRequestActions(ID, ({ currency = DEFAULT_CURRENCY_CODE, duration = '1m' }: Props = {}) => async (state: Object) => {
+  const [neo, gas] = await Promise.all([
+    fetchPriceHistory(ASSETS.NEO, currency, duration),
+    fetchPriceHistory(ASSETS.GAS, currency, duration)
+  ])
+
+  return {
+    [ASSETS.NEO]: neo.data.Data,
+    [ASSETS.GAS]: gas.data.Data
+  }
+})

--- a/app/components/Dashboard/PriceHistoryPanel/AxisLabel.jsx
+++ b/app/components/Dashboard/PriceHistoryPanel/AxisLabel.jsx
@@ -1,0 +1,25 @@
+// @flow
+import React from 'react'
+
+type Options = {
+  axisType: 'x' | 'y',
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  stroke: ?string,
+  children: ?(React$Node | string)
+}
+
+export default function AxisLabel ({ axisType, x, y, width, height, stroke, children }: Options) {
+  const isVertical = axisType === 'y'
+  const cx = isVertical ? x : x + (width / 2)
+  const cy = isVertical ? (height / 2) + y : y + height + 10
+  const rotation = isVertical ? `270 ${cx} ${cy}` : 0
+
+  return (
+    <text x={cx} y={cy} transform={`rotate(${rotation})`} textAnchor='middle' stroke={stroke}>
+      {children}
+    </text>
+  )
+}

--- a/app/components/Dashboard/PriceHistoryPanel/BoundingBox.jsx
+++ b/app/components/Dashboard/PriceHistoryPanel/BoundingBox.jsx
@@ -1,0 +1,132 @@
+// @flow
+import React from 'react'
+import classNames from 'classnames'
+import { isEqual } from 'lodash'
+
+import styles from './BoundingBox.scss'
+
+type SVGRect = {
+  x: number,
+  y: number,
+  width: number,
+  height: number
+}
+
+type SVGLocatable = {
+  getBBox(): SVGRect
+}
+
+type Props = {
+  className?: string,
+  children: React$Node,
+  paddingX: number,
+  paddingY: number,
+  roundedX: number,
+  roundedY: number
+}
+
+type State = {
+  position: ?SVGRect
+}
+
+export default class BoundingBox extends React.Component<Props, State> {
+  // HACK: Any recharts chart will only render pure SVG elements and child elements that have a
+  //       recognized displayName.  Since this element renders an SVG element, we'll make its
+  //       displayName recognized to recharts to force it to render.
+  static displayName = 'ReferenceArea'
+
+  static defaultProps = {
+    paddingX: 0,
+    paddingY: 0,
+    roundedX: 0,
+    roundedY: 0
+  }
+
+  group: ?Node
+
+  state = {
+    position: null
+  }
+
+  componentDidMount () {
+    this.updateBoundingBox()
+  }
+
+  componentDidUpdate (prevProps: Props) {
+    this.updateBoundingBox()
+  }
+
+  render () {
+    return (
+      <g ref={this.registerRef('group')} className={styles.boundingBoxGroup}>
+        {this.renderBoundingBox()}
+        {this.props.children}
+      </g>
+    )
+  }
+
+  renderBoundingBox () {
+    const { position } = this.state
+    const { roundedX, roundedY } = this.props
+
+    if (position) {
+      return (
+        <rect
+          ref={this.registerRef('box')}
+          className={classNames(styles.boundingBox, this.props.className)}
+          rx={roundedX}
+          ry={roundedY}
+          x={position.x}
+          y={position.y}
+          width={position.width}
+          height={position.height} />
+      )
+    }
+  }
+
+  registerRef = (name: string) => {
+    // $FlowFixMe
+    return (el: Node) => { this[name] = el }
+  }
+
+  updateBoundingBox = () => {
+    const position = this.calculateBoundingBox()
+
+    if (position && !isEqual(position, this.state.position)) {
+      this.setState({ position })
+    }
+  }
+
+  calculateBoundingBox = (): ?SVGRect => {
+    const nodes = this.group ? [...this.group.childNodes] : []
+    if (nodes.length === 0) return
+
+    // $FlowFixMe
+    const getBoundingBox = (el: SVGLocatable): SVGRect => el.getBBox()
+
+    // $FlowFixMe
+    const position = nodes.reduce((result: SVGRect, current: SVGLocatable): SVGRect => {
+      if (current === this.box) return result
+
+      const box = getBoundingBox(current)
+      const newX = Math.min(result.x, box.x)
+      const newY = Math.min(result.y, box.y)
+
+      return {
+        x: newX,
+        y: newY,
+        width: newX + Math.max(result.x + result.width, box.x + box.width),
+        height: newY + Math.max(result.y + result.height, box.y + box.height)
+      }
+    }, getBoundingBox(nodes.pop()))
+
+    const { paddingX, paddingY } = this.props
+
+    return {
+      x: position.x - paddingX,
+      y: position.y - paddingY,
+      width: position.width + (paddingX * 2),
+      height: position.height + (paddingY * 2)
+    }
+  }
+}

--- a/app/components/Dashboard/PriceHistoryPanel/BoundingBox.scss
+++ b/app/components/Dashboard/PriceHistoryPanel/BoundingBox.scss
@@ -1,0 +1,3 @@
+.boundingBoxGroup {
+  // TODO
+}

--- a/app/components/Dashboard/PriceHistoryPanel/PriceHistoryChart.jsx
+++ b/app/components/Dashboard/PriceHistoryPanel/PriceHistoryChart.jsx
@@ -5,7 +5,7 @@ import { ResponsiveContainer, LineChart, Line, CartesianGrid, XAxis, YAxis, Tool
 
 import AxisLabel from './AxisLabel'
 import BoundingBox from './BoundingBox'
-import { formatFiat } from '../../../core/formatters'
+import { formatFiat, formatThousands } from '../../../core/formatters'
 import { CURRENCIES } from '../../../core/constants'
 
 import styles from './PriceHistoryChart.scss'
@@ -79,7 +79,7 @@ export default class PriceHistoryChart extends React.Component<Props> {
   renderLatestPrice = () => {
     return (
       <text className={styles.current} x='50%' y={0} textAnchor='middle' alignmentBaseline='hanging' fill='#282828'>
-        {this.renderPrice(this.getLatestPrice())}
+        {this.renderPrice(this.getLatestPrice(), formatFiat)}
       </text>
     )
   }
@@ -111,9 +111,9 @@ export default class PriceHistoryChart extends React.Component<Props> {
     return `${date.getMonth() + 1}/${date.getDate()}`
   }
 
-  renderPrice = (price: number): string => {
+  renderPrice = (price: number, formatter: Function = formatThousands): string => {
     const { symbol } = CURRENCIES[this.props.currency]
-    return `${symbol}${formatFiat(price)}`
+    return `${symbol}${formatter(price)}`
   }
 
   handleFormatValue = (value: number): string => {

--- a/app/components/Dashboard/PriceHistoryPanel/PriceHistoryChart.jsx
+++ b/app/components/Dashboard/PriceHistoryPanel/PriceHistoryChart.jsx
@@ -25,13 +25,19 @@ type Props = {
   prices: Array<Price>,
   currency: string,
   timeKey: string,
-  priceKey: string
+  priceKey: string,
+  formatDate(Date): string
+}
+
+const formatDate = (date: Date): string => {
+  return date.toLocaleString('en-US', { month: 'numeric', day: 'numeric' })
 }
 
 export default class PriceHistoryChart extends React.Component<Props> {
   static defaultProps = {
     timeKey: 'time',
-    priceKey: 'close'
+    priceKey: 'close',
+    formatDate
   }
 
   render = (): React$Node => {
@@ -46,21 +52,21 @@ export default class PriceHistoryChart extends React.Component<Props> {
             interval='preserveStartEnd'
             stroke='#9ca0a8'
             tickLine={false}
-            tickFormatter={this.renderDate}
+            tickFormatter={this.formatDate}
             tickMargin={24}
             minTickGap={50} />
           <YAxis
             stroke='#9ca0a8'
             axisLine={false}
             tickLine={false}
-            tickFormatter={this.renderPrice}
+            tickFormatter={this.formatPrice}
             tickMargin={20}
             domain={['auto', 'auto']} />
           <CartesianGrid
             stroke='#e6e6e6' />
           <Tooltip
-            formatter={this.handleFormatValue}
-            labelFormatter={this.handleFormatLabel} />
+            formatter={this.formatValue}
+            labelFormatter={this.formatLabel} />
           <Line
             dataKey={priceKey}
             type='monotone'
@@ -79,7 +85,7 @@ export default class PriceHistoryChart extends React.Component<Props> {
   renderLatestPrice = () => {
     return (
       <text className={styles.current} x='50%' y={0} textAnchor='middle' alignmentBaseline='hanging' fill='#282828'>
-        {this.renderPrice(this.getLatestPrice(), formatFiat)}
+        {this.formatPrice(this.getLatestPrice(), formatFiat)}
       </text>
     )
   }
@@ -106,21 +112,11 @@ export default class PriceHistoryChart extends React.Component<Props> {
     )
   }
 
-  renderDate = (timestamp: number): string => {
-    const date = new Date(timestamp * 1000)
-    return `${date.getMonth() + 1}/${date.getDate()}`
-  }
-
-  renderPrice = (price: number, formatter: Function = formatThousands): string => {
-    const { symbol } = CURRENCIES[this.props.currency]
-    return `${symbol}${formatter(price)}`
-  }
-
-  handleFormatValue = (value: number): string => {
+  formatValue = (value: number): string => {
     return value.toString()
   }
 
-  handleFormatLabel = (timestamp: number): string => {
+  formatLabel = (timestamp: number): string => {
     const date = new Date(timestamp * 1000)
 
     return date.toLocaleString('en-US', {
@@ -131,12 +127,21 @@ export default class PriceHistoryChart extends React.Component<Props> {
     })
   }
 
-  getInitialPrice = () => {
+  formatPrice = (price: number, formatter: Function = formatThousands): string => {
+    const { symbol } = CURRENCIES[this.props.currency]
+    return `${symbol}${formatter(price)}`
+  }
+
+  formatDate = (timestamp: number): string => {
+    return this.props.formatDate(new Date(timestamp * 1000))
+  }
+
+  getInitialPrice = (): number => {
     const { prices, priceKey } = this.props
     return prices[0][priceKey]
   }
 
-  getLatestPrice = () => {
+  getLatestPrice = (): number => {
     const { prices, priceKey } = this.props
     return prices[prices.length - 1][priceKey]
   }

--- a/app/components/Dashboard/PriceHistoryPanel/PriceHistoryChart.jsx
+++ b/app/components/Dashboard/PriceHistoryPanel/PriceHistoryChart.jsx
@@ -1,0 +1,114 @@
+// @flow
+import React from 'react'
+import classNames from 'classnames'
+import { ResponsiveContainer, LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip } from 'recharts'
+
+import AxisLabel from './AxisLabel'
+import { formatFiat } from '../../../core/formatters'
+import { CURRENCIES } from '../../../core/constants'
+
+import styles from './PriceHistoryChart.scss'
+
+type Price = {
+  time: number,
+  close: number,
+  high: number,
+  low: number,
+  open: number,
+  volumefrom: number,
+  volumeto: number
+}
+
+type Props = {
+  className?: string,
+  prices: Array<Price>,
+  currency: string,
+  timeKey: string,
+  priceKey: string
+}
+
+export default class PriceHistoryChart extends React.Component<Props> {
+  static defaultProps = {
+    timeKey: 'time',
+    priceKey: 'close'
+  }
+
+  render = (): React$Node => {
+    const { className, prices, timeKey, priceKey } = this.props
+
+    return (
+      <ResponsiveContainer width='100%' height={250} className={classNames(styles.priceHistoryChart, className)}>
+        <LineChart data={prices} margin={{ top: 14, right: 10, bottom: 10, left: 10 }}>
+          <XAxis
+            dataKey={timeKey}
+            type='category'
+            interval='preserveStartEnd'
+            stroke='#9ca0a8'
+            tickLine={false}
+            tickFormatter={this.renderDate}
+            tickMargin={24}
+            minTickGap={50} />
+          <YAxis
+            stroke='#9ca0a8'
+            axisLine={false}
+            tickLine={false}
+            tickFormatter={this.renderPrice}
+            tickMargin={20}
+            domain={['auto', 'auto']} />
+          <CartesianGrid
+            stroke='#e6e6e6' />
+          <Tooltip
+            formatter={this.handleFormatValue}
+            labelFormatter={this.handleFormatLabel} />
+          <Line
+            dataKey={priceKey}
+            type='monotone'
+            stroke='#dc6b87'
+            strokeWidth={4}
+            dot={false}
+            animationDuration={500}
+            animationEasing='ease-out' />
+          <text className={styles.current} x='50%' y={0} textAnchor='middle' alignmentBaseline='hanging' fill='##282828'>
+            {this.renderPrice(this.getLatestPrice())}
+          </text>
+        </LineChart>
+      </ResponsiveContainer>
+    )
+  }
+
+  renderAxisLabel = (axisType: string, label: ?string): Function => {
+    return ({ viewBox }: { viewBox: Object }): React$Node => (
+      <AxisLabel axisType={axisType} {...viewBox}>{label}</AxisLabel>
+    )
+  }
+
+  renderDate = (timestamp: number): string => {
+    const date = new Date(timestamp * 1000)
+    return `${date.getMonth() + 1}/${date.getDate()}`
+  }
+
+  renderPrice = (price: number): string => {
+    const { symbol } = CURRENCIES[this.props.currency]
+    return `${symbol}${formatFiat(price)}`
+  }
+
+  handleFormatValue = (value: number): string => {
+    return value.toString()
+  }
+
+  handleFormatLabel = (timestamp: number): string => {
+    const date = new Date(timestamp * 1000)
+
+    return date.toLocaleString('en-US', {
+      weekday: 'short',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    })
+  }
+
+  getLatestPrice = () => {
+    const { prices, priceKey } = this.props
+    return prices[prices.length - 1][priceKey]
+  }
+}

--- a/app/components/Dashboard/PriceHistoryPanel/PriceHistoryChart.jsx
+++ b/app/components/Dashboard/PriceHistoryPanel/PriceHistoryChart.jsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import { ResponsiveContainer, LineChart, Line, CartesianGrid, XAxis, YAxis, Tooltip } from 'recharts'
 
 import AxisLabel from './AxisLabel'
+import BoundingBox from './BoundingBox'
 import { formatFiat } from '../../../core/formatters'
 import { CURRENCIES } from '../../../core/constants'
 
@@ -68,11 +69,34 @@ export default class PriceHistoryChart extends React.Component<Props> {
             dot={false}
             animationDuration={500}
             animationEasing='ease-out' />
-          <text className={styles.current} x='50%' y={0} textAnchor='middle' alignmentBaseline='hanging' fill='##282828'>
-            {this.renderPrice(this.getLatestPrice())}
-          </text>
+          {this.renderLatestPrice()}
+          {this.renderPriceChange()}
         </LineChart>
       </ResponsiveContainer>
+    )
+  }
+
+  renderLatestPrice = () => {
+    return (
+      <text className={styles.current} x='50%' y={0} textAnchor='middle' alignmentBaseline='hanging' fill='#282828'>
+        {this.renderPrice(this.getLatestPrice())}
+      </text>
+    )
+  }
+
+  renderPriceChange = () => {
+    const change = this.getPriceChange()
+    const classes = classNames(styles.change, {
+      [styles.increase]: change >= 0,
+      [styles.decrease]: change < 0
+    })
+
+    return (
+      <BoundingBox className={classes} roundedX={3} roundedY={3} paddingX={3} paddingY={1}>
+        <text className={styles.changeText} x='50%' y={35} textAnchor='middle' alignmentBaseline='hanging' fill='#282828'>
+          {change >= 0 && '+'}{(change * 100).toFixed(2)}%
+        </text>
+      </BoundingBox>
     )
   }
 
@@ -107,8 +131,17 @@ export default class PriceHistoryChart extends React.Component<Props> {
     })
   }
 
+  getInitialPrice = () => {
+    const { prices, priceKey } = this.props
+    return prices[0][priceKey]
+  }
+
   getLatestPrice = () => {
     const { prices, priceKey } = this.props
     return prices[prices.length - 1][priceKey]
+  }
+
+  getPriceChange = () => {
+    return (this.getLatestPrice() - this.getInitialPrice()) / this.getInitialPrice()
   }
 }

--- a/app/components/Dashboard/PriceHistoryPanel/PriceHistoryChart.scss
+++ b/app/components/Dashboard/PriceHistoryPanel/PriceHistoryChart.scss
@@ -5,4 +5,21 @@
     font-size: 24px;
     font-weight: 600;
   }
+
+  .change {
+    &.increase {
+      fill: #5abf6b;
+    }
+
+    &.decrease {
+      fill: #ee6d66;
+    }
+  }
+
+  .changeText {
+    fill: #fff;
+    line-height: 12px;
+    font-size: 12px;
+    font-weight: 600;
+  }
 }

--- a/app/components/Dashboard/PriceHistoryPanel/PriceHistoryChart.scss
+++ b/app/components/Dashboard/PriceHistoryPanel/PriceHistoryChart.scss
@@ -1,0 +1,8 @@
+.priceHistoryChart {
+  font-size: 12px;
+
+  .current {
+    font-size: 24px;
+    font-weight: 600;
+  }
+}

--- a/app/components/Dashboard/PriceHistoryPanel/PriceHistoryPanel.jsx
+++ b/app/components/Dashboard/PriceHistoryPanel/PriceHistoryPanel.jsx
@@ -1,0 +1,79 @@
+// @flow
+import React from 'react'
+import classNames from 'classnames'
+import { keys } from 'lodash'
+
+import PriceHistoryChart from './PriceHistoryChart'
+import Panel from '../../Panel'
+import DropdownIcon from '../../../assets/icons/dropdown.svg'
+import { ASSETS } from '../../../core/constants'
+import styles from './PriceHistoryPanel.scss'
+
+type Duration = '1m' | '1w' | '1d'
+
+type Price = {
+  time: number,
+  close: number,
+  high: number,
+  low: number,
+  open: number,
+  volumefrom: number,
+  volumeto: number
+}
+
+type Props = {
+  className: ?string,
+  asset: string,
+  duration: Duration,
+  currency: string,
+  prices: Array<Price>,
+  setAsset: Function,
+  setDuration: Function
+}
+
+const DURATIONS: { [key: Duration]: string } = {
+  '1m': '1 month',
+  '1w': '1 week',
+  '1d': '1 day'
+}
+
+export default class PriceHistoryPanel extends React.Component<Props> {
+  render = () => {
+    const { className, prices, currency } = this.props
+
+    return (
+      <Panel className={classNames(styles.priceHistoryPanel, className)} renderHeader={this.renderHeader}>
+        <PriceHistoryChart prices={prices} currency={currency} />
+      </Panel>
+    )
+  }
+
+  renderHeader = () => {
+    return (
+      <div className={styles.header}>
+        <span className={styles.asset} onClick={this.handleChangeAsset}>
+          {this.props.asset}
+          <DropdownIcon className={styles.icon} />
+        </span>
+        <span className={styles.duration} onClick={this.handleChangeDuration}>
+          {this.getDuration()}
+          <DropdownIcon className={styles.icon} />
+        </span>
+      </div>
+    )
+  }
+
+  handleChangeAsset = () => {
+    this.props.setAsset(this.props.asset === ASSETS.NEO ? ASSETS.GAS : ASSETS.NEO)
+  }
+
+  handleChangeDuration = () => {
+    const durations = keys(DURATIONS)
+    const index = (durations.indexOf(this.props.duration) + 1) % durations.length
+    this.props.setDuration(durations[index])
+  }
+
+  getDuration = () => {
+    return DURATIONS[this.props.duration]
+  }
+}

--- a/app/components/Dashboard/PriceHistoryPanel/PriceHistoryPanel.jsx
+++ b/app/components/Dashboard/PriceHistoryPanel/PriceHistoryPanel.jsx
@@ -43,7 +43,7 @@ export default class PriceHistoryPanel extends React.Component<Props> {
 
     return (
       <Panel className={classNames(styles.priceHistoryPanel, className)} renderHeader={this.renderHeader}>
-        <PriceHistoryChart prices={prices} currency={currency} />
+        <PriceHistoryChart prices={prices} currency={currency} formatDate={this.formatDate} />
       </Panel>
     )
   }
@@ -75,5 +75,13 @@ export default class PriceHistoryPanel extends React.Component<Props> {
 
   getDuration = () => {
     return DURATIONS[this.props.duration]
+  }
+
+  formatDate = (date: Date): string => {
+    if (this.props.duration === '1d') {
+      return date.toLocaleString('en-US', { hour: 'numeric', minute: 'numeric', hour12: true })
+    } else {
+      return date.toLocaleString('en-US', { month: 'numeric', day: 'numeric' })
+    }
   }
 }

--- a/app/components/Dashboard/PriceHistoryPanel/PriceHistoryPanel.scss
+++ b/app/components/Dashboard/PriceHistoryPanel/PriceHistoryPanel.scss
@@ -1,0 +1,27 @@
+.priceHistoryPanel {
+  .header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    .asset,
+    .duration {
+      display: flex;
+      align-items: center;
+      color: #969aa0;
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      cursor: pointer;
+
+      > * {
+        flex: 0 0 auto;
+      }
+
+      svg,
+      svg path {
+        fill: currentColor;
+      }
+    }
+  }
+}

--- a/app/components/Dashboard/PriceHistoryPanel/index.js
+++ b/app/components/Dashboard/PriceHistoryPanel/index.js
@@ -1,0 +1,30 @@
+// @flow
+import { compose, withState } from 'recompose'
+
+import PriceHistoryPanel from './PriceHistoryPanel'
+import priceHistoryActions from '../../../actions/priceHistoryActions'
+import withData from '../../../hocs/api/withData'
+import withActions from '../../../hocs/api/withActions'
+import withCurrencyData from '../../../hocs/withCurrencyData'
+import { ASSETS } from '../../../core/constants'
+
+type Duration = '1m' | '1w' | '1d'
+
+const mapPricesDataToProps = (prices, props) => ({
+  prices: prices[props.asset]
+})
+
+const mapPriceHistoryActionsToProps = (actions, props) => ({
+  setDuration: (duration: Duration) => {
+    props.setDuration(duration)
+    return actions.request({ duration, currency: props.currency })
+  }
+})
+
+export default compose(
+  withState('asset', 'setAsset', ASSETS.NEO),
+  withState('duration', 'setDuration', '1m'),
+  withData(priceHistoryActions, mapPricesDataToProps),
+  withCurrencyData(),
+  withActions(priceHistoryActions, mapPriceHistoryActionsToProps)
+)(PriceHistoryPanel)

--- a/app/components/Dashboard/TokenBalancesPanel/TokenBalancesPanel.jsx
+++ b/app/components/Dashboard/TokenBalancesPanel/TokenBalancesPanel.jsx
@@ -3,9 +3,7 @@ import React from 'react'
 import classNames from 'classnames'
 
 import Panel from '../../Panel'
-import Tooltip from '../../../components/Tooltip'
-// import { formatGAS } from '../../../core/formatters'
-// import { toBigNumber } from '../../../core/math'
+import Tooltip from '../../Tooltip'
 import RefreshIcon from '../../../assets/icons/refresh.svg'
 import styles from './TokenBalancesPanel.scss'
 

--- a/app/components/Inputs/SelectInput/SelectInput.jsx
+++ b/app/components/Inputs/SelectInput/SelectInput.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react'
 import classNames from 'classnames'
-import { noop, omit, trim, includes, lowerCase } from 'lodash'
+import { noop, omit, trim, includes, toLower } from 'lodash'
 
 import Dropdown from './Dropdown'
 import DropdownButton from './DropdownButton'
@@ -29,7 +29,7 @@ const defaultRenderAfter = (props) => <DropdownButton {...props} />
 const defaultItemValue = (item) => item
 
 const defaultSearchResults = (items, term) => {
-  return items.filter((item) => includes(lowerCase(item), lowerCase(term)))
+  return items.filter((item) => includes(toLower(item), toLower(term)))
 }
 
 export default class SelectInput extends React.Component<Props, State> {

--- a/app/components/Panel/Panel.scss
+++ b/app/components/Panel/Panel.scss
@@ -1,6 +1,7 @@
 .panel {
   display: flex;
   flex-direction: column;
+  width: 100%;
 
   .header {
     flex: 0 0 auto;

--- a/app/containers/App/App.scss
+++ b/app/containers/App/App.scss
@@ -23,6 +23,7 @@
     .content {
       flex: 1 1 auto;
       height: 100%;
+      overflow: auto;
     }
   }
 

--- a/app/containers/Dashboard/Dashboard.jsx
+++ b/app/containers/Dashboard/Dashboard.jsx
@@ -3,6 +3,7 @@ import React, { Component } from 'react'
 
 import AssetBalancesPanel from '../../components/Dashboard/AssetBalancesPanel'
 import TokenBalancesPanel from '../../components/Dashboard/TokenBalancesPanel'
+import PriceHistoryPanel from '../../components/Dashboard/PriceHistoryPanel'
 import { log } from '../../util/Logs'
 
 import styles from './Dashboard.scss'
@@ -42,7 +43,7 @@ export default class Dashboard extends Component<Props> {
           <TokenBalancesPanel className={styles.tokensPanel} />
         </div>
         <div className={styles.chartsColumn}>
-          {/* TODO */}
+          <PriceHistoryPanel className={styles.pricesPanel} />
         </div>
       </div>
     )

--- a/app/containers/Dashboard/Dashboard.scss
+++ b/app/containers/Dashboard/Dashboard.scss
@@ -7,10 +7,10 @@
   height: 100%;
 
   .dataColumn {
+    flex: 0 0 440px;
     display: flex;
     flex-direction: column;
     align-items: stretch;
-    width: 440px;
     margin-right: 24px;
 
     .assetsPanel {
@@ -20,9 +20,16 @@
 
     .tokensPanel {
       flex: 1 1 auto;
+      min-height: 150px;
     }
   }
 
   .chartsColumn {
+    flex: 1 1 auto;
+    min-width: 0;
+
+    // .pricesPanel {
+    //   flex: 0 0 auto;
+    // }
   }
 }

--- a/main.js
+++ b/main.js
@@ -26,7 +26,7 @@ app.on('ready', () => {
   const onAppReady = () => {
     mainWindow = new BrowserWindow({
       height: 750,
-      width: 1000,
+      width: 1280,
       minHeight: 750,
       minWidth: 1000,
       icon: path.join(__dirname, 'icons/png/64x64.png'),
@@ -36,7 +36,7 @@ app.on('ready', () => {
     })
 
     if (process.platform !== 'darwin') {
-    // Windows/Linxu Menu
+      // Windows/Linux Menu
       mainWindow.setMenu(null)
     } else {
       // Menu is required for MacOS

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "react-syntax-highlighter": "5.8.0",
     "react-test-renderer": "16.1.1",
     "react-tippy": "1.2.2",
+    "recharts": "^1.0.0-beta.10",
     "recompose": "^0.26.0",
     "redux": "3.7.2",
     "redux-logger": "3.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1931,6 +1931,10 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
+chain-function@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/chain-function/-/chain-function-1.0.0.tgz#0d4ab37e7e18ead0bdc47b920764118ce58733dc"
+
 chainsaw@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/chainsaw/-/chainsaw-0.1.0.tgz#5eab50b28afe58074d0d58291388828b5e5fbc98"
@@ -2026,7 +2030,7 @@ clap@^1.0.9:
   dependencies:
     chalk "^1.1.3"
 
-classnames@2.2.5:
+classnames@2.2.5, classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
@@ -2332,6 +2336,10 @@ core-assert@^0.2.0:
     buf-compare "^1.0.0"
     is-error "^2.2.0"
 
+core-js@2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"
+
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
@@ -2613,6 +2621,60 @@ cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
 
+d3-array@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.1.tgz#d1ca33de2f6ac31efadb8e050a021d7e2396d5dc"
+
+d3-collection@1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.4.tgz#342dfd12837c90974f33f1cc0a785aea570dcdc2"
+
+d3-color@1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.0.3.tgz#bc7643fca8e53a8347e2fbdaffa236796b58509b"
+
+d3-format@1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.2.2.tgz#1a39c479c8a57fe5051b2e67a3bee27061a74e7a"
+
+d3-interpolate@1, d3-interpolate@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.1.6.tgz#2cf395ae2381804df08aa1bf766b7f97b5f68fb6"
+  dependencies:
+    d3-color "1"
+
+d3-path@1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.5.tgz#241eb1849bd9e9e8021c0d0a799f8a0e8e441764"
+
+d3-scale@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-1.0.6.tgz#bce19da80d3a0cf422c9543ae3322086220b34ed"
+  dependencies:
+    d3-array "^1.2.0"
+    d3-collection "1"
+    d3-color "1"
+    d3-format "1"
+    d3-interpolate "1"
+    d3-time "1"
+    d3-time-format "2"
+
+d3-shape@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.2.0.tgz#45d01538f064bafd05ea3d6d2cb748fd8c41f777"
+  dependencies:
+    d3-path "1"
+
+d3-time-format@2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.1.1.tgz#85b7cdfbc9ffca187f14d3c456ffda268081bb31"
+  dependencies:
+    d3-time "1"
+
+d3-time@1:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.0.8.tgz#dbd2d6007bf416fe67a76d17947b784bffea1e84"
+
 d@1:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
@@ -2843,6 +2905,10 @@ dom-converter@~0.1:
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.1.4.tgz#a45ef5727b890c9bffe6d7c876e7b19cb0e17f3b"
   dependencies:
     utila "~0.3"
+
+dom-helpers@^3.2.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
 
 dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
@@ -7211,7 +7277,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.6.0:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -7329,7 +7395,7 @@ rabin-bindings@~1.7.4:
     nan "^2.8.0"
     prebuild-install "^2.3.0"
 
-raf@3.4.0, raf@^3.3.2:
+raf@3.4.0, raf@^3.2.0, raf@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
   dependencies:
@@ -7471,6 +7537,12 @@ react-redux@5.0.6:
     loose-envify "^1.1.0"
     prop-types "^15.5.10"
 
+react-resize-detector@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-1.1.0.tgz#4a9831fa3caad32230478dd0185cbd2aa91a5ebf"
+  dependencies:
+    prop-types "^15.5.10"
+
 react-router-dom@4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-4.2.2.tgz#c8a81df3adc58bba8a76782e946cbd4eae649b8d"
@@ -7493,6 +7565,15 @@ react-router@^4.2.0:
     path-to-regexp "^1.7.0"
     prop-types "^15.5.4"
     warning "^3.0.0"
+
+react-smooth@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-smooth/-/react-smooth-1.0.0.tgz#b29dbebddddb06d21b5b08962167fb9eac1897d8"
+  dependencies:
+    lodash "~4.17.4"
+    prop-types "^15.6.0"
+    raf "^3.2.0"
+    react-transition-group "^2.2.1"
 
 react-split-pane@0.1.68:
   version "0.1.68"
@@ -7539,6 +7620,17 @@ react-tippy@1.2.2:
   resolved "https://registry.yarnpkg.com/react-tippy/-/react-tippy-1.2.2.tgz#061467d34d29e7a5a9421822d125c451d6bb5153"
   dependencies:
     popper.js "^1.11.1"
+
+react-transition-group@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.2.1.tgz#e9fb677b79e6455fd391b03823afe84849df4a10"
+  dependencies:
+    chain-function "^1.0.0"
+    classnames "^2.2.5"
+    dom-helpers "^3.2.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.5.8"
+    warning "^3.0.0"
 
 react@16.1.1:
   version "16.1.1"
@@ -7636,6 +7728,26 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
+recharts-scale@0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/recharts-scale/-/recharts-scale-0.3.2.tgz#dac7621714a4765d152cb2adbc30c73b831208c9"
+
+recharts@^1.0.0-beta.10:
+  version "1.0.0-beta.10"
+  resolved "https://registry.yarnpkg.com/recharts/-/recharts-1.0.0-beta.10.tgz#d3cd15df6b7879d5968da3c942b5fcdaf2504fe1"
+  dependencies:
+    classnames "2.2.5"
+    core-js "2.5.1"
+    d3-interpolate "^1.1.5"
+    d3-scale "1.0.6"
+    d3-shape "1.2.0"
+    lodash "~4.17.4"
+    prop-types "^15.6.0"
+    react-resize-detector "1.1.0"
+    react-smooth "1.0.0"
+    recharts-scale "0.3.2"
+    reduce-css-calc "1.3.0"
+
 recompose@^0.26.0:
   version "0.26.0"
   resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.26.0.tgz#9babff039cb72ba5bd17366d55d7232fbdfb2d30"
@@ -7667,7 +7779,7 @@ redeyed@~1.0.0:
   dependencies:
     esprima "~3.0.0"
 
-reduce-css-calc@^1.2.6:
+reduce-css-calc@1.3.0, reduce-css-calc@^1.2.6:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz#747c914e049614a4c9cfbba629871ad1d2927716"
   dependencies:


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
This implements the NEO/GAS price chart based upon @asalib's designs.  (Proper fonts will be added in a follow-up PR.)

![price-history-chart](https://user-images.githubusercontent.com/169093/36075335-fb2b5cf8-0f12-11e8-97ff-4a60a9460040.gif)

**How did you solve this problem?**
I added a new action set to fetch the data from cryptocompare.com's API, and I added the recharts package for rendering the chart in a new dashboard panel.  The user can toggle between NEO & GAS assets, as well as 1 month, 1 week, and 1 day timeframes.

**How did you make sure your solution works?**
I smoke tested it.  I'll be adding tests in a follow-up PR.

**Are there any special changes in the code that we should be aware of?**
* New `recharts` package introduced.
* I increased the window width from 1000px to 1280px to match Alf's designs.

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
