### PR TITLE
Omit ended ICO's

### DIFF
--- a/app/containers/WalletInfo/WalletInfo.jsx
+++ b/app/containers/WalletInfo/WalletInfo.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component } from 'react'
 import classNames from 'classnames'
-import { isNil, keyBy } from 'lodash'
+import { isNil, keyBy, omitBy } from 'lodash'
 
 import Claim from '../Claim'
 
@@ -9,7 +9,7 @@ import Tooltip from '../../components/Tooltip'
 import Button from '../../components/Button'
 
 import { formatGAS, formatFiat, formatNEO } from '../../core/formatters'
-import { ASSETS, CURRENCIES, MODAL_TYPES } from '../../core/constants'
+import { ASSETS, CURRENCIES, MODAL_TYPES, ENDED_ICO_TOKENS } from '../../core/constants'
 import { toNumber } from '../../core/math'
 
 import MdSync from 'react-icons/lib/md/sync'
@@ -139,7 +139,12 @@ export default class WalletInfo extends Component<Props> {
                 [ASSETS.NEO]: NEO,
                 [ASSETS.GAS]: GAS
               },
-              tokenBalances: keyBy(tokenBalances, 'symbol'),
+              tokenBalances: keyBy(
+                tokenBalances.filter(
+                  token => !ENDED_ICO_TOKENS.includes(token.symbol)
+                ),
+                'symbol'
+              ),
               showTokensModal: () => {
                 showModal(MODAL_TYPES.TOKEN, {
                   tokens: allTokens,

--- a/app/containers/WalletInfo/WalletInfo.jsx
+++ b/app/containers/WalletInfo/WalletInfo.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component } from 'react'
 import classNames from 'classnames'
-import { isNil, keyBy, omitBy } from 'lodash'
+import { isNil, keyBy } from 'lodash'
 
 import Claim from '../Claim'
 

--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -81,6 +81,8 @@ export const TOKENS = {
   NRV: '2e25d2127e0240c6deaf35394702feb236d4d7fc'
 }
 
+export const ENDED_ICO_TOKENS = ['DBC', 'RPX', 'QLC', 'RHT']
+
 export const DEFAULT_WALLET = {
   name: 'userWallet',
   version: '1.0',


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
People have sent funds to ICO's that have ended, which caused them to lose money. This PR removes the ones that are known to have ended.

**How did you solve this problem?**
I have created a list of known ICO's that have ended, and that list is omitted from the tokens that are passed to the Sale Participation Modal.

**How did you make sure your solution works?**
Have tested it, both in MainNet/TestNet.

**Are there any special changes in the code that we should be aware of?**

**Is there anything else we should know?**

- [ ] Unit tests written?
