### PR TITLE
Omit balances with 0 or undefined for token sale participation success

### DIFF
--- a/app/components/Modals/TokenSaleModal/ParticipationSuccess/index.jsx
+++ b/app/components/Modals/TokenSaleModal/ParticipationSuccess/index.jsx
@@ -17,10 +17,13 @@ type Props = {
 const formatAssetBalances = assetBalancesToSend => {
   const balances = []
   Object.keys(assetBalancesToSend).forEach(symbol => {
-    balances.push(`${assetBalancesToSend[symbol]} ${symbol}`)
+    const balance = assetBalancesToSend[symbol]
+    if (balance) {
+      balances.push(`${balance} ${symbol}`)
+    }
   })
 
-  return balances.join(',')
+  return balances.join(', ')
 }
 
 const ParticipationSuccess = ({


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
When participating with just NEO, the participation success message also included GAS without any balance attached to it.

**How did you solve this problem?**
Zero balances/undefined balances are omitted now.

**How did you make sure your solution works?**
Tested participation with just NEO/GAS and both. Works well.

**Are there any special changes in the code that we should be aware of?**

**Is there anything else we should know?**

- [ ] Unit tests written?
