### PR TITLE
Updated logout button to display at bottom of sidebar

### DIFF
--- a/app/containers/App/Sidebar/Sidebar.jsx
+++ b/app/containers/App/Sidebar/Sidebar.jsx
@@ -35,43 +35,47 @@ const Sidebar = ({
   showTokenSaleModal
 }: Props) => (
   <div className={classNames(styles.container, className)}>
-    <div className={styles.logo}>
-      <Logo />
+    <div className={styles.group}>
+      <div className={styles.logo}>
+        <Logo />
+      </div>
+
+      <Tooltip title='Dashboard' position='right'>
+        <NavLink id='dashboard' exact to={ROUTES.DASHBOARD} className={styles.navItem} activeClassName={styles.active}>
+          <HomeIcon />
+        </NavLink>
+      </Tooltip>
+
+      <Tooltip title='Transaction History' position='right'>
+        <NavLink id='history' exact to={ROUTES.TRANSACTION_HISTORY} className={styles.navItem} activeClassName={styles.active}>
+          <HistoryIcon />
+        </NavLink>
+      </Tooltip>
+
+      <Tooltip title='Send' position='right'>
+        <a id='send' className={styles.navItem} onClick={showSendModal}>
+          <SendIcon />
+        </a>
+      </Tooltip>
+
+      <Tooltip title='Receive' position='right'>
+        <a id='receive' className={styles.navItem} onClick={showReceiveModal}>
+          <ReceiveIcon />
+        </a>
+      </Tooltip>
+
+      <Tooltip title='Token Sale' position='right'>
+        <a id='tokenSale' className={styles.navItem} onClick={showTokenSaleModal}>
+          <TokenSaleIcon />
+        </a>
+      </Tooltip>
     </div>
 
-    <Tooltip title='Dashboard' position='right'>
-      <NavLink id='dashboard' exact to={ROUTES.DASHBOARD} className={styles.navItem} activeClassName={styles.active}>
-        <HomeIcon />
-      </NavLink>
-    </Tooltip>
-
-    <Tooltip title='Transaction History' position='right'>
-      <NavLink id='history' exact to={ROUTES.TRANSACTION_HISTORY} className={styles.navItem} activeClassName={styles.active}>
-        <HistoryIcon />
-      </NavLink>
-    </Tooltip>
-
-    <Tooltip title='Send' position='right'>
-      <a id='send' className={styles.navItem} onClick={showSendModal}>
-        <SendIcon />
-      </a>
-    </Tooltip>
-
-    <Tooltip title='Receive' position='right'>
-      <a id='receive' className={styles.navItem} onClick={showReceiveModal}>
-        <ReceiveIcon />
-      </a>
-    </Tooltip>
-
-    <Tooltip title='Token Sale' position='right'>
-      <a id='tokenSale' className={styles.navItem} onClick={showTokenSaleModal}>
-        <TokenSaleIcon />
-      </a>
-    </Tooltip>
-
-    <Tooltip title='Logout' position='right'>
-      <Logout id='logout' className={styles.navItem} />
-    </Tooltip>
+    <div className={styles.group}>
+      <Tooltip title='Logout' position='right'>
+        <Logout id='logout' className={styles.navItem} />
+      </Tooltip>
+    </div>
   </div>
 )
 

--- a/app/containers/App/Sidebar/Sidebar.scss
+++ b/app/containers/App/Sidebar/Sidebar.scss
@@ -3,9 +3,16 @@
 $size: 64px;
 
 .container {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
   box-sizing: border-box;
   width: $size;
   background: #f2f2f2;
+
+  .group {
+    flex: 0 0 auto;
+  }
 }
 
 .logo {


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
It moves the logout button to the bottom of the sidebar to match the designs.

*Before:*
<img width="66" alt="sidebar-before" src="https://user-images.githubusercontent.com/169093/36211608-efbeea3a-115e-11e8-919f-3fd136402aee.png">

*After:*
<img width="65" alt="sidebar-after" src="https://user-images.githubusercontent.com/169093/36211612-f3aacf38-115e-11e8-8768-26872ffd1252.png">

**How did you solve this problem?**
I used flexbox to align the sidebar sections.

**How did you make sure your solution works?**
Looked at the sidebar.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
