### PR TITLE
updated BaseModel.jsx to have a new prop shouldCloseWithEscapeKey the…

### DIFF
--- a/__tests__/components/Modals/__snapshots__/ConfirmModal.test.js.snap
+++ b/__tests__/components/Modals/__snapshots__/ConfirmModal.test.js.snap
@@ -4,6 +4,7 @@ exports[`ConfirmModal should render without crashing 1`] = `
 <BaseModal
   height="450px"
   hideModal={[Function]}
+  shouldCloseWithEscapeKey={true}
   style={
     Object {
       "content": Object {

--- a/app/components/Modals/BaseModal/BaseModal.jsx
+++ b/app/components/Modals/BaseModal/BaseModal.jsx
@@ -18,7 +18,8 @@ type Props = {
       content: Object,
       overlay: Object
     },
-    onAfterOpen?: Function
+    onAfterOpen?: Function,
+    shouldCloseWithEscapeKey: boolean
 }
 
 const BaseModal = ({
@@ -30,11 +31,12 @@ const BaseModal = ({
   className,
   bodyClassName,
   style,
-  onAfterOpen
+  onAfterOpen,
+  shouldCloseWithEscapeKey
 }: Props) => (
   <ReactModal
     isOpen
-    onRequestClose={hideModal}
+    onRequestClose={() => shouldCloseWithEscapeKey && hideModal()}
     style={{
       content: {
         width,
@@ -71,7 +73,8 @@ BaseModal.defaultProps = {
   style: {
     content: {},
     overlay: {}
-  }
+  },
+  shouldCloseWithEscapeKey: true
 }
 
 export default BaseModal

--- a/app/components/Modals/SendModal/SendModal.jsx
+++ b/app/components/Modals/SendModal/SendModal.jsx
@@ -53,11 +53,11 @@ export default class SendModal extends Component<Props, State> {
 
   render () {
     const { hideModal } = this.props
-
     return (
       <BaseModal
         title='Send'
         hideModal={hideModal}
+        shouldCloseWithEscapeKey={false}
         style={{ content: { width: '925px', height: '410px' } }}>
         {this.renderDisplay()}
       </BaseModal>


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
This is the https://github.com/CityOfZion/neon-wallet/pull/751 with commit history squashed

**What problem does this PR solve?**
@canesin pointed that its frustrating UX to have some modals close via the `esc` key. This PR adds prop to the `BaseModal` component so that it can condtionally close via `esc` this prop is called
`shouldCloseWithEscapeKey`.

**How did you solve this problem?**
By adding a new prop to `BaseModal`

**How did you make sure your solution works?**
Testing locally

**Are there any special changes in the code that we should be aware of?**

**Is there anything else we should know?**

- [ ] Unit tests written?
