### PR TITLE
Updated token sale behavior to clear previously selected asset amounts

### DIFF
--- a/app/components/Modals/TokenSaleModal/SelectToken/index.jsx
+++ b/app/components/Modals/TokenSaleModal/SelectToken/index.jsx
@@ -119,7 +119,9 @@ class SelectToken extends Component<Props, State> {
                   <AssetInput
                     symbols={Object.keys(assetBalances)}
                     value={selectedAsset}
-                    onChange={asset => this.setState({ selectedAsset: asset })}
+                    onChange={asset => this.setState({ selectedAsset: asset }, () => {
+                      onChangeAmount(asset, '')
+                    })}
                     className={styles.assetInput}
                   />
                 </div>

--- a/app/components/Modals/TokenSaleModal/TokenSaleModal.jsx
+++ b/app/components/Modals/TokenSaleModal/TokenSaleModal.jsx
@@ -39,14 +39,13 @@ type State = {
   loaded: boolean,
 }
 
+const initialBalancesToSend = { [ASSETS.NEO]: '', [ASSETS.GAS]: '' }
+
 export default class TokenSale extends Component<Props, State> {
   // $FlowFixMe
   state = {
     useVerification: true,
-    assetBalancesToSend: {
-      NEO: '',
-      GAS: ''
-    },
+    assetBalancesToSend: initialBalancesToSend,
     tokenToMint: '',
     participationSuccessful: false,
     loaded: false,
@@ -59,7 +58,7 @@ export default class TokenSale extends Component<Props, State> {
     if (tokenToMint) {
       const scriptHash = get(tokenBalances[tokenToMint], 'scriptHash')
 
-      oldParticipateInSale(assetBalancesToSend.NEO, scriptHash, gasCost).then(
+      oldParticipateInSale(assetBalancesToSend[ASSETS.NEO], scriptHash, gasCost).then(
         success => {
           if (success) {
             this.setState({
@@ -153,7 +152,7 @@ export default class TokenSale extends Component<Props, State> {
               onChangeAmount={(symbol: SymbolType, amount: string) =>
                 this.setState({
                   assetBalancesToSend: {
-                    ...assetBalancesToSend,
+                    ...initialBalancesToSend,
                     [symbol]: amount
                   }
                 })


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Fixes #744

**What problem does this PR solve?**
Copied from issue:

> An issue we ran into with a few of our contributors during our token sale is that they inadvertently sent both GAS and NEO when invoking mintTokens. If you first select GAS and enter an amount and then change to NEO and enter a new amount, the old value of GAS is still sent even though it's not present in the UI. This is an undesirable and unexpected side effect that users would not expect.
>
> It's probably best to limit ICO participation to either GAS or NEO? Alternatively, if some ICOs need to support both, the user experience should be improved to make it clear what's being sent, similar to the multi-recipient approach when sending funds in Neon wallet.

**How did you solve this problem?**
When the asset is changed, I forced any previously selected asset to reset to the default value of "" (empty string).  It's possible that we will want to support sending multiple types of assets for token sales in the future, so I didn't want to remove the possibility of doing so as a whole.

**How did you make sure your solution works?**
I smoke tested it to ensure the value resets.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
