### PR TITLE
Added portfolio panel to new dashboard

### DIFF
--- a/app/actions/pricesActions.js
+++ b/app/actions/pricesActions.js
@@ -1,16 +1,36 @@
 // @flow
-import { api } from 'neon-js'
+import axios from 'axios'
 
 import createRequestActions from '../util/api/createRequestActions'
-import { ASSETS, DEFAULT_CURRENCY_CODE } from '../core/constants'
+import { DEFAULT_CURRENCY_CODE } from '../core/constants'
 
 type Props = {
   symbols?: Array<string>,
   currency?: string
 }
 
+function mapPrices (tickers, currency) {
+  const mapping = {}
+
+  tickers.forEach((ticker) => {
+    mapping[ticker.symbol] = parseFloat(ticker[`price_${currency.toLowerCase()}`])
+  })
+
+  return mapping
+}
+
+function getPrices (currency) {
+  const url = `https://api.coinmarketcap.com/v1/ticker/?limit=0&convert=${currency.toLowerCase()}`
+
+  return axios.get(url).then((response) => {
+    const { data } = response
+    if (data.error) throw new Error(data.error)
+    return mapPrices(data, currency)
+  })
+}
+
 export const ID = 'PRICES'
 
-export default createRequestActions(ID, ({ symbols = [ASSETS.NEO, ASSETS.GAS], currency = DEFAULT_CURRENCY_CODE }: Props = {}) => (state: Object) => {
-  return api.cmc.getPrices(symbols, currency)
+export default createRequestActions(ID, ({ currency = DEFAULT_CURRENCY_CODE }: Props = {}) => (state: Object) => {
+  return getPrices(currency)
 })

--- a/app/components/Dashboard/PortfolioPanel/PortfolioBreakdownChart.jsx
+++ b/app/components/Dashboard/PortfolioPanel/PortfolioBreakdownChart.jsx
@@ -4,13 +4,12 @@ import classNames from 'classnames'
 import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip } from 'recharts'
 import { map, times } from 'lodash'
 
+import COLORS from './colors'
 import { toNumber } from '../../../core/math'
 import { formatThousands } from '../../../core/formatters' // formatFiat
 import { CURRENCIES } from '../../../core/constants'
 
 import styles from './PortfolioBreakdownChart.scss'
-
-const COLORS = ['#a866ee', '#edaa66', '#ee6d66', '#66edcd']
 
 type Props = {
   className?: string,

--- a/app/components/Dashboard/PortfolioPanel/PortfolioBreakdownChart.jsx
+++ b/app/components/Dashboard/PortfolioPanel/PortfolioBreakdownChart.jsx
@@ -1,0 +1,52 @@
+// @flow
+import React from 'react'
+import classNames from 'classnames'
+import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip } from 'recharts'
+import { map, times } from 'lodash'
+
+import { toNumber } from '../../../core/math'
+import { formatThousands } from '../../../core/formatters' // formatFiat
+import { CURRENCIES } from '../../../core/constants'
+
+import styles from './PortfolioBreakdownChart.scss'
+
+const COLORS = ['#a866ee', '#edaa66', '#ee6d66', '#66edcd']
+
+type Props = {
+  className?: string,
+  balances: { [key: SymbolType]: string },
+  currency: string
+}
+
+export default class PortfolioBreakdownChart extends React.Component<Props> {
+  render = (): React$Node => {
+    const { className } = this.props
+    const data = this.getData()
+
+    return (
+      <ResponsiveContainer width={250} height={180} className={classNames(styles.priceHistoryChart, className)}>
+        <PieChart width={200} height={180}>
+          <Pie data={data} dataKey='balance' nameKey='symbol' innerRadius={40} outerRadius={75}>
+            {times(data.length, (index) => (
+              <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} stroke={COLORS[index]} />
+            ))}
+          </Pie>
+          <Tooltip />
+        </PieChart>
+      </ResponsiveContainer>
+    )
+  }
+
+  getData = () => {
+    return map(this.props.balances, (balance, symbol) => ({ symbol, balance: toNumber(balance) }))
+  }
+
+  formatValue = (value: number): string => {
+    return value.toString()
+  }
+
+  formatPrice = (price: number, formatter: Function = formatThousands): string => {
+    const { symbol } = CURRENCIES[this.props.currency]
+    return `${symbol}${formatter(price)}`
+  }
+}

--- a/app/components/Dashboard/PortfolioPanel/PortfolioBreakdownChart.jsx
+++ b/app/components/Dashboard/PortfolioPanel/PortfolioBreakdownChart.jsx
@@ -5,15 +5,21 @@ import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip } from 'recharts'
 import { map, times } from 'lodash'
 
 import COLORS from './colors'
-import { toNumber } from '../../../core/math'
 import { formatThousands } from '../../../core/formatters' // formatFiat
 import { CURRENCIES } from '../../../core/constants'
 
 import styles from './PortfolioBreakdownChart.scss'
 
+type BalanceType = {
+  symbol: SymbolType,
+  balance: string,
+  value: number,
+  percent: number
+}
+
 type Props = {
   className?: string,
-  balances: { [key: SymbolType]: string },
+  balances: { [key: SymbolType]: BalanceType },
   currency: string
 }
 
@@ -25,23 +31,23 @@ export default class PortfolioBreakdownChart extends React.Component<Props> {
     return (
       <ResponsiveContainer width={250} height={180} className={classNames(styles.priceHistoryChart, className)}>
         <PieChart width={200} height={180}>
-          <Pie data={data} dataKey='balance' nameKey='symbol' innerRadius={40} outerRadius={75}>
+          <Pie data={data} dataKey='value' nameKey='symbol' innerRadius={40} outerRadius={75}>
             {times(data.length, (index) => (
               <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} stroke={COLORS[index]} />
             ))}
           </Pie>
-          <Tooltip />
+          <Tooltip formatter={this.formatValue} />
         </PieChart>
       </ResponsiveContainer>
     )
   }
 
   getData = () => {
-    return map(this.props.balances, (balance, symbol) => ({ symbol, balance: toNumber(balance) }))
+    return map(this.props.balances, ({ value }, symbol) => ({ symbol, value }))
   }
 
   formatValue = (value: number): string => {
-    return value.toString()
+    return `$${formatThousands(value.toString())}`
   }
 
   formatPrice = (price: number, formatter: Function = formatThousands): string => {

--- a/app/components/Dashboard/PortfolioPanel/PortfolioBreakdownChart.scss
+++ b/app/components/Dashboard/PortfolioPanel/PortfolioBreakdownChart.scss
@@ -1,0 +1,3 @@
+.portfolioBreakdownChart {
+  // TODO
+}

--- a/app/components/Dashboard/PortfolioPanel/PortfolioPanel.jsx
+++ b/app/components/Dashboard/PortfolioPanel/PortfolioPanel.jsx
@@ -1,0 +1,31 @@
+// @flow
+import React from 'react'
+import classNames from 'classnames'
+
+import PortfolioBreakdownChart from './PortfolioBreakdownChart'
+import Panel from '../../Panel'
+import styles from './PortfolioPanel.scss'
+
+type Props = {
+  className: ?string,
+  currency: string,
+  balances: { [key: SymbolType]: string }
+}
+
+export default class PortfolioPanel extends React.Component<Props> {
+  render = () => {
+    const { className, balances, currency } = this.props
+
+    return (
+      <Panel className={classNames(styles.priceHistoryPanel, className)} renderHeader={this.renderHeader}>
+        <PortfolioBreakdownChart balances={balances} currency={currency} />
+      </Panel>
+    )
+  }
+
+  renderHeader = () => {
+    return (
+      <div className={styles.header}>Portfolio</div>
+    )
+  }
+}

--- a/app/components/Dashboard/PortfolioPanel/PortfolioPanel.jsx
+++ b/app/components/Dashboard/PortfolioPanel/PortfolioPanel.jsx
@@ -7,17 +7,22 @@ import PortfolioTable from './PortfolioTable'
 import Panel from '../../Panel'
 import styles from './PortfolioPanel.scss'
 
+type BalanceType = {
+  symbol: SymbolType,
+  balance: string,
+  value: number,
+  percent: number
+}
+
 type Props = {
   className: ?string,
   currency: string,
-  prices: { [key: SymbolType]: number },
-  balances: { [key: SymbolType]: string },
-  total: number
+  balances: { [key: SymbolType]: BalanceType }
 }
 
 export default class PortfolioPanel extends React.Component<Props> {
   render = () => {
-    const { className, prices, balances, currency, total } = this.props
+    const { className, balances, currency } = this.props
 
     return (
       <Panel className={classNames(styles.portfolioPanel, className)} renderHeader={this.renderHeader}>
@@ -29,10 +34,8 @@ export default class PortfolioPanel extends React.Component<Props> {
           />
           <PortfolioTable
             className={styles.table}
-            prices={prices}
             balances={balances}
             currency={currency}
-            total={total}
           />
         </div>
       </Panel>

--- a/app/components/Dashboard/PortfolioPanel/PortfolioPanel.jsx
+++ b/app/components/Dashboard/PortfolioPanel/PortfolioPanel.jsx
@@ -3,22 +3,38 @@ import React from 'react'
 import classNames from 'classnames'
 
 import PortfolioBreakdownChart from './PortfolioBreakdownChart'
+import PortfolioTable from './PortfolioTable'
 import Panel from '../../Panel'
 import styles from './PortfolioPanel.scss'
 
 type Props = {
   className: ?string,
   currency: string,
-  balances: { [key: SymbolType]: string }
+  prices: { [key: SymbolType]: number },
+  balances: { [key: SymbolType]: string },
+  total: number
 }
 
 export default class PortfolioPanel extends React.Component<Props> {
   render = () => {
-    const { className, balances, currency } = this.props
+    const { className, prices, balances, currency, total } = this.props
 
     return (
-      <Panel className={classNames(styles.priceHistoryPanel, className)} renderHeader={this.renderHeader}>
-        <PortfolioBreakdownChart balances={balances} currency={currency} />
+      <Panel className={classNames(styles.portfolioPanel, className)} renderHeader={this.renderHeader}>
+        <div className={styles.container}>
+          <PortfolioBreakdownChart
+            className={styles.chart}
+            balances={balances}
+            currency={currency}
+          />
+          <PortfolioTable
+            className={styles.table}
+            prices={prices}
+            balances={balances}
+            currency={currency}
+            total={total}
+          />
+        </div>
       </Panel>
     )
   }

--- a/app/components/Dashboard/PortfolioPanel/PortfolioPanel.scss
+++ b/app/components/Dashboard/PortfolioPanel/PortfolioPanel.scss
@@ -1,3 +1,14 @@
 .portfolioPanel {
-  // TODO
+  .container {
+    display: flex;
+    flex-direction: row;
+
+    .chart {
+      flex: 0 0 auto;
+    }
+
+    .table {
+      flex: 1 1 auto;
+    }
+  }
 }

--- a/app/components/Dashboard/PortfolioPanel/PortfolioPanel.scss
+++ b/app/components/Dashboard/PortfolioPanel/PortfolioPanel.scss
@@ -1,0 +1,3 @@
+.portfolioPanel {
+  // TODO
+}

--- a/app/components/Dashboard/PortfolioPanel/PortfolioRow.jsx
+++ b/app/components/Dashboard/PortfolioPanel/PortfolioRow.jsx
@@ -1,0 +1,39 @@
+// @flow
+import React from 'react'
+import classNames from 'classnames'
+
+import { formatThousands } from '../../../core/formatters'
+import { CURRENCIES } from '../../../core/constants'
+
+import styles from './PortfolioRow.scss'
+
+type Props = {
+  className?: string,
+  symbol: string,
+  balance: string,
+  value: number,
+  percent: number,
+  color: string,
+  currency: string
+}
+
+export default class PortfolioRow extends React.Component<Props> {
+  render = (): React$Node => {
+    const { className, symbol, balance, value, percent, color } = this.props
+
+    return (
+      <div className={classNames(styles.portfolioRow, className)}>
+        <span className={styles.color} style={{ background: color }} />
+        <span className={styles.symbol}>{symbol}</span>
+        <span className={styles.balance}>{balance}</span>
+        <span className={styles.value}>{this.formatPrice(value)}</span>
+        <span className={styles.percent}>{(percent * 100).toFixed(1)}%</span>
+      </div>
+    )
+  }
+
+  formatPrice = (price: number): string => {
+    const { symbol } = CURRENCIES[this.props.currency]
+    return `${symbol}${formatThousands(price)}`
+  }
+}

--- a/app/components/Dashboard/PortfolioPanel/PortfolioRow.scss
+++ b/app/components/Dashboard/PortfolioPanel/PortfolioRow.scss
@@ -1,0 +1,39 @@
+.portfolioRow {
+  display: flex;
+  flex-direction: row;
+  margin: 0 0 16px;
+  align-items: center;
+
+  .color,
+  .symbol,
+  .balance,
+  .value,
+  .percent {
+    flex: 1 1 auto;
+    width: 50%;
+    margin-right: 24px;
+    color: #282828;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .color {
+    flex: 0 0 auto;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+  }
+
+  .balance,
+  .value {
+    flex-grow: 2;
+    width: 100%;
+  }
+
+  .percent {
+    color: #969aa0;
+    font-size: 12px;
+    font-weight: 600;
+    text-transform: uppercase;
+  }
+}

--- a/app/components/Dashboard/PortfolioPanel/PortfolioTable.jsx
+++ b/app/components/Dashboard/PortfolioPanel/PortfolioTable.jsx
@@ -1,51 +1,42 @@
 // @flow
 import React from 'react'
 import classNames from 'classnames'
-import { map, times } from 'lodash'
+import { values, times } from 'lodash'
 
 import COLORS from './colors'
 import PortfolioRow from './PortfolioRow'
-import { toNumber } from '../../../core/math'
-// import { formatThousands } from '../../../core/formatters' // formatFiat
 
 import styles from './PortfolioTable.scss'
 
+type BalanceType = {
+  symbol: SymbolType,
+  balance: string,
+  value: number,
+  percent: number
+}
+
 type Props = {
   className?: string,
-  prices: { [key: SymbolType]: number },
-  balances: { [key: SymbolType]: string },
-  currency: string,
-  total: number
+  balances: { [key: SymbolType]: BalanceType },
+  currency: string
 }
 
 export default class PortfolioTable extends React.Component<Props> {
   render = (): React$Node => {
     const { className, currency } = this.props
-    const data = this.getData()
+    const data = values(this.props.balances)
 
     return (
       <div className={classNames(styles.portfolioTable, className)}>
         {times(data.length, (index) => (
           <PortfolioRow
-            key={data[index].symbol}
             {...data[index]}
+            key={data[index].symbol}
             color={COLORS[index % COLORS.length]}
             currency={currency}
           />
         ))}
       </div>
     )
-  }
-
-  getData = () => {
-    const { prices, total } = this.props
-
-    return map(this.props.balances, (tokenBalance, symbol) => {
-      const balance = toNumber(tokenBalance)
-      const value = balance * (prices[symbol] || 0)
-      const percent = value / total
-
-      return { symbol, balance, value, percent }
-    })
   }
 }

--- a/app/components/Dashboard/PortfolioPanel/PortfolioTable.jsx
+++ b/app/components/Dashboard/PortfolioPanel/PortfolioTable.jsx
@@ -1,0 +1,51 @@
+// @flow
+import React from 'react'
+import classNames from 'classnames'
+import { map, times } from 'lodash'
+
+import COLORS from './colors'
+import PortfolioRow from './PortfolioRow'
+import { toNumber } from '../../../core/math'
+// import { formatThousands } from '../../../core/formatters' // formatFiat
+
+import styles from './PortfolioTable.scss'
+
+type Props = {
+  className?: string,
+  prices: { [key: SymbolType]: number },
+  balances: { [key: SymbolType]: string },
+  currency: string,
+  total: number
+}
+
+export default class PortfolioTable extends React.Component<Props> {
+  render = (): React$Node => {
+    const { className, currency } = this.props
+    const data = this.getData()
+
+    return (
+      <div className={classNames(styles.portfolioTable, className)}>
+        {times(data.length, (index) => (
+          <PortfolioRow
+            key={data[index].symbol}
+            {...data[index]}
+            color={COLORS[index % COLORS.length]}
+            currency={currency}
+          />
+        ))}
+      </div>
+    )
+  }
+
+  getData = () => {
+    const { prices, total } = this.props
+
+    return map(this.props.balances, (tokenBalance, symbol) => {
+      const balance = toNumber(tokenBalance)
+      const value = balance * (prices[symbol] || 0)
+      const percent = value / total
+
+      return { symbol, balance, value, percent }
+    })
+  }
+}

--- a/app/components/Dashboard/PortfolioPanel/PortfolioTable.scss
+++ b/app/components/Dashboard/PortfolioPanel/PortfolioTable.scss
@@ -1,0 +1,3 @@
+.portfolioTable {
+  // TODO
+}

--- a/app/components/Dashboard/PortfolioPanel/colors.js
+++ b/app/components/Dashboard/PortfolioPanel/colors.js
@@ -1,0 +1,1 @@
+export default ['#a866ee', '#edaa66', '#ee6d66', '#66edcd']

--- a/app/components/Dashboard/PortfolioPanel/index.js
+++ b/app/components/Dashboard/PortfolioPanel/index.js
@@ -1,13 +1,17 @@
 // @flow
-import { compose } from 'recompose'
-import { pick, omit } from 'lodash'
+import { compose, withProps } from 'recompose'
+import { pick, omit, reduce } from 'lodash'
 
 import PortfolioPanel from './PortfolioPanel'
+import pricesActions from '../../../actions/pricesActions'
 import balancesActions from '../../../actions/balancesActions'
 import withData from '../../../hocs/api/withData'
 import withCurrencyData from '../../../hocs/withCurrencyData'
 import { getTokenBalancesMap } from '../../../core/wallet'
+import { toNumber } from '../../../core/math'
 import { ASSETS } from '../../../core/constants'
+
+const mapPricesDataToProps = (prices) => ({ prices })
 
 const mapBalancesDataToProps = (balances) => ({
   balances: {
@@ -16,7 +20,15 @@ const mapBalancesDataToProps = (balances) => ({
   }
 })
 
+const mapTotalPortfolioValueToProps = ({ prices, balances }) => ({
+  total: reduce(balances, (result, balance, symbol) => {
+    return result + toNumber(balance) * (prices[symbol] || 0)
+  }, 0)
+})
+
 export default compose(
+  withData(pricesActions, mapPricesDataToProps),
   withData(balancesActions, mapBalancesDataToProps),
-  withCurrencyData()
+  withCurrencyData(),
+  withProps(mapTotalPortfolioValueToProps)
 )(PortfolioPanel)

--- a/app/components/Dashboard/PortfolioPanel/index.js
+++ b/app/components/Dashboard/PortfolioPanel/index.js
@@ -1,6 +1,6 @@
 // @flow
 import { compose, withProps } from 'recompose'
-import { pickBy, pick, omit, reduce } from 'lodash'
+import { pickBy, pick, omit, reduce, map } from 'lodash'
 
 import PortfolioPanel from './PortfolioPanel'
 import pricesActions from '../../../actions/pricesActions'
@@ -30,9 +30,20 @@ const mapTotalPortfolioValueToProps = ({ prices, balances }) => ({
   }, 0)
 })
 
+const mapPortfolioBalanceProps = ({ prices, balances, total }) => ({
+  balances: map(balances, (tokenBalance, symbol) => {
+    const balance = toNumber(tokenBalance)
+    const value = balance * (prices[symbol] || 0)
+    const percent = value / total
+
+    return { symbol, balance, value, percent }
+  })
+})
+
 export default compose(
   withData(pricesActions, mapPricesDataToProps),
   withData(balancesActions, mapBalancesDataToProps),
   withCurrencyData(),
-  withProps(mapTotalPortfolioValueToProps)
+  withProps(mapTotalPortfolioValueToProps),
+  withProps(mapPortfolioBalanceProps)
 )(PortfolioPanel)

--- a/app/components/Dashboard/PortfolioPanel/index.js
+++ b/app/components/Dashboard/PortfolioPanel/index.js
@@ -1,6 +1,6 @@
 // @flow
 import { compose, withProps } from 'recompose'
-import { pick, omit, reduce } from 'lodash'
+import { pickBy, pick, omit, reduce } from 'lodash'
 
 import PortfolioPanel from './PortfolioPanel'
 import pricesActions from '../../../actions/pricesActions'
@@ -8,16 +8,20 @@ import balancesActions from '../../../actions/balancesActions'
 import withData from '../../../hocs/api/withData'
 import withCurrencyData from '../../../hocs/withCurrencyData'
 import { getTokenBalancesMap } from '../../../core/wallet'
-import { toNumber } from '../../../core/math'
+import { toNumber, toBigNumber } from '../../../core/math'
 import { ASSETS } from '../../../core/constants'
+
+const removeEmptyBalances = (balances) => {
+  return pickBy(balances, (balance) => toBigNumber(balance).gt(0))
+}
 
 const mapPricesDataToProps = (prices) => ({ prices })
 
 const mapBalancesDataToProps = (balances) => ({
-  balances: {
+  balances: removeEmptyBalances({
     ...pick(balances, ASSETS.NEO, ASSETS.GAS),
     ...getTokenBalancesMap(omit(balances, 'NEO', 'GAS'))
-  }
+  })
 })
 
 const mapTotalPortfolioValueToProps = ({ prices, balances }) => ({

--- a/app/components/Dashboard/PortfolioPanel/index.js
+++ b/app/components/Dashboard/PortfolioPanel/index.js
@@ -1,0 +1,22 @@
+// @flow
+import { compose } from 'recompose'
+import { pick, omit } from 'lodash'
+
+import PortfolioPanel from './PortfolioPanel'
+import balancesActions from '../../../actions/balancesActions'
+import withData from '../../../hocs/api/withData'
+import withCurrencyData from '../../../hocs/withCurrencyData'
+import { getTokenBalancesMap } from '../../../core/wallet'
+import { ASSETS } from '../../../core/constants'
+
+const mapBalancesDataToProps = (balances) => ({
+  balances: {
+    ...pick(balances, ASSETS.NEO, ASSETS.GAS),
+    ...getTokenBalancesMap(omit(balances, 'NEO', 'GAS'))
+  }
+})
+
+export default compose(
+  withData(balancesActions, mapBalancesDataToProps),
+  withCurrencyData()
+)(PortfolioPanel)

--- a/app/components/Dashboard/TokenBalancesPanel/index.js
+++ b/app/components/Dashboard/TokenBalancesPanel/index.js
@@ -1,6 +1,6 @@
 // @flow
 import { compose } from 'recompose'
-import { values, omit } from 'lodash'
+import { filter, values, omit } from 'lodash'
 
 import TokenBalancesPanel from './TokenBalancesPanel'
 import balancesActions from '../../../actions/balancesActions'
@@ -10,9 +10,18 @@ import withNetworkData from '../../../hocs/withNetworkData'
 import withAuthData from '../../../hocs/withAuthData'
 import withCurrencyData from '../../../hocs/withCurrencyData'
 import withFilteredTokensData from '../../../hocs/withFilteredTokensData'
+import { toBigNumber } from '../../../core/math'
+
+const filterZeroBalanceTokens = (balances) => {
+  return filter(balances, (token) => toBigNumber(token.balance).gt(0))
+}
+
+const getTokenBalances = (balances) => {
+  return values(omit(balances, 'NEO', 'GAS'))
+}
 
 const mapBalanceDataToProps = (balances) => ({
-  balances: values(omit(balances, 'NEO', 'GAS'))
+  balances: filterZeroBalanceTokens(getTokenBalances(balances))
 })
 
 const mapBalancesActionsToProps = (actions, props) => ({

--- a/app/containers/Dashboard/Dashboard.jsx
+++ b/app/containers/Dashboard/Dashboard.jsx
@@ -4,6 +4,7 @@ import React, { Component } from 'react'
 import AssetBalancesPanel from '../../components/Dashboard/AssetBalancesPanel'
 import TokenBalancesPanel from '../../components/Dashboard/TokenBalancesPanel'
 import PriceHistoryPanel from '../../components/Dashboard/PriceHistoryPanel'
+import PortfolioPanel from '../../components/Dashboard/PortfolioPanel'
 import { log } from '../../util/Logs'
 
 import styles from './Dashboard.scss'
@@ -44,6 +45,7 @@ export default class Dashboard extends Component<Props> {
         </div>
         <div className={styles.chartsColumn}>
           <PriceHistoryPanel className={styles.pricesPanel} />
+          <PortfolioPanel className={styles.portfolioPanel} />
         </div>
       </div>
     )

--- a/app/containers/Dashboard/Dashboard.scss
+++ b/app/containers/Dashboard/Dashboard.scss
@@ -26,10 +26,18 @@
 
   .chartsColumn {
     flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
     min-width: 0;
 
-    // .pricesPanel {
-    //   flex: 0 0 auto;
-    // }
+    .pricesPanel {
+      flex: 0 0 auto;
+      margin-bottom: 24px;
+    }
+
+    .portfolioPanel {
+      flex: 1 1 auto;
+    }
   }
 }


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
This implements the new portfolio design into the v2 dashboard.  It also filters out zero-balance assets/tokens from both the token balances panel and the portfolio panel.

![screen shot 2018-02-28 at 11 54 38 pm](https://user-images.githubusercontent.com/169093/36829737-37aa1a44-1ce6-11e8-9782-33451c90d934.png)

**How did you solve this problem?**
* Added new panel component for portfolio panel
* Added portfolio chart component for donut
* Added portfolio table component
* Updated `pricesActions` to fetch full mapping of tokens to currency price.

**How did you make sure your solution works?**
Smoke tested it, compared the value & percentage calculations manually.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
