### PR TITLE
Updated to clear stale redux state on action success or failure

### DIFF
--- a/app/modules/api/request.js
+++ b/app/modules/api/request.js
@@ -41,9 +41,9 @@ function reduceRequest (state: State = initialState, actionState: ActionState): 
     case ACTION_REQUEST:
       return { ...state, state: LOADING, rollbackState: state.state }
     case ACTION_SUCCESS:
-      return { ...state, state: LOADED, rollbackState: LOADED, data: actionState.payload, loadedCount: state.loadedCount + 1 }
+      return { ...state, state: LOADED, rollbackState: LOADED, error: null, data: actionState.payload, loadedCount: state.loadedCount + 1 }
     case ACTION_FAILURE:
-      return { ...state, state: FAILED, rollbackState: FAILED, error: actionState.payload }
+      return { ...state, state: FAILED, rollbackState: FAILED, error: actionState.payload, data: null }
     case ACTION_RESET:
       return { ...state, ...initialState }
     case ACTION_CANCEL:


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
* If an action throws an error, it should clear the previously loaded data.
* If an action succeeds, it should clear the previous error message.

**How did you solve this problem?**
I updated the redux store for the current action when one of these scenarios occurs.

**How did you make sure your solution works?**
I visited the Ledger login screen and opened/closed the NEO app on it.  Previously, I saw both the success and error states on the login form.  Now I only see one or the other since the previous state is cleared.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
