### PR TITLE
Added short-term fix for resetting redux store keys on logout

### DIFF
--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -5,7 +5,9 @@ import { compose } from 'recompose'
 
 import appActions from '../../actions/appActions'
 import authActions from '../../actions/authActions'
-import accountActions from '../../actions/accountActions'
+import balancesActions from '../../actions/balancesActions'
+import claimsActions from '../../actions/claimsActions'
+import transactionHistoryActions from '../../actions/transactionHistoryActions'
 import networkActions from '../../actions/networkActions'
 import withFetch from '../../hocs/api/withFetch'
 import withReload from '../../hocs/api/withReload'
@@ -61,5 +63,8 @@ export default compose(
 
   // Remove stale data from store on logout
   withLogoutReset(authActions),
-  withLogoutReset(accountActions)
+  // TODO: replace these three calls with `withLogoutReset(accountActions)` once batch reset is fixes
+  withLogoutReset(balancesActions),
+  withLogoutReset(claimsActions),
+  withLogoutReset(transactionHistoryActions)
 )(App)


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Fixes #796.

**What problem does this PR solve?**
This resets the authenticated user's data when they logout from the wallet.  Without this, the next login during the same app session will end up displaying the previous account's data until the new data has loaded.

**How did you solve this problem?**
This is a temporary quick fix.  The issue is that calling `reset` on a batch action is not resulting in each associated action's `reset` function being called even though it should be.  (Specifically calling `reset` on accounts action should trigger `reset` for balances, claims, and transaction history.)

This fixes the issue for release.  I will circle back on a long term fix for batch resets.

**How did you make sure your solution works?**
Before fix:
* Logged in as user "A".
* Saw loading spinner, followed by user "A" account info.
* Logged out.
* Logged in as user "B".
* Saw user "A" account info, followed by user "B" account info.

After fix:
* Logged in as user "A".
* Saw loading spinner, followed by user "A" account info.
* Logged out.
* Logged in as user "B".
* Saw loading spinner, followed by user "B" account info.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
