### PR TITLE
Fixed ledger device description to remove $ signs

### DIFF
--- a/app/containers/LoginLedgerNanoS/LoginLedgerNanoS.jsx
+++ b/app/containers/LoginLedgerNanoS/LoginLedgerNanoS.jsx
@@ -56,7 +56,7 @@ export default class LoginLedgerNanoS extends Component<Props> {
     const { deviceInfo } = this.props
 
     if (deviceInfo) {
-      return <p>Found USB ${deviceInfo.manufacturer} ${deviceInfo.product}</p>
+      return <p>Found USB {deviceInfo.manufacturer} {deviceInfo.product}</p>
     } else {
       return <p>Looking for USB Devices. Please plugin your device and login.</p>
     }


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
#798 point 3:

> 3: $Ledger $Nano
>
> Once you have opened the NEO app, you see:
> 
> > Found USB $Ledger $Nano S
> 
> as opposed to 0.1.4:
> 
> > Found USB Ledger Nano S

**What problem does this PR solve?**
Removes leading $ signs from ledger device description.

**How did you solve this problem?**
Removed $ signs.

**How did you make sure your solution works?**
Smoke tested.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
