### PR TITLE
Fixed duplicate API requests

### DIFF
--- a/__tests__/components/__snapshots__/TransactionHistory.test.js.snap
+++ b/__tests__/components/__snapshots__/TransactionHistory.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TransactionHistory renders without crashing 1`] = `
-<withData(withProps(Connect(withData(Connect(withFetch(Connect(withData(Connect(withProgressProp(withProps(withoutProps(TransactionHistory))))))))))))
+<withData(withProps(Connect(withData(Connect(withData(Connect(withProgressProp(withProps(withoutProps(TransactionHistory))))))))))
   dispatch={[Function]}
   networkId="1"
   store={

--- a/app/containers/TransactionHistory/index.js
+++ b/app/containers/TransactionHistory/index.js
@@ -3,7 +3,6 @@ import { compose, withProps } from 'recompose'
 
 import TransactionHistory from './TransactionHistory'
 import transactionHistoryActions from '../../actions/transactionHistoryActions'
-import withFetch from '../../hocs/api/withFetch'
 import withData from '../../hocs/api/withData'
 import withProgressProp from '../../hocs/api/withProgressProp'
 import withNetworkData from '../../hocs/withNetworkData'
@@ -24,7 +23,6 @@ const mapLoadingProp = (props) => ({
 export default compose(
   withNetworkData(),
   withAuthData(),
-  withFetch(transactionHistoryActions),
   withData(transactionHistoryActions, mapTransactionsDataToProps),
 
   // pass `loading` boolean to component

--- a/app/sagas/batchSaga.js
+++ b/app/sagas/batchSaga.js
@@ -3,8 +3,6 @@ import { map } from 'lodash'
 import { put, take, race, all, call } from 'redux-saga/effects'
 import { type Saga } from 'redux-saga'
 
-import requestSaga from './requestSaga'
-import { isBatch } from '../util/api/helpers'
 import { actionMatcher } from '../util/api/matchers'
 import {
   BATCH_SUCCESS,
@@ -26,7 +24,6 @@ type SagaActions = {
 function createSagaActions (meta: ActionMeta): SagaActions {
   function * sagaForAction (state: Object, actionState: ActionState) {
     yield put(actionState)
-    yield isBatch(actionState) ? batchSaga(state, actionState) : requestSaga(state, actionState)
   }
 
   function * request (state: Object, requests: ActionStateMap) {


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
This fixes a pretty significant issue that I noticed where we're duplicating all batched actions.  This resulted in duplicate API calls, duplicate local storage lookups, etc.  We haven't been using batch actions for updates, but if we had been, it would have updated data twice.

**How did you solve this problem?**
I removed the effective duplicate call.

**How did you make sure your solution works?**
I smoke tested the app, saw that requests are being made only once, and the app still behaves as expected.

**Are there any special changes in the code that we should be aware of?**
The line removed and the one above it were having the same effect even though they were implemented differently.  I believe it was due to two attempts to perform the logic, and both were left it by mistake.

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
