### PR TITLE
Fixed issue with default tokens being deleted from local storage

### DIFF
--- a/app/actions/settingsActions.js
+++ b/app/actions/settingsActions.js
@@ -1,5 +1,5 @@
 // @flow
-import { pick, keys } from 'lodash'
+import { pick, keys, uniqBy } from 'lodash'
 
 import createRequestActions from '../util/api/createRequestActions'
 import { getStorage, setStorage } from '../core/storage'
@@ -20,10 +20,17 @@ const DEFAULT_SETTINGS: Settings = {
   tokens: getDefaultTokens()
 }
 
-const getSettings = async (): Promise<Settings> => ({
-  ...DEFAULT_SETTINGS,
-  ...await getStorage(STORAGE_KEY)
-})
+const getSettings = async (): Promise<Settings> => {
+  const defaults = DEFAULT_SETTINGS
+  const settings = await getStorage(STORAGE_KEY) || {}
+
+  const tokens = uniqBy([
+    ...defaults.tokens || [],
+    ...settings.tokens || []
+  ], (token) => [token.networkId, token.scriptHash].join('-'))
+
+  return { ...defaults, ...settings, tokens }
+}
 
 export const ID = 'SETTINGS'
 


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Fixes #797.

**What problem does this PR solve?**
There was a bug that allowed users to inadvertently delete default tokens from local storage.  This would result in the hardcoded tokens no longer rendering token amounts (e.g.: RPX) despite the settings screen showing that the token exists there.

**How did you solve this problem?**
I updated the logic around fetching settings from local storage to ensure that the default tokens are always included in the list of user tokens.

**How did you make sure your solution works?**
I verified that both default tokens and custom tokens are now included in the redux store data and display on the dashboard as expected.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
