### PR TITLE
Fixed retrying, resetting, and cancelling batch actions

### DIFF
--- a/__tests__/sagas/requestSaga.test.js
+++ b/__tests__/sagas/requestSaga.test.js
@@ -1,10 +1,10 @@
 import { call, take } from 'redux-saga/effects'
 import { cloneDeep, each, isFunction, isArray, isObject } from 'lodash'
 
-import requestSaga, { createSagaActions, retryAction } from '../../app/sagas/requestSaga'
+import requestSaga, { createSagaActions } from '../../app/sagas/requestSaga'
 import createRequestActions from '../../app/util/api/createRequestActions'
 import { actionMatcher } from '../../app/util/api/matchers'
-import { ACTION_RESET, ACTION_CANCEL } from '../../app/values/api'
+import { ACTION_RETRY, ACTION_RESET, ACTION_CANCEL } from '../../app/values/api'
 
 // treat functions in an object or array as equivalent in tests
 const matchFunctions = items => {
@@ -60,7 +60,7 @@ describe('requestSaga', () => {
 
   describe('retry action', () => {
     const retryState = step.RACE.retry.TAKE
-    const retry = take(retryAction(ID))
+    const retry = take(actionMatcher(ACTION_RETRY, ID))
 
     it('performs valid actions', () => {
       const validAction = actions.retry('foo')

--- a/__tests__/util/api/createBatchActions.js
+++ b/__tests__/util/api/createBatchActions.js
@@ -57,7 +57,8 @@ describe('createBatchActions', () => {
     expect(actions.reset()).toEqual({
       batch: true,
       type: 'BATCH/RESET',
-      meta: { id: BATCH_ID, type: 'BATCH/RESET' }
+      meta: { id: BATCH_ID, type: 'BATCH/RESET' },
+      payload: { requests: { one: reqActions1.reset(), two: reqActions2.reset() } }
     })
   })
 
@@ -65,7 +66,8 @@ describe('createBatchActions', () => {
     expect(actions.cancel()).toEqual({
       batch: true,
       type: 'BATCH/CANCEL',
-      meta: { id: BATCH_ID, type: 'BATCH/CANCEL' }
+      meta: { id: BATCH_ID, type: 'BATCH/CANCEL' },
+      payload: { requests: { one: reqActions1.cancel(), two: reqActions2.cancel() } }
     })
   })
 })

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -5,9 +5,7 @@ import { compose } from 'recompose'
 
 import appActions from '../../actions/appActions'
 import authActions from '../../actions/authActions'
-import balancesActions from '../../actions/balancesActions'
-import claimsActions from '../../actions/claimsActions'
-import transactionHistoryActions from '../../actions/transactionHistoryActions'
+import accountActions from '../../actions/accountActions'
 import networkActions from '../../actions/networkActions'
 import withFetch from '../../hocs/api/withFetch'
 import withReload from '../../hocs/api/withReload'
@@ -63,8 +61,5 @@ export default compose(
 
   // Remove stale data from store on logout
   withLogoutReset(authActions),
-  // TODO: replace these three calls with `withLogoutReset(accountActions)` once batch reset is fixes
-  withLogoutReset(balancesActions),
-  withLogoutReset(claimsActions),
-  withLogoutReset(transactionHistoryActions)
+  withLogoutReset(accountActions)
 )(App)

--- a/app/sagas/batchSaga.js
+++ b/app/sagas/batchSaga.js
@@ -23,12 +23,12 @@ type SagaActions = {
 }
 
 function createSagaActions (meta: ActionMeta): SagaActions {
-  function * sagaForAction (state: Object, actionState: ActionState) {
+  function * delegateAction (actionState: ActionState) {
     yield put(actionState)
   }
 
   function * request (state: Object, requests: ActionStateMap) {
-    yield all(map(requests, (actionState) => sagaForAction(state, actionState)))
+    yield all(map(requests, delegateAction))
     return true
   }
 

--- a/app/sagas/batchSaga.js
+++ b/app/sagas/batchSaga.js
@@ -7,6 +7,7 @@ import { actionMatcher } from '../util/api/matchers'
 import {
   BATCH_SUCCESS,
   BATCH_FAILURE,
+  BATCH_RETRY,
   BATCH_RESET,
   BATCH_CANCEL,
   type Error,
@@ -62,13 +63,14 @@ export default function * batchSaga (state: Object, actionState: ActionState): S
   const sagaActions = createSagaActions(actionState.meta)
 
   try {
-    const { cancelled } = yield race({
-      responses: call(sagaActions.request, state, payload.requests),
-      cancelled: take(actionMatcher(BATCH_CANCEL, id)),
+    const { cancel } = yield race({
+      request: call(sagaActions.request, state, payload.requests),
+      retry: take(actionMatcher(BATCH_RETRY, id)),
+      cancel: take(actionMatcher(BATCH_CANCEL, id)),
       reset: take(actionMatcher(BATCH_RESET, id))
     })
 
-    if (!cancelled) {
+    if (!cancel) {
       yield put(sagaActions.success())
     }
   } catch (err) {

--- a/app/sagas/index.js
+++ b/app/sagas/index.js
@@ -5,14 +5,26 @@ import { type Saga } from 'redux-saga'
 import batchSaga from './batchSaga'
 import requestSaga from './requestSaga'
 import { actionTypeMatcher } from '../util/api/matchers'
-import { ACTION_REQUEST, BATCH_REQUEST, type ActionState } from '../values/api'
+import {
+  ACTION_REQUEST,
+  BATCH_REQUEST,
+  BATCH_RETRY,
+  BATCH_RESET,
+  BATCH_CANCEL,
+  type ActionState
+} from '../values/api'
+
+const createMatchers = (actionTypes) => actionTypes.map(actionTypeMatcher)
+
+const batchMatchers = createMatchers([BATCH_REQUEST, BATCH_RETRY, BATCH_RESET, BATCH_CANCEL])
+const requestMatchers = createMatchers([ACTION_REQUEST])
 
 function batchAction (actionState: ActionState) {
-  return actionTypeMatcher(BATCH_REQUEST)(actionState)
+  return batchMatchers.some((matcher) => matcher(actionState))
 }
 
 function requestAction (actionState: ActionState) {
-  return actionTypeMatcher(ACTION_REQUEST)(actionState)
+  return requestMatchers.some((matcher) => matcher(actionState))
 }
 
 export default function * root (): Saga<void> {

--- a/app/sagas/requestSaga.js
+++ b/app/sagas/requestSaga.js
@@ -1,5 +1,4 @@
 // @flow
-import { get } from 'lodash'
 import { call, put, race, take } from 'redux-saga/effects'
 import { type Saga } from 'redux-saga'
 
@@ -24,10 +23,8 @@ type SagaActions = {
 
 export function createSagaActions (meta: ActionMeta): SagaActions {
   function * request (state: Object, payload: Payload, actions: SagaActions) {
-    const { fn } = payload
-
     try {
-      const result = yield call(fn, state)
+      const result = yield call(payload.fn, state)
       yield put(actions.success(result))
     } catch (err) {
       console.error(`${meta.id} request action failed.`, err)
@@ -57,7 +54,7 @@ export function createSagaActions (meta: ActionMeta): SagaActions {
 }
 
 export default function * requestSaga (state: Object, actionState: ActionState): Saga<boolean> {
-  const id = get(actionState, 'meta.id')
+  const { id } = actionState.meta
   const sagaActions = createSagaActions(actionState.meta)
 
   yield race({

--- a/app/sagas/requestSaga.js
+++ b/app/sagas/requestSaga.js
@@ -56,19 +56,13 @@ export function createSagaActions (meta: ActionMeta): SagaActions {
   return { request, success, failure }
 }
 
-export function retryAction (id: string): Function {
-  return (actionState: ActionState) => {
-    return actionMatcher(ACTION_RETRY, id)(actionState)
-  }
-}
-
 export default function * requestSaga (state: Object, actionState: ActionState): Saga<boolean> {
   const id = get(actionState, 'meta.id')
   const sagaActions = createSagaActions(actionState.meta)
 
   yield race({
     request: call(sagaActions.request, state, actionState.payload, sagaActions),
-    retry: take(retryAction(id)),
+    retry: take(actionMatcher(ACTION_RETRY, id)),
     cancel: take(actionMatcher(ACTION_CANCEL, id)),
     reset: take(actionMatcher(ACTION_RESET, id))
   })

--- a/app/util/api/createBatchActions.js
+++ b/app/util/api/createBatchActions.js
@@ -23,8 +23,8 @@ const actionTypes: ActionTypeMap = {
   RESET: BATCH_RESET
 }
 
-function mapActions (actionsMap: Object, actionName: string, props: Object = {}): RequestMapping {
-  return mapValues(actionsMap, (actions: Actions) => actions[actionName](props))
+function mapActions (actionsMap: Object, actionName: string, ...params: Array<any>): RequestMapping {
+  return mapValues(actionsMap, (actions: Actions) => actions[actionName](...params))
 }
 
 export default function createBatchActions (id: string, actionsMap: Object): Actions {
@@ -45,13 +45,15 @@ export default function createBatchActions (id: string, actionsMap: Object): Act
   const cancel = (): ActionState => ({
     batch: true,
     type: actionTypes.CANCEL,
-    meta: { type: BATCH_CANCEL, id }
+    meta: { type: BATCH_CANCEL, id },
+    payload: { requests: mapActions(actionsMap, 'cancel') }
   })
 
   const reset = (): ActionState => ({
     batch: true,
     type: actionTypes.RESET,
-    meta: { type: BATCH_RESET, id }
+    meta: { type: BATCH_RESET, id },
+    payload: { requests: mapActions(actionsMap, 'reset') }
   })
 
   return { id, request, retry, cancel, reset, actionTypes }


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
The basis of this change is to address a long-term fix for batch resets not working as expected.  This actually fixes related issues around resets and cancellations as well.  A short-term fix was implemented in #800, which this circles back on.

In addition, I cleaned up some differing logic between the action saga and batch saga to ensure they behave the same in similar scenarios.

**How did you solve this problem?**
I updated the saga matcher for batches to handle all 4 action types (requests, retries, resets, and cancellations), which then delegates to any child batch or child action.

**How did you make sure your solution works?**
I originally included a lot of console logging and debugger lines to step through the code.  Without those, the fix can be seen by logging out of the wallet and observing that all redux states associated with `appActions` properly get reset to their initial state.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [x] Unit tests written?
