### PR TITLE
Reverted load balancing change for transaction history

### DIFF
--- a/app/actions/transactionHistoryActions.js
+++ b/app/actions/transactionHistoryActions.js
@@ -14,7 +14,7 @@ type Props = {
 export const ID = 'TRANSACTION_HISTORY'
 
 export default createRequestActions(ID, ({ net, address }: Props = {}) => async (state: Object) => {
-  const transactions = await api.loadBalance(api.getTransactionHistoryFrom, { net, address })
+  const transactions = await api.neonDB.getTransactionHistory(net, address)
 
   return transactions.map(({ NEO, GAS, txid }: TransactionHistoryType) => ({
     txid,


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Fixes #813.

**What problem does this PR solve?**
Load balancing was added in several spots recently, but load balancing the transaction history is not working due to a bug in neon-js.  Specifically, the neonDB and neoscan API's return different values, and the neoscan API sometimes returns bad data.

**How did you solve this problem?**
I reverted the load balancing of transaction history to only fetch from neonDB based upon @snowypowers advice:

> i went with the alternative implementation  as it would allow you to just iterate the balance object for easy retrieval of the amts
> anyway dont wait on this change, i want to add more tests to make sure both sides sync up properly. will probably take a day more
> on a side note, i notice that neoscan doesnt have all transactions that neonDB shows and it also takes 8s just to pull the data.

**How did you make sure your solution works?**
Smoke tested.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
