### PR TITLE
Updated token list to hide zero balances

### DIFF
--- a/app/containers/WalletInfo/index.js
+++ b/app/containers/WalletInfo/index.js
@@ -2,7 +2,7 @@
 import { connect, type MapStateToProps } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import { compose } from 'recompose'
-import { values, omit } from 'lodash'
+import { values, omit, filter } from 'lodash'
 
 import accountActions from '../../actions/accountActions'
 import pricesActions from '../../actions/pricesActions'
@@ -26,10 +26,15 @@ const mapStateToProps: MapStateToProps<*, *, *> = (state: Object) => ({
   networks: getNetworks()
 })
 
+const getTokenBalances = (balances) => {
+  const tokens = values(omit(balances, 'NEO', 'GAS'))
+  return filter(tokens, (token) => token.balance !== '0')
+}
+
 const mapBalanceDataToProps = (balances) => ({
   NEO: balances.NEO,
   GAS: balances.GAS,
-  tokenBalances: values(omit(balances, 'NEO', 'GAS'))
+  tokenBalances: getTokenBalances(balances)
 })
 
 const mapPricesDataToProps = ({ NEO, GAS }) => ({


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Fixes #746.

**What problem does this PR solve?**
This hides any token balances of 0, since otherwise the list of tokens is overwhelmingly long for no reason.

**How did you solve this problem?**
I filtered out any tokens with a value of '0'.

**How did you make sure your solution works?**
Smoke tested and observed that only non-zero balances display.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
