### PR TITLE
Hide zero-balance tokens in send modal

### DIFF
--- a/app/components/Modals/SendModal/AddRecipientDisplay.jsx
+++ b/app/components/Modals/SendModal/AddRecipientDisplay.jsx
@@ -2,12 +2,14 @@
 import React from 'react'
 import classNames from 'classnames'
 import ArrowForward from 'react-icons/lib/md/arrow-forward'
+import { pickBy } from 'lodash'
 
 import Button from '../../Button'
 import NumberInput from '../../NumberInput'
 import AddressInput from '../../Inputs/AddressInput'
 import AssetInput from '../../Inputs/AssetInput'
 
+import { ASSETS } from '../../../core/constants'
 import { formatBalance, COIN_DECIMAL_LENGTH } from '../../../core/formatters'
 import { isToken } from '../../../core/wallet'
 
@@ -106,6 +108,8 @@ export default class AddRecipientDisplay extends React.Component<Props, State> {
   }
 
   getSymbols = () => {
-    return Object.keys(this.props.balances)
+    return Object.keys(pickBy(this.props.balances, (balance: string, symbol: string) => {
+      return [ASSETS.NEO, ASSETS.GAS].includes(symbol) || balance !== '0'
+    }))
   }
 }


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Fixes #746.

**What problem does this PR solve?**
In my [previous PR](https://github.com/CityOfZion/neon-wallet/pull/815), I updated the token list on the dashboard to hide zero balances.  This updates the send modal to exclude tokens with a zero balance from the dropdown.  NEO & GAS are always available as options.

**How did you solve this problem?**
I checked the symbol to keep NEO & GAS and check the balance to keep any non-zero amount.

**How did you make sure your solution works?**
Opened the send modal for various addresses that don't have NEO/GAS or only have 1-2 types of tokens.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
