### PR TITLE
Updated to poll for new claims before claiming GAS

### DIFF
--- a/__tests__/components/Claim.test.js
+++ b/__tests__/components/Claim.test.js
@@ -5,7 +5,7 @@ import { mount } from 'enzyme'
 
 import { createStore, provideStore } from '../testHelpers'
 import Claim from '../../app/containers/Claim'
-import { setClaimRequest, disableClaim } from '../../app/modules/claim'
+import { disableClaim } from '../../app/modules/claim'
 import { SHOW_NOTIFICATION } from '../../app/modules/notifications'
 import { NOTIFICATION_LEVELS, MAIN_NETWORK_ID } from '../../app/core/constants'
 import { LOADED } from '../../app/values/state'
@@ -85,13 +85,13 @@ describe('Claim', () => {
         type: SHOW_NOTIFICATION,
         payload: expect.objectContaining({
           level: NOTIFICATION_LEVELS.ERROR,
-          message: 'Transaction failed!'
+          message: 'Calculating claimable GAS failed.'
         })
       }))
       done()
     })
 
-    test('should dispatch transaction waiting, set claim request, and disable claim events', async (done) => {
+    test('should dispatch disable claim event', async (done) => {
       const store = createStore(initialState)
       const wrapper = mount(provideStore(<Claim />, store))
       neonjs.api.sendAsset = simulateSendAsset(true)
@@ -102,7 +102,6 @@ describe('Claim', () => {
 
       const actions = store.getActions()
 
-      expect(actions).toContainEqual(setClaimRequest(true))
       expect(actions).toContainEqual(disableClaim(true))
       done()
     })

--- a/__tests__/components/__snapshots__/Claim.test.js.snap
+++ b/__tests__/components/__snapshots__/Claim.test.js.snap
@@ -15,22 +15,14 @@ exports[`Claim should render claim GAS button as disabled 1`] = `
 >
   <Connect(Connect(withData(Claim)))>
     <Connect(withData(Claim))
-      checkClaimStatus={[Function]}
-      claimRequest={false}
       disableClaimButton={true}
-      doClaimNotify={[Function]}
       doGasClaim={[Function]}
-      setClaimRequest={[Function]}
     >
       <withData(Claim)
-        checkClaimStatus={[Function]}
         claimAmount="0.01490723"
-        claimRequest={false}
         disableClaimButton={true}
         dispatch={[Function]}
-        doClaimNotify={[Function]}
         doGasClaim={[Function]}
-        setClaimRequest={[Function]}
       >
         <div>
           <Tooltip
@@ -128,22 +120,14 @@ exports[`Claim should render claim GAS button as enabled 1`] = `
 >
   <Connect(Connect(withData(Claim)))>
     <Connect(withData(Claim))
-      checkClaimStatus={[Function]}
-      claimRequest={false}
       disableClaimButton={false}
-      doClaimNotify={[Function]}
       doGasClaim={[Function]}
-      setClaimRequest={[Function]}
     >
       <withData(Claim)
-        checkClaimStatus={[Function]}
         claimAmount="0.01490723"
-        claimRequest={false}
         disableClaimButton={false}
         dispatch={[Function]}
-        doClaimNotify={[Function]}
         doGasClaim={[Function]}
-        setClaimRequest={[Function]}
       >
         <div>
           <Tooltip
@@ -241,22 +225,14 @@ exports[`Claim should render without crashing 1`] = `
 >
   <Connect(Connect(withData(Claim)))>
     <Connect(withData(Claim))
-      checkClaimStatus={[Function]}
-      claimRequest={false}
       disableClaimButton={false}
-      doClaimNotify={[Function]}
       doGasClaim={[Function]}
-      setClaimRequest={[Function]}
     >
       <withData(Claim)
-        checkClaimStatus={[Function]}
         claimAmount="0.01490723"
-        claimRequest={false}
         disableClaimButton={false}
         dispatch={[Function]}
-        doClaimNotify={[Function]}
         doGasClaim={[Function]}
-        setClaimRequest={[Function]}
       >
         <div>
           <Tooltip

--- a/app/containers/Claim/Claim.jsx
+++ b/app/containers/Claim/Claim.jsx
@@ -7,58 +7,38 @@ import { formatGAS } from '../../core/formatters'
 import { toBigNumber } from '../../core/math'
 
 type Props = {
-  doClaimNotify: Function,
-  setClaimRequest: Function,
   doGasClaim: Function,
-  checkClaimStatus: Function,
-  claimRequest: boolean,
   disableClaimButton: boolean,
-  claimAmount: string,
-  finalizeClaim: boolean
+  claimAmount: string
 }
-
-const POLL_FREQUENCY = 5000
 
 export default class Claim extends Component<Props> {
   intervalId: ?number
 
-  componentDidUpdate (prevProps: Props) {
-    const { claimRequest, doClaimNotify, setClaimRequest, finalizeClaim, checkClaimStatus } = this.props
-    if (claimRequest && !prevProps.claimRequest) {
-      setClaimRequest(false)
-      this.intervalId = setInterval(checkClaimStatus, POLL_FREQUENCY)
-    }
-    if (finalizeClaim && !prevProps.finalizeClaim) {
-      doClaimNotify()
-      this.stopPolling()
-    }
-  }
-
-  componentWillUnmount () {
-    this.stopPolling()
-  }
-
-  stopPolling = () => {
-    if (this.intervalId) {
-      clearInterval(this.intervalId)
-    }
-  }
-
   render () {
-    const { claimAmount, disableClaimButton, doGasClaim } = this.props
-    const shouldDisableButton = disableClaimButton || toBigNumber(claimAmount).eq(0)
-    const formattedAmount = formatGAS(claimAmount)
+    const disabled = this.isDisabled()
+
     return (
       <div>
-        <Tooltip
-          title='You can claim GAS once every 5 minutes'
-          disabled={!disableClaimButton}
-        >
-          <Button id='claim' disabled={shouldDisableButton} onClick={doGasClaim}>
-            Claim {formattedAmount} GAS
+        <Tooltip title='You can claim GAS once every 5 minutes' disabled={!disabled}>
+          <Button id='claim' disabled={disabled} onClick={this.handleClaim}>
+            Claim {this.getFormattedAmount()} GAS
           </Button>
         </Tooltip>
       </div>
     )
+  }
+
+  handleClaim = () => {
+    this.props.doGasClaim()
+  }
+
+  isDisabled = () => {
+    const { claimAmount, disableClaimButton } = this.props
+    return disableClaimButton || toBigNumber(claimAmount).eq(0)
+  }
+
+  getFormattedAmount = () => {
+    return formatGAS(this.props.claimAmount)
   }
 }

--- a/app/containers/Claim/index.js
+++ b/app/containers/Claim/index.js
@@ -6,30 +6,13 @@ import { compose } from 'recompose'
 import Claim from './Claim'
 import claimsActions from '../../actions/claimsActions'
 import withData from '../../hocs/api/withData'
-import {
-  setClaimRequest,
-  doGasClaim,
-  doClaimNotify,
-  getClaimRequest,
-  getDisableClaimButton,
-  getFinalizeClaim,
-  checkClaimStatus
-} from '../../modules/claim'
+import { doGasClaim, getDisableClaimButton } from '../../modules/claim'
 
 const mapStateToProps = (state: Object) => ({
-  finalizeClaim: getFinalizeClaim(state),
-  claimRequest: getClaimRequest(state),
   disableClaimButton: getDisableClaimButton(state)
 })
 
-const actionCreators = {
-  setClaimRequest,
-  doGasClaim,
-  doClaimNotify,
-  checkClaimStatus
-}
-
-const mapDispatchToProps = dispatch => bindActionCreators(actionCreators, dispatch)
+const mapDispatchToProps = (dispatch) => bindActionCreators({ doGasClaim }, dispatch)
 
 const mapClaimsDataToProps = (claims) => ({
   claimAmount: claims.total

--- a/app/modules/claim.js
+++ b/app/modules/claim.js
@@ -1,5 +1,6 @@
 // @flow
-import { api, rpc } from 'neon-js'
+import { api, type Claims } from 'neon-js'
+import { map, reduce } from 'lodash'
 
 import {
   showErrorNotification,
@@ -15,38 +16,119 @@ import {
   getIsHardwareLogin,
   getNEO
 } from '../core/deprecated'
+import { toBigNumber, toNumber } from '../core/math'
 import { ASSETS } from '../core/constants'
 import { FIVE_MINUTES_MS } from '../core/time'
+import poll from '../util/poll'
 
-import { log } from '../util/Logs'
+const POLL_ATTEMPTS = 50
+const POLL_FREQUENCY = 5000
+
+const fetchClaims = async ({ net, address }) => {
+  const response = await api.loadBalance(api.getClaimsFrom, { net, address })
+  const { claims } = response.claims
+  return map(claims, 'claim')
+}
+
+const calculateClaimableAmount = (claims: Claims) => {
+  return reduce(claims, (sum, claim) => claim.plus(sum), 0).toString()
+}
+
+const getClaimableAmount = async ({ net, address }) => {
+  const claims = await fetchClaims({ net, address })
+  return calculateClaimableAmount(claims)
+}
+
+const updateClaimableAmount = async ({ net, address, publicKey, privateKey, signingFunction, balance }) => {
+  const { response } = await api.sendAsset({
+    net,
+    address,
+    publicKey,
+    privateKey,
+    signingFunction,
+    intents: api.makeIntent({ [ASSETS.NEO]: toNumber(balance) }, address)
+  })
+
+  if (!response.result || !response.txid) {
+    throw new Error('Transaction failed!')
+  }
+
+  return response.result.response
+}
+
+const pollForUpdatedClaimableAmount = async ({ net, address, claimableAmount }) => {
+  return poll(async () => {
+    const updatedClaimableAmount = await getClaimableAmount({ net, address })
+
+    if (toBigNumber(updatedClaimableAmount).eq(claimableAmount)) {
+      throw new Error('Waiting for updated claims')
+    }
+
+    return updatedClaimableAmount
+  }, { attempts: POLL_ATTEMPTS, frequency: POLL_FREQUENCY })
+}
+
+const getUpdatedClaimableAmount = async ({ net, address, balance, publicKey, privateKey, signingFunction }) => {
+  const claimableAmount = await getClaimableAmount({ net, address })
+
+  if (toBigNumber(balance).eq(0)) {
+    return claimableAmount
+  } else {
+    await updateClaimableAmount({ net, address, balance, publicKey, privateKey, signingFunction })
+    return pollForUpdatedClaimableAmount({ net, address, claimableAmount })
+  }
+}
+
+export const doGasClaim = () => async (dispatch: DispatchType, getState: GetStateType) => {
+  const state = getState()
+  const address = getAddress(state)
+  const net = getNetwork(state)
+  const balance = getNEO(state)
+  const publicKey = getPublicKey(state)
+  const privateKey = getWIF(state)
+  const signingFunction = getSigningFunction(state)
+  const isHardwareClaim = getIsHardwareLogin(state)
+
+  dispatch(disableClaim(true))
+
+  if (isHardwareClaim) {
+    dispatch(showInfoNotification({ message: 'Please sign transaction on hardware device.' }))
+  }
+
+  try {
+    await getUpdatedClaimableAmount({ net, address, balance, publicKey, privateKey, signingFunction })
+  } catch (err) {
+    dispatch(disableClaim(false))
+    dispatch(showErrorNotification({ message: 'Calculating claimable GAS failed.' }))
+    return
+  }
+
+  if (isHardwareClaim) {
+    dispatch(showInfoNotification({ message: 'Please sign transaction on hardware device.' }))
+  }
+
+  try {
+    const { response } = await api.claimGas({ net, address, publicKey, privateKey, signingFunction })
+
+    if (!response.result) {
+      throw new Error('Claiming GAS failed')
+    }
+  } catch (err) {
+    dispatch(disableClaim(false))
+    dispatch(showErrorNotification({ message: 'Claiming GAS failed.' }))
+    return
+  }
+
+  dispatch(showSuccessNotification({
+    message: 'Claim was successful! Your balance will update once the blockchain has processed it.'
+  }))
+  setTimeout(() => dispatch(disableClaim(false)), FIVE_MINUTES_MS)
+}
 
 // Constants
-export const SET_CLAIM_REQUEST = 'SET_CLAIM_REQUEST'
 export const DISABLE_CLAIM = 'DISABLE_CLAIM'
-export const SET_FINALIZE_CLAIM = 'SET_FINALIZE_CLAIM'
-export const SET_TRANSACTION_ID = 'SET_TRANSACTION_ID'
 
 // Actions
-export function setClaimRequest (claimRequest: boolean) {
-  return {
-    type: SET_CLAIM_REQUEST,
-    payload: { claimRequest }
-  }
-}
-export function setTransactionId (transactionId: string) {
-  return {
-    type: SET_TRANSACTION_ID,
-    payload: { transactionId }
-  }
-}
-
-export function setFinalizeClaim (finalizeClaim: boolean) {
-  return {
-    type: SET_FINALIZE_CLAIM,
-    payload: { finalizeClaim }
-  }
-}
-
 export function disableClaim (disableClaimButton: boolean) {
   return {
     type: DISABLE_CLAIM,
@@ -54,151 +136,15 @@ export function disableClaim (disableClaimButton: boolean) {
   }
 }
 
-export const doClaimNotify = () => async (
-  dispatch: DispatchType,
-  getState: GetStateType
-) => {
-  const state = getState()
-  const address = getAddress(state)
-  const net = getNetwork(state)
-  const signingFunction = getSigningFunction(state)
-  const publicKey = getPublicKey(state)
-  const privateKey = getWIF(state)
-  const isHardwareClaim = getIsHardwareLogin(state)
-
-  log(net, 'CLAIM', address, { info: 'claim all GAS' })
-
-  if (isHardwareClaim) {
-    dispatch(showInfoNotification({
-      message: 'Sign transaction 2 of 2 to claim GAS on your hardware device (claiming GAS)',
-      autoDismiss: 0
-    }))
-  }
-
-  try {
-    const { response } = await api.claimGas({ net, address, publicKey, privateKey, signingFunction })
-    dispatch(setFinalizeClaim(false))
-
-    if (!response.result) {
-      throw new Error('Claim failed')
-    }
-
-    dispatch(showSuccessNotification({
-      message: 'Claim was successful! Your balance will update once the blockchain has processed it.'
-    }))
-    setTimeout(() => dispatch(disableClaim(false)), FIVE_MINUTES_MS)
-  } catch (err) {
-    return dispatch(showErrorNotification({ message: 'Claim failed' }))
-  }
-}
-
-// To initiate claim, first send all NEO to own address, the set claimRequest state
-// When new claims are available, this will trigger the claim
-export const doGasClaim = () => async (
-  dispatch: DispatchType,
-  getState: GetStateType
-) => {
-  const state = getState()
-  const address = getAddress(state)
-  const net = getNetwork(state)
-  const NEO = getNEO(state)
-  const publicKey = getPublicKey(state)
-  const privateKey = getWIF(state)
-  const signingFunction = getSigningFunction(state)
-  const isHardwareClaim = getIsHardwareLogin(state)
-
-  // if no NEO in account, no need to send to self first
-  if (NEO === '0') {
-    return dispatch(doClaimNotify())
-  } else {
-    dispatch(showInfoNotification({
-      message: 'Sending NEO to Yourself...',
-      autoDismiss: 0
-    }))
-    log(net, 'SEND', address, { to: address, amount: NEO, asset: ASSETS.NEO })
-
-    if (isHardwareClaim) {
-      dispatch(showInfoNotification({
-        message: 'Sign transaction 1 of 2 to claim GAS on your hardware device (sending NEO to yourself)',
-        autoDismiss: 0
-      }))
-    }
-
-    try {
-      const { response } = await api.sendAsset({
-        net,
-        address,
-        publicKey,
-        privateKey,
-        signingFunction,
-        intents: api.makeIntent({ [ASSETS.NEO]: NEO }, address)
-      })
-
-      if (!response.result || !response.txid) {
-        throw new Error('Transaction failed!')
-      }
-
-      dispatch(showInfoNotification({
-        message: 'Waiting for transaction to clear...',
-        autoDismiss: 0
-      }))
-      dispatch(setTransactionId(response.txid))
-      dispatch(setClaimRequest(true))
-      return dispatch(disableClaim(true))
-    } catch (err) {
-      return dispatch(showErrorNotification({ message: 'Transaction failed!' }))
-    }
-  }
-}
-
-export const checkClaimStatus = () => async (
-  dispatch: DispatchType,
-  getState: GetStateType
-) => {
-  const state = getState()
-  const net = getNetwork(state)
-  const txid = getTransactionId(state)
-  const endpoint = await api.loadBalance(api.getRPCEndpointFrom, { net })
-  const response = await rpc.Query.getRawTransaction(txid).execute(endpoint)
-  if (response.result && response.result.blockhash && response.result.confirmations) {
-    dispatch(setTransactionId(''))
-    dispatch(setFinalizeClaim(true))
-  }
-}
-
 // State Getters
-export const getFinalizeClaim = (state: Object) => state.claim.finalizeClaim
-export const getClaimRequest = (state: Object) => state.claim.claimRequest
 export const getDisableClaimButton = (state: Object) => state.claim.disableClaimButton
-export const getTransactionId = (state: Object) => state.claim.transactionId
 
 const initialState = {
-  claimRequest: false,
-  disableClaimButton: false,
-  transactionId: '',
-  finalizeClaim: false
+  disableClaimButton: false
 }
 
 export default (state: Object = initialState, action: ReduxAction) => {
   switch (action.type) {
-    case SET_TRANSACTION_ID:
-      const { transactionId } = action.payload
-      return {
-        ...state,
-        transactionId
-      }
-    case SET_FINALIZE_CLAIM:
-      const { finalizeClaim } = action.payload
-      return {
-        ...state,
-        finalizeClaim
-      }
-    case SET_CLAIM_REQUEST:
-      const { claimRequest } = action.payload
-      return {
-        ...state,
-        claimRequest
-      }
     case DISABLE_CLAIM:
       const { disableClaimButton } = action.payload
       return {

--- a/app/util/delay.js
+++ b/app/util/delay.js
@@ -1,0 +1,5 @@
+export default function delay (duration) {
+  return new Promise((resolve) => {
+    setTimeout(() => { resolve() }, duration)
+  })
+}

--- a/app/util/poll.js
+++ b/app/util/poll.js
@@ -1,0 +1,14 @@
+import delay from './delay'
+
+const DEFAULT_ATTEMPTS = Infinity
+const DEFAULT_FREQUENCY = 1000
+
+export default function poll (request, { attempts = DEFAULT_ATTEMPTS, frequency = DEFAULT_FREQUENCY } = {}) {
+  return request().catch(function retry (err) {
+    if (attempts-- > 0) {
+      return delay(frequency).then(request).catch(retry)
+    } else {
+      throw err
+    }
+  })
+}


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Pretty much all the GitHub issues around claiming GAS.

**What problem does this PR solve?**
This PR ensures that, when claiming GAS, we perform two actions and wait for them to complete:

* send all NEO to the current address
* poll to wait for updated list of claims for the current address

Note that these two actions only occur if the NEO balance > 0.  Otherwise, GAS claim immediately occurs.

**How did you solve this problem?**
I refactored the behavior between the claim component and the claim module.  Rather than the component trying to manage the entire claim request lifecycle, it instead just kicks off the claim when the user click's the claim button.  The module now manages the entire lifecycle, which includes the steps outlined above.

Because of this change, much code cleanup occurred due to additional redux states and actions no longer being needed.

**How did you make sure your solution works?**
I tested on MainNet and TestNet using an address with 0 NEO and an address with >0 NEO.  I have not yet test Ledger (happening now).

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [x] Unit tests written?
