### PR TITLE
Fixed issue with missing asset key in balances response

### DIFF
--- a/app/actions/balancesActions.js
+++ b/app/actions/balancesActions.js
@@ -38,11 +38,13 @@ async function getBalances ({ net, address, tokens }: Props) {
   // asset balances
   promises.push((async () => {
     const assetBalances = await api.loadBalance(api.getBalanceFrom, { net, address })
+    const { assets } = assetBalances.balance
 
-    return {
-      [ASSETS.NEO]: assetBalances.balance.assets.NEO.balance.toString(),
-      [ASSETS.GAS]: assetBalances.balance.assets.GAS.balance.round(COIN_DECIMAL_LENGTH).toString()
-    }
+    // The API doesn't always return NEO or GAS keys if, for example, the address only has one asset
+    const neoBalance = assets.NEO ? assets.NEO.balance.toString() : '0'
+    const gasBalance = assets.GAS ? assets.GAS.balance.round(COIN_DECIMAL_LENGTH).toString() : '0'
+
+    return { [ASSETS.NEO]: neoBalance, [ASSETS.GAS]: gasBalance }
   })())
 
   return extend({}, ...await Promise.all(promises))


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
Sometimes when we get an API response back for asset balances, it *only* includes a GAS key *or* a NEO key; not both.  In such circumstances, we can assume the balance is '0'.  Without this change, an error is raised, and the app just shows a white screen.

**How did you solve this problem?**
I short-circuited to return '0' for either asset balance if the key is not set.

**How did you make sure your solution works?**
Logged into an account that has only ever had GAS and no NEO.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
@snowypowers This might be worth fixing on the neon-js side of things.

- [ ] Unit tests written?
