### PR TITLE
Updated version comparison to only notify for older versions

### DIFF
--- a/__tests__/modules/metadata.test.js
+++ b/__tests__/modules/metadata.test.js
@@ -1,0 +1,50 @@
+import axios from 'axios'
+import MockAdapter from 'axios-mock-adapter'
+
+import { checkVersion } from '../../app/modules/metadata'
+import * as notifications from '../../app/modules/notifications'
+import { TEST_NETWORK_ID } from '../../app/core/networks'
+import { version } from '../../package.json'
+
+const axiosMock = new MockAdapter(axios)
+
+describe('metadata module tests', () => {
+  describe('checkVersion tests', () => {
+    const dispatch = jest.fn()
+    const getState = () => ({ api: { NETWORK: TEST_NETWORK_ID } })
+
+    const generateNewerVersion = (version) => {
+      const parts = version.split('.')
+      const last = parts.pop()
+      return [...parts, parseInt(last) + 1].join('.')
+    }
+
+    test('it does not show a warning when the versions match', async (done) => {
+      const spy = jest.spyOn(notifications, 'showWarningNotification')
+
+      axiosMock
+        .onGet('http://testnet-api.wallet.cityofzion.io/v2/version')
+        .reply(200, { version })
+
+      await checkVersion()(dispatch, getState)
+      expect(spy).not.toHaveBeenCalled()
+
+      axiosMock.restore()
+      done()
+    })
+
+    test.only("it shows a wraning when the versions don't match", async (done) => {
+      const spy = jest.spyOn(notifications, 'showWarningNotification')
+
+      axiosMock
+        .onGet('http://testnet-api.wallet.cityofzion.io/v2/version')
+        .reply(200, { version: generateNewerVersion(version) })
+
+      await checkVersion()(dispatch, getState)
+      expect(spy).toHaveBeenCalled()
+
+      axiosMock.restore()
+      done()
+    })
+  })
+})

--- a/app/modules/metadata.js
+++ b/app/modules/metadata.js
@@ -1,12 +1,14 @@
 // @flow
 import axios from 'axios'
 import { api } from 'neon-js'
+import compareVersions from 'compare-versions'
 
 import { showWarningNotification } from './notifications'
-import asyncWrap from '../core/asyncHelper'
 import { getNetwork } from '../core/deprecated'
 import { NEON_WALLET_RELEASE_LINK, NOTIFICATION_POSITIONS } from '../core/constants'
 import { version } from '../../package.json'
+
+const DOWNLOAD_LINK = `<a href='${NEON_WALLET_RELEASE_LINK}' target='_blank' class="notification-link">${NEON_WALLET_RELEASE_LINK}</a>`
 
 // Actions
 export const checkVersion = () => async (dispatch: DispatchType, getState: GetStateType) => {
@@ -14,20 +16,23 @@ export const checkVersion = () => async (dispatch: DispatchType, getState: GetSt
   const net = getNetwork(state)
   const apiEndpoint = api.neonDB.getAPIEndpoint(net)
 
-  const [err, res] = await asyncWrap(axios.get(`${apiEndpoint}/v2/version`))
-  const shouldUpdate = res && res.data && res.data.version !== version
-  if (err || shouldUpdate) {
-    const link = `<a href='${NEON_WALLET_RELEASE_LINK}' target='_blank' class="notification-link">${NEON_WALLET_RELEASE_LINK}</a>`
-    const message = err
-      ? `Error checking wallet version! Please make sure you have downloaded the latest version: ${link}`
-      : `Your wallet is out of date! Please download the latest version from ${link}`
-    return dispatch(
-      showWarningNotification({
-        message,
-        autoDismiss: 0,
-        stack: true,
-        position: NOTIFICATION_POSITIONS.BOTTOM_CENTER
-      })
-    )
+  const showError = (message) => {
+    return dispatch(showWarningNotification({
+      message,
+      autoDismiss: 0,
+      stack: true,
+      position: NOTIFICATION_POSITIONS.BOTTOM_CENTER
+    }))
+  }
+
+  try {
+    const response = await axios.get(`${apiEndpoint}/v2/version`)
+    const shouldUpdate = response && response.data && compareVersions(version, response.data.version) === -1
+
+    if (shouldUpdate) {
+      showError(`Your wallet is out of date! Please download the latest version from ${DOWNLOAD_LINK}`)
+    }
+  } catch (err) {
+    showError(`Error checking wallet version! Please make sure you have downloaded the latest version: ${DOWNLOAD_LINK}`)
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "buffer": "5.0.8",
     "classnames": "2.2.5",
     "cleave.js": "1.0.7",
+    "compare-versions": "^3.1.0",
     "coveralls": "3.0.0",
     "electron-context-menu": "0.9.1",
     "electron-json-storage": "4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2336,6 +2336,10 @@ compare-version@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/compare-version/-/compare-version-0.1.2.tgz#0162ec2d9351f5ddd59a9202cba935366a725080"
 
+compare-versions@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.1.0.tgz#43310256a5c555aaed4193c04d8f154cf9c6efd5"
+
 component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
This changes the behavior for the "your wallet is out of date" notification to only display the notification if the version is older than the latest version.  This will ensure that wallets with a *newer* version than we track in the neon DB do not see the notification, which has historically confused users.

**How did you solve this problem?**
I added the [`compare-versions` package](https://www.npmjs.com/package/compare-versions) and used it to compare the currently installed package version to the latest available version.

**How did you make sure your solution works?**
I added tests!

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [x] Unit tests written?
