### PR TITLE
Restored claiming gas messaging for clarity

### DIFF
--- a/app/modules/claim.js
+++ b/app/modules/claim.js
@@ -92,7 +92,7 @@ export const doGasClaim = () => async (dispatch: DispatchType, getState: GetStat
   dispatch(disableClaim(true))
 
   if (isHardwareClaim) {
-    dispatch(showInfoNotification({ message: 'Please sign transaction on hardware device.' }))
+    dispatch(showInfoNotification({ message: 'Please sign transaction 1 of 2 on hardware device.' }))
   } else {
     dispatch(showInfoNotification({ message: 'Calculating claimable GAS...' }))
   }
@@ -107,7 +107,7 @@ export const doGasClaim = () => async (dispatch: DispatchType, getState: GetStat
   }
 
   if (isHardwareClaim) {
-    dispatch(showInfoNotification({ message: 'Please sign transaction on hardware device.' }))
+    dispatch(showInfoNotification({ message: 'Please sign transaction 2 of 2 on hardware device.' }))
   } else {
     dispatch(showInfoNotification({ message: 'Claiming GAS...' }))
   }
@@ -117,7 +117,7 @@ export const doGasClaim = () => async (dispatch: DispatchType, getState: GetStat
     const { response } = await api.claimGas({ net, address, publicKey, privateKey, signingFunction })
 
     if (!response.result) {
-      throw new Error('Claiming GAS failed.')
+      throw new Error('Claiming GAS failed')
     }
   } catch (err) {
     dispatch(disableClaim(false))

--- a/app/modules/claim.js
+++ b/app/modules/claim.js
@@ -93,8 +93,11 @@ export const doGasClaim = () => async (dispatch: DispatchType, getState: GetStat
 
   if (isHardwareClaim) {
     dispatch(showInfoNotification({ message: 'Please sign transaction on hardware device.' }))
+  } else {
+    dispatch(showInfoNotification({ message: 'Calculating claimable GAS...' }))
   }
 
+  // step 1: update available claims
   try {
     await getUpdatedClaimableAmount({ net, address, balance, publicKey, privateKey, signingFunction })
   } catch (err) {
@@ -105,13 +108,16 @@ export const doGasClaim = () => async (dispatch: DispatchType, getState: GetStat
 
   if (isHardwareClaim) {
     dispatch(showInfoNotification({ message: 'Please sign transaction on hardware device.' }))
+  } else {
+    dispatch(showInfoNotification({ message: 'Claiming GAS...' }))
   }
 
+  // step 2: send claim request
   try {
     const { response } = await api.claimGas({ net, address, publicKey, privateKey, signingFunction })
 
     if (!response.result) {
-      throw new Error('Claiming GAS failed')
+      throw new Error('Claiming GAS failed.')
     }
   } catch (err) {
     dispatch(disableClaim(false))


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
#832

**What problem does this PR solve?**
This restores some of the additional messaging for the Ledger and non-Ledger flows:

* Ledger users see "1 of 2" and "2 of 2" in the signing notifications, better guiding through the cliam process.
* Non-Ledger users will now see an initial notification when claiming starts.  Without this, the user is only informed *after* claiming has succeeded, which can take upwards of 30 seconds easily.

**How did you solve this problem?**
I added some dispatched notifications that were lost during a previous fix around this feature.

**How did you make sure your solution works?**
I claimed GAS with & without a Ledger.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
