### PR TITLE
Fixed private key login to only permit private key or WIF

### DIFF
--- a/__mocks__/neon-js.js
+++ b/__mocks__/neon-js.js
@@ -87,7 +87,10 @@ neonjs.wallet = {
   Account: jest.fn(() => { return { address } }),
   getVerificationScriptFromPublicKey: jest.fn(() => scriptHash),
   isAddress: jest.fn(() => true),
-  isNEP2: jest.fn(() => true)
+  isNEP2: jest.fn(() => true),
+  isWIF: jest.fn(() => false),
+  isPrivateKey: jest.fn(() => false),
+  isPublicKey: jest.fn(() => false)
 }
 
 module.exports = neonjs

--- a/__tests__/actions/authActions.test.js
+++ b/__tests__/actions/authActions.test.js
@@ -1,0 +1,132 @@
+import { wallet } from 'neon-js'
+
+import { wifLoginActions } from '../../app/actions/authActions'
+
+describe('authActions', () => {
+  describe('wifLoginActions', () => {
+    describe('request', () => {
+      const wif = 'KxB52D1FGe5xBn6YeezNwj7grhkHZxq7bv2tmaCPoT4rxApMwMvU'
+      const address = 'ASJQLBnhAs6fSgBv2R7KtRZjC8A9fAmcNW'
+      const privateKey = '1c7a992d0e68b7b23cb430ba596bd68cecde042410d81e9e95ee19dc1bcd739d'
+
+      test('returns an action object', () => {
+        expect(wifLoginActions.request({ wif })).toEqual({
+          batch: false,
+          type: 'AUTH/REQ/REQUEST',
+          meta: {
+            id: 'AUTH',
+            type: 'REQ/REQUEST'
+          },
+          payload: {
+            fn: expect.any(Function)
+          }
+        })
+      })
+
+      describe('with valid WIF', () => {
+        let wifMock, keyMock, accountMock
+
+        beforeEach(() => {
+          wifMock = jest.spyOn(wallet, 'isWIF').mockImplementation((str) => false)
+          keyMock = jest.spyOn(wallet, 'isPrivateKey').mockImplementation((str) => true)
+          accountMock = jest.spyOn(wallet, 'Account').mockImplementation((str) => ({ WIF: wif, address }))
+        })
+
+        afterEach(() => {
+          wifMock.mockRestore()
+          keyMock.mockRestore()
+          accountMock.mockRestore()
+        })
+
+        test('returns authenticated account data', () => {
+          const request = wifLoginActions.request({ wif })
+          expect(request.payload.fn({})).toEqual({ wif, address, isHardwareLogin: false })
+        })
+      })
+
+      describe('with valid private key', () => {
+        let wifMock, keyMock, accountMock
+
+        beforeEach(() => {
+          wifMock = jest.spyOn(wallet, 'isWIF').mockImplementation((str) => false)
+          keyMock = jest.spyOn(wallet, 'isPrivateKey').mockImplementation((str) => true)
+          accountMock = jest.spyOn(wallet, 'Account').mockImplementation((str) => ({ WIF: wif, address }))
+        })
+
+        afterEach(() => {
+          wifMock.mockRestore()
+          keyMock.mockRestore()
+          accountMock.mockRestore()
+        })
+
+        test('returns authenticated account data', () => {
+          const request = wifLoginActions.request({ wif: privateKey })
+          expect(request.payload.fn({})).toEqual({ wif, address, isHardwareLogin: false })
+        })
+      })
+
+      describe('with invalid private key', () => {
+        let wifMock, keyMock
+
+        beforeEach(() => {
+          wifMock = jest.spyOn(wallet, 'isWIF').mockImplementation((str) => false)
+          keyMock = jest.spyOn(wallet, 'isPrivateKey').mockImplementation((str) => false)
+        })
+
+        afterEach(() => {
+          wifMock.mockRestore()
+          keyMock.mockRestore()
+        })
+
+        test('throws an error', () => {
+          const request = wifLoginActions.request({ wif })
+          expect(() => request.payload.fn({})).toThrowError('That is not a valid private key')
+        })
+      })
+    })
+
+    describe('retry', () => {
+      const wif = 'KxB52D1FGe5xBn6YeezNwj7grhkHZxq7bv2tmaCPoT4rxApMwMvU'
+
+      test('returns an action object', () => {
+        expect(wifLoginActions.retry({ wif })).toEqual({
+          batch: false,
+          type: 'AUTH/REQ/RETRY',
+          meta: {
+            id: 'AUTH',
+            type: 'REQ/RETRY'
+          },
+          payload: {
+            fn: expect.any(Function)
+          }
+        })
+      })
+    })
+
+    describe('cancel', () => {
+      test('returns an action object', () => {
+        expect(wifLoginActions.cancel()).toEqual({
+          batch: false,
+          type: 'AUTH/REQ/CANCEL',
+          meta: {
+            id: 'AUTH',
+            type: 'REQ/CANCEL'
+          }
+        })
+      })
+    })
+
+    describe('reset', () => {
+      test('returns an action object', () => {
+        expect(wifLoginActions.reset()).toEqual({
+          batch: false,
+          type: 'AUTH/REQ/RESET',
+          meta: {
+            id: 'AUTH',
+            type: 'REQ/RESET'
+          }
+        })
+      })
+    })
+  })
+})

--- a/app/actions/authActions.js
+++ b/app/actions/authActions.js
@@ -32,9 +32,13 @@ type AccountType = ?{
 export const ID = 'AUTH'
 
 export const wifLoginActions = createRequestActions(ID, ({ wif }: WifLoginProps) => (state: Object): AccountType => {
+  if (!wallet.isWIF(wif) && !wallet.isPrivateKey(wif)) {
+    throw new Error('That is not a valid private key')
+  }
+
   const account = new wallet.Account(wif)
 
-  return { wif, address: account.address, isHardwareLogin: false }
+  return { wif: account.WIF, address: account.address, isHardwareLogin: false }
 })
 
 export const nep2LoginActions = createRequestActions(ID, ({ passphrase, encryptedWIF }: Nep2LoginProps) => async (state: Object): Promise<AccountType> => {
@@ -51,7 +55,7 @@ export const nep2LoginActions = createRequestActions(ID, ({ passphrase, encrypte
 
   await upgradeNEP6AddAddresses(encryptedWIF, wif)
 
-  return { wif, address: account.address, isHardwareLogin: false }
+  return { wif: account.WIF, address: account.address, isHardwareLogin: false }
 })
 
 export const ledgerLoginActions = createRequestActions(ID, ({ publicKey }: LedgerLoginProps) => (state: Object): AccountType => {


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
Users are currently able to login with their address or public key instead of WIF or private key.  Nothing can actually be done other than looking at publicly accessible data, but we should not incorrectly authenticate in the first place.

**How did you solve this problem?**
I tested that the string provided to the authentication function is a WIF or private key.

**How did you make sure your solution works?**
I smoke tested and added tests.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [x] Unit tests written?
