### PR TITLE
Fixed balance calculation for non-USD currencies

### DIFF
--- a/__tests__/components/App.test.js
+++ b/__tests__/components/App.test.js
@@ -14,7 +14,19 @@ const initialState = {
   api: {
     APP: {
       batch: true,
-      mapping: ['NETWORK', 'PRICES', 'SETTINGS']
+      mapping: ['ACCOUNTS', 'BLOCK_HEIGHT', 'SETTINGS']
+    },
+    ACCOUNTS: {
+      batch: false,
+      state: LOADED,
+      data: [],
+      loadedCount: 1
+    },
+    BLOCK_HEIGHT: {
+      batch: false,
+      state: LOADED,
+      data: 2000000,
+      loadedCount: 1
     },
     NETWORK: {
       batch: false,

--- a/app/actions/appActions.js
+++ b/app/actions/appActions.js
@@ -2,7 +2,6 @@
 import createBatchActions from '../util/api/createBatchActions'
 import accountsActions from './accountsActions'
 import blockHeightActions from './blockHeightActions'
-import pricesActions from './pricesActions'
 import settingsActions from './settingsActions'
 
 export const ID = 'APP'
@@ -10,6 +9,5 @@ export const ID = 'APP'
 export default createBatchActions(ID, {
   accounts: accountsActions,
   blockHeight: blockHeightActions,
-  prices: pricesActions,
   settings: settingsActions
 })

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -7,12 +7,14 @@ import appActions from '../../actions/appActions'
 import authActions from '../../actions/authActions'
 import accountActions from '../../actions/accountActions'
 import networkActions from '../../actions/networkActions'
+import pricesActions from '../../actions/pricesActions'
 import withFetch from '../../hocs/api/withFetch'
 import withReload from '../../hocs/api/withReload'
 import withProgressComponents from '../../hocs/api/withProgressComponents'
 import withLoginRedirect from '../../hocs/auth/withLoginRedirect'
 import withLogoutRedirect from '../../hocs/auth/withLogoutRedirect'
 import withLogoutReset from '../../hocs/auth/withLogoutReset'
+import withCurrencyData from '../../hocs/withCurrencyData'
 import withNetworkData from '../../hocs/withNetworkData'
 import alreadyLoaded from '../../hocs/api/progressStrategies/alreadyLoadedStrategy'
 import { checkVersion } from '../../modules/metadata'
@@ -49,6 +51,17 @@ export default compose(
   withFetch(appActions),
   withReload(appActions, ['networkId']),
   withProgressComponents(appActions, {
+    [LOADING]: Loading,
+    [FAILED]: Failed
+  }, {
+    strategy: alreadyLoaded
+  }),
+
+  // Fetch prices data based based upon the selected currency.  Reload data with the currency changes.
+  withCurrencyData(),
+  withFetch(pricesActions),
+  withReload(pricesActions, ['currency']),
+  withProgressComponents(pricesActions, {
     [LOADING]: Loading,
     [FAILED]: Failed
   }, {


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Fixed #843.

**What problem does this PR solve?**
The price functionality always reflects the USD value even if you change it to any other currency.  The symbol changes, but the number doesn't.  For example, you might see 1 NEO at 95 USD and also at 95 JPY.

**How did you solve this problem?**
I separated the call for prices data to occur after settings data have been loaded.  This is necessary since we don't know the user's desired currency until settings are loaded, and the currency is needed to make the token prices fetch request.

**How did you make sure your solution works?**
I loaded up the dashboard with the currency set to USD and not USD, confirming that it shows not just different symbols but also different/correct values.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [x] Unit tests written?
