### PR TITLE
Fixed repeat error notifications not appearing

### DIFF
--- a/__tests__/sagas/requestSaga.test.js
+++ b/__tests__/sagas/requestSaga.test.js
@@ -52,7 +52,9 @@ describe('requestSaga', () => {
 
     it('performs the action', () => {
       const request = call(requestState.fn, storeState, actionState.payload, sagaActions)
-      const response = request.CALL.fn(...request.CALL.args).next().value
+      const fn = request.CALL.fn(...request.CALL.args)
+      fn.next() // account for delay
+      const response = fn.next().value
       const result = response.CALL.fn(...response.CALL.args)
       expect(result).toEqual('my foo baz')
     })

--- a/app/hocs/withFailureNotification.js
+++ b/app/hocs/withFailureNotification.js
@@ -42,7 +42,7 @@ export default function withFailureNotification (actions: Actions, message: Mess
 
     class ErrorNotifier extends React.Component<Props> {
       componentWillReceiveProps (nextProps) {
-        if (hasError(nextProps) && (!hasError(this.props) || progressChangedToError(this.props, nextProps))) {
+        if (hasError(nextProps) && progressChangedToError(this.props, nextProps)) {
           const showErrorNotification = nextProps[NOTIFICATION_PROP]
           showErrorNotification({ message: nextProps[ERROR_PROP] })
         }

--- a/app/sagas/requestSaga.js
+++ b/app/sagas/requestSaga.js
@@ -1,6 +1,6 @@
 // @flow
 import { call, put, race, take } from 'redux-saga/effects'
-import { type Saga } from 'redux-saga'
+import { delay, type Saga } from 'redux-saga'
 
 import { actionMatcher } from '../util/api/matchers'
 import {
@@ -24,6 +24,7 @@ type SagaActions = {
 export function createSagaActions (meta: ActionMeta): SagaActions {
   function * request (state: Object, payload: Payload, actions: SagaActions) {
     try {
+      yield delay(0) // allow request state to propagate
       const result = yield call(payload.fn, state)
       yield put(actions.success(result))
     } catch (err) {


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
When authenticating with private key or WIF, if the user encounters we show an error notification.  If the user encounters a second error (or more), we do not show another error notification even though we should.

**How did you solve this problem?**
Without this change, the initial failing request would have the redux state change from "LOADING" to "FAILED".  Subsequent requests would simply remain at the "FAILED" state.

I added a delay to the redux saga request to ensure that the redux store has a chance to cycle through all state changes.  It now properly reflects a change from "FAILED" to "LOADING" and back to "FAILED" again if the request does not succeed.

**How did you make sure your solution works?**
I smoke tested logging in with invalid private keys.  I also updated the tests.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [x] Unit tests written?
