### PR TITLE
Surface errors from tx failures

### DIFF
--- a/app/modules/transactions.js
+++ b/app/modules/transactions.js
@@ -178,6 +178,6 @@ export const sendTransaction = (sendEntries: Array<SendEntryType>) => async (
       message: 'Transaction complete! Your balance will automatically update when the blockchain has processed it.'
     }))
   } catch (err) {
-    return rejectTransaction('Transaction failed!')
+    return rejectTransaction(`Transaction failed: ${err.message}`)
   }
 }


### PR DESCRIPTION
Currently, without any reporting system in place, it is impossible for us to judge what is the problem because the only thing the users can tell us is `Transaction Failed`. This PR attempts to surface the errors by printing the error message if the transaction actually fails before even getting sent. 

This way, we are able to debug with more information available because these errors are more likely to be code issues than network issues.

This is an example:
![image](https://user-images.githubusercontent.com/9101245/37444326-2222fad6-27ce-11e8-9908-ec1355e7d2de.png)
