### PR TITLE
Prevented multiple wallets from having the same label (fixes #776)

### DIFF
--- a/app/modules/generateWallet.js
+++ b/app/modules/generateWallet.js
@@ -37,6 +37,9 @@ export function resetKey () {
 export const walletHasKey = (wallet: Object, key: string) =>
   wallet.accounts.some(account => account.key === key)
 
+export const walletHasLabel = (wallet: Object, label: string) =>
+  wallet.accounts.some(account => account.label === label)
+
 export const saveAccount = (label: string, address: string, key: string) => (dispatch: DispatchType) => {
   if (!label || !address || !key) { return null }
 
@@ -51,11 +54,14 @@ export const saveAccount = (label: string, address: string, key: string) => (dis
       dispatch(showErrorNotification({ message: `Error loading wallet: ${readError.message}` }))
     }
 
-    if (!walletHasKey(data, newAccount.key)) {
-      data.accounts.push(newAccount)
-    } else {
+    if (walletHasKey(data, newAccount.key)) {
       dispatch(showErrorNotification({ message: `Error saving wallet: '${newAccount.address}' already exists` }))
       return
+    } else if (walletHasLabel(data, newAccount.label)) {
+      dispatch(showErrorNotification({ message: `Error saving wallet: Name '${newAccount.label}' already exists` }))
+      return
+    } else {
+      data.accounts.push(newAccount)
     }
 
     storage.set('userWallet', data, (saveError) => {


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Fixes Issue #776

**What problem does this PR solve?**
Prevents users from creating multiple wallets with the same label/alias, which implicitly fixes the wallet deletion bug described in issue #776.

**How did you solve this problem?**
Checked for a duplicate label in the saveAccount() method in app/modules/generateWallet

**How did you make sure your solution works?**
It was straightforward to test. When a user attempts to create another wallet with the same label, an error message is flashed on the Electron app telling them to choose a different name.

