### PR TITLE
Added Discord invite link to footer (fixes #880)

### DIFF
--- a/app/containers/App/Footer/Footer.jsx
+++ b/app/containers/App/Footer/Footer.jsx
@@ -6,6 +6,6 @@ import { shell } from 'electron'
 const discordInviteLink = 'https://discordapp.com/invite/R8v48YA'
 const openDiscordLink = () => shell.openExternal(discordInviteLink)
 
-const Footer = () => <div className={styles.container}>Discord Link: <a href='#' onClick={openDiscordLink}>{discordInviteLink}</a> | Created by CoZ. Donations: Adr3XjZ5QDzVJrWvzmsTTchpLRRGSzgS5A</div>
+const Footer = () => <div className={styles.container}>Community Support: <a href='#' onClick={openDiscordLink}>{discordInviteLink}</a> | Created by CoZ. Donations: Adr3XjZ5QDzVJrWvzmsTTchpLRRGSzgS5A</div>
 
 export default Footer

--- a/app/containers/App/Footer/Footer.jsx
+++ b/app/containers/App/Footer/Footer.jsx
@@ -1,7 +1,11 @@
 // @flow
 import React from 'react'
 import styles from './Footer.scss'
+import { shell } from 'electron'
 
-const Footer = () => <div className={styles.container}>Created by CoZ. Donations: Adr3XjZ5QDzVJrWvzmsTTchpLRRGSzgS5A</div>
+const discordInviteLink = 'https://discordapp.com/invite/R8v48YA'
+const openDiscordLink = () => shell.openExternal(discordInviteLink)
+
+const Footer = () => <div className={styles.container}>Discord Link: <a href='#' onClick={openDiscordLink}>{discordInviteLink}</a> | Created by CoZ. Donations: Adr3XjZ5QDzVJrWvzmsTTchpLRRGSzgS5A</div>
 
 export default Footer


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Resolves issue #880 

**What problem does this PR solve?**
It adds a direct invite link to the discord support server 

**How did you solve this problem?**
Added the discord link to the footer JSX template and made it open the link in an external browser on click

**How did you make sure your solution works?**
Tested the link on my local computer and verified that it works as intended
