### PR TITLE
Fixed failing e2e tests because of missing Chrome Driver dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
           key: neon-wallet-{{ checksum "yarn.lock" }}
       - run: apt-get -y update
       - run: apt-get -y install libusb-1.0-0-dev graphicsmagick libudev-dev
+      - run: apt-get -y install libxtst6 libxss1 libgtk2.0-0 libnss3 libasound2 libgconf-2-4
       - run: yarn test-ci
       - run:
           name: Running Xvfb for e2e test


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
None.
**What problem does this PR solve?**
Fixed failing e2e tests.
**How did you solve this problem?**
Added display server related packages for Chrome Driver.
**How did you make sure your solution works?**
Ran tests on my private CircleCI:
https://circleci.com/gh/drptbl/neon-wallet/11
**Are there any special changes in the code that we should be aware of?**
Nope.
**Is there anything else we should know?**
Nope.
- [ ] Unit tests written?
