### PR TITLE
feat(ci): automated builds upon tagging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,16 @@
 version: 2
+
 references:
   container_config: &container_config
     docker:
       - image: electronuserland/builder:wine-chrome
+        environment:
+          TARGET_ARCH: x64
+    working_directory: ~/neon-wallet
+
+  win_config: &win_config
+    docker:
+      - image: electronuserland/builder:wine
         environment:
           TARGET_ARCH: x64
     working_directory: ~/neon-wallet
@@ -36,6 +44,7 @@ jobs:
           root: *workspace_root
           paths:
             - dist/*
+
   test:
     <<: *container_config
     steps:
@@ -61,11 +70,55 @@ jobs:
       - path: artifacts/
       - destination: yarnpkg
 
+  deploy_win64:
+    <<: *win_config
+    steps:
+      - checkout
+      - restore_cache:
+          key: neon-wallet-{{ checksum "yarn.lock" }}
+      - run: apt-get -y update
+      - run: apt-get -y install libusb-1.0-0-dev icnsutils graphicsmagick libudev-dev
+      - run: apt-get install --no-install-recommends -y gcc-multilib g++-multilib
+      - run: yarn
+      - run: yarn assets
+      - run: yarn build -w --x64
+      - store_artifacts:
+          path: dist
+          destination: build
+
+  deploy_linux:
+    <<: *container_config
+    steps:
+      - checkout
+      - restore_cache:
+          key: neon-wallet-{{ checksum "yarn.lock" }}
+      - run: apt-get -y update
+      - run: apt-get -y install libusb-1.0-0-dev icnsutils graphicsmagick libudev-dev
+      - run: yarn
+      - run: yarn dist
+      - store_artifacts:
+          path: dist
+          destination: build
+
 workflows:
   version: 2
-  build-test-and-deploy:
+  build_test:
     jobs:
       - build
       - test:
           requires:
             - build
+  deploy:
+    jobs:
+      - deploy_win64:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /[0-9]+(\.[0-9]+)+.*/
+      - deploy_linux:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /[0-9]+(\.[0-9]+)+.*/


### PR DESCRIPTION
This adds the ability to use CI to build upon tagging. I have it setup for linux and windows builds.

## How

1. We will have to tag the build beforehand. Instead of using the release page to tag, we use cmd. Assuming we are on `master` on the commit that we want to release:
```
git tag 0.2.3
git push upstream 0.2.3 --no-verify
```

This will push the tag up and CircleCi should pick this up and trigger the builds.

The builds can be found by going to Workflows -> neon-wallet. The dist folder is uploaded as artifacts. Unfortunately, I do not see anyway to automate the attachement of the builds to the release draft so we will have to do this ourselves.