### PR TITLE
Removed unintentionally left .only() calls in tests

### DIFF
--- a/__tests__/actions/authActions.test.js
+++ b/__tests__/actions/authActions.test.js
@@ -36,7 +36,7 @@ describe('authActions', () => {
       })
 
       describe('with invalid private key', () => {
-        test.only('throws an error', () => {
+        test('throws an error', () => {
           const request = wifLoginActions.request({ wif: 'invalid' })
           expect(() => request.payload.fn({})).toThrowError('That is not a valid private key')
         })

--- a/__tests__/actions/claimsActions.test.js
+++ b/__tests__/actions/claimsActions.test.js
@@ -17,7 +17,7 @@ describe('claimsActions', () => {
     jest.restoreAllMocks()
   })
 
-  describe.only('request', () => {
+  describe('request', () => {
     test('returns an action object', () => {
       expect(claimsActions.request({ net, address })).toEqual({
         batch: false,


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
Some `.only()` calls were accidentally left in tests, which prevents the full suite from running.

**How did you solve this problem?**
I removed the `.only()` calls.

**How did you make sure your solution works?**
Ran the test suite.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [x] Unit tests written?
