### PR TITLE
Removed more tokens that have completed ICOs

### DIFF
--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -81,7 +81,7 @@ export const TOKENS = {
   SWH: '78e6d16b914fe15bc16150aeb11d0c2a8e532bdd'
 }
 
-export const ENDED_ICO_TOKENS = ['DBC', 'RPX', 'QLC', 'RHT']
+export const ENDED_ICO_TOKENS = ['DBC', 'RPX', 'QLC', 'RHT', 'ONT', 'SWH']
 
 export const DEFAULT_WALLET = {
   name: 'userWallet',


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
This removes ONT and SWH tokens from displaying in the token sale modal since their token sales are over or never occurred.

**How did you solve this problem?**
Added both token symbols to the array used for tracking completed ICOs.

**How did you make sure your solution works?**
Opens the token sale modal and confirmed they're not available in the dropdown.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
