### PR TITLE
Updated token sale screen to require user to manually agree to purchase terms

### DIFF
--- a/app/components/Modals/TokenSaleModal/TokenSaleModal.jsx
+++ b/app/components/Modals/TokenSaleModal/TokenSaleModal.jsx
@@ -1,12 +1,13 @@
 // @flow
 import React, { Component } from 'react'
-import { get, pick } from 'lodash'
+import { get, pick, map, every, times, constant } from 'lodash'
 
 import { isZero, isNumber } from '../../../core/math'
 import { ASSETS } from '../../../core/constants'
 
 import BaseModal from '../BaseModal'
-import Button from '../../../components/Button'
+import Tooltip from '../../Tooltip'
+import Button from '../../Button'
 
 import WarningText from './WarningText'
 import SelectToken from './SelectToken'
@@ -14,6 +15,14 @@ import VerificationOptions from './VerificationOptions'
 import ParticipationSuccess from './ParticipationSuccess'
 
 import styles from './styles.scss'
+
+const WARNINGS = [
+  'I understand that submitting NEO or GAS multiple times may result in a loss of funds or a delayed refund depending on the policy of the ICO company.',
+  'I understand that some sales may only accept NEO or GAS, and I have verified which is accepted.',
+  'I understand that if I send NEO or GAS to a token sale that has already ended, I will lose my NEO/GAS and will not be refunded.',
+  'I understand that I should only click the ‘Purchase!’ button once.',
+  'I understand that City of Zion (CoZ) is not responsible for my usage of this feature, and I have consulted this software\'s licenses.'
+]
 
 type Props = {
   oldParticipateInSale: (string, string, string) => Promise<boolean>,
@@ -37,6 +46,7 @@ type State = {
   participationSuccessful: boolean,
   gasCost: string,
   loaded: boolean,
+  agreements: Array<boolean>
 }
 
 const initialBalancesToSend = { [ASSETS.NEO]: '', [ASSETS.GAS]: '' }
@@ -49,45 +59,37 @@ export default class TokenSale extends Component<Props, State> {
     tokenToMint: '',
     participationSuccessful: false,
     loaded: false,
-    gasCost: '0' // hard coded for now
+    gasCost: '0', // hard coded for now
+    agreements: times(WARNINGS.length, constant(false))
   }
 
-  oldParticipateInSale = () => {
+  oldParticipateInSale = async () => {
     const { oldParticipateInSale, tokenBalances } = this.props
     const { assetBalancesToSend, tokenToMint, gasCost } = this.state
+
     if (tokenToMint) {
       const scriptHash = get(tokenBalances[tokenToMint], 'scriptHash')
+      const success = await oldParticipateInSale(assetBalancesToSend[ASSETS.NEO], scriptHash, gasCost)
 
-      oldParticipateInSale(assetBalancesToSend[ASSETS.NEO], scriptHash, gasCost).then(
-        success => {
-          if (success) {
-            this.setState({
-              participationSuccessful: true
-            })
-          }
-        }
-      )
+      if (success) {
+        this.setState({ participationSuccessful: true })
+      }
     }
   }
 
-  participateInSale = () => {
+  participateInSale = async () => {
     const { participateInSale, tokenBalances } = this.props
     const { assetBalancesToSend, tokenToMint, gasCost } = this.state
+
     if (tokenToMint) {
       const scriptHash = get(tokenBalances[tokenToMint], 'scriptHash')
+      const amountNEO = assetBalancesToSend[ASSETS.NEO] || '0'
+      const amountGAS = assetBalancesToSend[ASSETS.GAS] || '0'
+      const success = await participateInSale(amountNEO, amountGAS, scriptHash, gasCost)
 
-      participateInSale(
-        assetBalancesToSend.NEO || '0',
-        assetBalancesToSend.GAS || '0',
-        scriptHash,
-        gasCost
-      ).then(success => {
-        if (success) {
-          this.setState({
-            participationSuccessful: true
-          })
-        }
-      })
+      if (success) {
+        this.setState({ participationSuccessful: true })
+      }
     }
   }
 
@@ -112,18 +114,9 @@ export default class TokenSale extends Component<Props, State> {
   }
 
   render () {
-    const {
-      assetBalancesToSend,
-      useVerification,
-      tokenToMint,
-      participationSuccessful
-    } = this.state
-    const {
-      hideModal,
-      tokenBalances,
-      assetBalances,
-      showTokensModal
-    } = this.props
+    const { assetBalancesToSend, useVerification, tokenToMint, participationSuccessful } = this.state
+    const { hideModal, tokenBalances, assetBalances, showTokensModal } = this.props
+    const disabled = this.isDisabled()
 
     return (
       <BaseModal
@@ -135,16 +128,12 @@ export default class TokenSale extends Component<Props, State> {
           <ParticipationSuccess
             hideModal={hideModal}
             token={tokenBalances[tokenToMint]}
-            assetBalancesToSend={
-              useVerification
-                ? assetBalancesToSend
-                : pick(assetBalancesToSend, ASSETS.NEO)
-            }
+            assetBalancesToSend={useVerification
+              ? assetBalancesToSend
+              : pick(assetBalancesToSend, ASSETS.NEO)}
           />
         ) : (
           <div className={styles.tokenSale}>
-            <WarningText />
-
             <SelectToken
               onChangeToken={(symbol: SymbolType) =>
                 this.setState({ tokenToMint: symbol })
@@ -159,11 +148,7 @@ export default class TokenSale extends Component<Props, State> {
               }
               assetBalancesToSend={assetBalancesToSend}
               tokenBalances={tokenBalances}
-              assetBalances={
-                useVerification
-                  ? assetBalances
-                  : pick(assetBalances, ASSETS.NEO)
-              }
+              assetBalances={useVerification ? assetBalances : pick(assetBalances, ASSETS.NEO)}
               tokenToMint={tokenToMint}
               showTokensModal={showTokensModal}
             />
@@ -173,21 +158,50 @@ export default class TokenSale extends Component<Props, State> {
               onChange={useVerification => this.setState({ useVerification })}
             />
 
+            <WarningText>
+              {map(WARNINGS, this.renderWarning)}
+            </WarningText>
+
             <div className={styles.purchaseButton}>
-              <Button
-                onClick={
-                  useVerification
-                    ? this.participateInSale
-                    : this.oldParticipateInSale
-                }
-                disabled={!this.isValidAssetBalances()}
-              >
-                Purchase!
-              </Button>
+              <Tooltip title='Please agree to the terms of purchase' position='top' disabled={!disabled}>
+                <Button
+                  onClick={useVerification ? this.participateInSale : this.oldParticipateInSale}
+                  disabled={disabled}
+                >
+                  Purchase!
+                </Button>
+              </Tooltip>
             </div>
           </div>
         )}
       </BaseModal>
     )
+  }
+
+  renderWarning = (message: string, index: number) => {
+    return (
+      <li key={index}>
+        <label>
+          <input
+            type='checkbox'
+            checked={this.state.agreements[index]}
+            onChange={this.handleChangeAgreementCurry(index)}
+          />
+          {message}
+        </label>
+      </li>
+    )
+  }
+
+  isDisabled = () => {
+    return !this.isValidAssetBalances() || !every(this.state.agreements)
+  }
+
+  handleChangeAgreementCurry = (index: number) => {
+    return (event: Object) => {
+      const agreements = [...this.state.agreements]
+      agreements.splice(index, 1, event.target.checked)
+      this.setState({ agreements })
+    }
   }
 }

--- a/app/components/Modals/TokenSaleModal/WarningText/index.jsx
+++ b/app/components/Modals/TokenSaleModal/WarningText/index.jsx
@@ -3,32 +3,20 @@ import React from 'react'
 
 import styles from './styles.scss'
 
-const WarningText = () => (
+type Props = {
+  children: React$Node
+}
+
+const WarningText = (props: Props) => (
   <div className={styles.container}>
     <div className={styles.section}>
       <div className={styles.heading}>
-        <strong>IMPORTANT: Read the points below before continuing</strong>
+        <strong>IMPORTANT: You must agree to the following before continuing</strong>
       </div>
       <div className={styles.sectionBody}>
         <div className={styles.bullets}>
           <ol>
-            <li>
-            Submitting NEO multiple times may result in a loss of funds or a
-            delayed refund depending on the policy of the ICO company.
-            </li>
-            <li>
-            Some sales may only accept NEO or GAS so please be sure to check
-            before you send.
-            </li>
-            <li>
-            If you send NEO/GAS to a token sale that has already ended, you will
-            lose your NEO/GAS and will not be refunded.
-            </li>
-            <li>Only click the ‘Purchase!’ button once.</li>
-            <li>
-            City of Zion (CoZ) is not responsible for your usage of this
-            feature, please consult this software licenses.
-            </li>
+            {props.children}
           </ol>
         </div>
       </div>


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
Many users are blindly sending NEO/GAS for already completed token sales.  Providing a gigantic red block of warning text that takes up half the screen apparently isn't enough to deter many users from using the feature without understanding it.  This changes the warning text to be distinct checkboxes that the user must agree to in order to draw better attention to what it says.

![token-sale-agreement](https://user-images.githubusercontent.com/169093/38064221-7be9f868-32c2-11e8-944f-ffe6859fc73c.gif)

**How did you solve this problem?**
I updated the warning text to be 5 distinct checkboxes that must be clicked before the form can be submitted.

**How did you make sure your solution works?**
I verified that the button is disabled when any of the 5 checkboxes is not checked, as well is when any other validation errors occur in the form.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
Since the user is explicitly agreeing to the terms, I moved it to the end of the form.  That way, the checkboxes are more visible if the button is disabled and needs to look up to understand why.

- [ ] Unit tests written?
