### PR TITLE
Remove NRVE and ONT as ICOs

### DIFF
--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -80,7 +80,7 @@ export const TOKENS = {
   CGE: '34579e4614ac1a7bd295372d3de8621770c76cdc'
 }
 
-export const ENDED_ICO_TOKENS = ['DBC', 'RPX', 'QLC', 'RHT']
+export const ENDED_ICO_TOKENS = ['DBC', 'RPX', 'QLC', 'RHT', 'NRVE']
 
 export const DEFAULT_WALLET = {
   name: 'userWallet',

--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -80,7 +80,7 @@ export const TOKENS = {
   CGE: '34579e4614ac1a7bd295372d3de8621770c76cdc'
 }
 
-export const ENDED_ICO_TOKENS = ['DBC', 'RPX', 'QLC', 'RHT', 'NRVE']
+export const ENDED_ICO_TOKENS = ['DBC', 'RPX', 'QLC', 'RHT', 'NRVE', 'ONT']
 
 export const DEFAULT_WALLET = {
   name: 'userWallet',


### PR DESCRIPTION
**What problem does this PR solve?**

Removes NRVE and ONT from the Token Sale Participation tool.

**How did you solve this problem?**

Added them to the `ENDED_ICO_TOKENS`