### PR TITLE
Mint script hash

### DIFF
--- a/__tests__/components/__snapshots__/WalletInfo.test.js.snap
+++ b/__tests__/components/__snapshots__/WalletInfo.test.js.snap
@@ -1,21 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`WalletInfo renders without crashing 1`] = `
-<Connect(withData(Connect(withData(Connect(withData(withProps(Connect(withData(Connect(withData(Connect(withData(withProps(Connect(withData(Connect(withActions(Connect(withActions(Connect(Connect(withProgress(LoadedNotifier)))))))))))))))))))))))
-  networks={
-    Array [
-      Object {
-        "id": "1",
-        "label": "MainNet",
-        "network": "MainNet",
-      },
-      Object {
-        "id": "2",
-        "label": "TestNet",
-        "network": "TestNet",
-      },
-    ]
-  }
+<Connect(withData(Connect(withData(Connect(withData(Connect(withData(Connect(withData(withProps(Connect(withData(Connect(withActions(Connect(Connect(withProgress(LoadedNotifier))))))))))))))))))
   participateInSale={[Function]}
   showModal={[Function]}
   store={
@@ -26,27 +12,6 @@ exports[`WalletInfo renders without crashing 1`] = `
       "getState": [Function],
       "replaceReducer": [Function],
       "subscribe": [Function],
-    }
-  }
-  storeSubscription={
-    Subscription {
-      "listeners": Object {
-        "clear": [Function],
-        "get": [Function],
-        "notify": [Function],
-        "subscribe": [Function],
-      },
-      "onStateChange": [Function],
-      "parentSub": undefined,
-      "store": Object {
-        "clearActions": [Function],
-        "dispatch": [Function],
-        "getActions": [Function],
-        "getState": [Function],
-        "replaceReducer": [Function],
-        "subscribe": [Function],
-      },
-      "unsubscribe": [Function],
     }
   }
 />

--- a/app/components/Modals/TokenSaleModal/ParticipationSuccess/index.jsx
+++ b/app/components/Modals/TokenSaleModal/ParticipationSuccess/index.jsx
@@ -11,7 +11,7 @@ type Props = {
   assetBalancesToSend: {
     [key: SymbolType]: string
   },
-  token: TokenBalanceType
+  scriptHash: string
 }
 
 const formatAssetBalances = assetBalancesToSend => {
@@ -26,12 +26,7 @@ const formatAssetBalances = assetBalancesToSend => {
   return balances.join(', ')
 }
 
-const ParticipationSuccess = ({
-  hideModal,
-  token,
-  assetBalancesToSend
-}: Props) => {
-  const { scriptHash, name, symbol } = token
+const ParticipationSuccess = ({ hideModal, scriptHash, assetBalancesToSend }: Props) => {
   return (
     <div className={styles.container}>
       <div className={styles.iconContainer}>
@@ -44,9 +39,6 @@ const ParticipationSuccess = ({
       <div className={styles.confirmation}>
         <div>You sent <strong>{formatAssetBalances(assetBalancesToSend)}</strong></div>
         <div>To: <strong>{scriptHash}</strong></div>
-        <div>
-          For: <strong>{symbol} ({name})</strong>
-        </div>
       </div>
       <div className={styles.buttonContainer}>
         <Button onClick={() => hideModal()}>I'm Finished</Button>

--- a/app/components/Modals/TokenSaleModal/SelectToken/index.jsx
+++ b/app/components/Modals/TokenSaleModal/SelectToken/index.jsx
@@ -1,36 +1,31 @@
 // @flow
-import React, { Component } from 'react'
+import React from 'react'
 
 import { COIN_DECIMAL_LENGTH } from '../../../../core/formatters'
 
 import AssetInput from '../../../../components/Inputs/AssetInput'
 import NumberInput from '../../../../components/NumberInput'
-import Button from '../../../../components/Button'
 
 import styles from './styles.scss'
 import commonStyles from '../styles.scss'
 
 type Props = {
-  onChangeToken: string => any,
+  onChangeScriptHash: string => any,
   onChangeAmount: (SymbolType, string) => any,
   assetBalancesToSend: {
     [key: SymbolType]: string
   },
-  tokenBalances: {
-    [key: SymbolType]: TokenBalanceType
-  },
   assetBalances: {
     [key: SymbolType]: string
   },
-  tokenToMint: SymbolType,
-  showTokensModal: () => any,
+  scriptHash: string
 }
 
 type State = {
   selectedAsset: SymbolType
 }
 
-class SelectToken extends Component<Props, State> {
+class SelectToken extends React.Component<Props, State> {
   state = {
     selectedAsset: Object.keys(this.props.assetBalances)[0]
   }
@@ -45,22 +40,16 @@ class SelectToken extends Component<Props, State> {
 
   render () {
     const {
-      onChangeToken,
-      showTokensModal,
+      onChangeScriptHash,
       assetBalances,
       onChangeAmount,
-      tokenBalances,
-      tokenToMint,
+      scriptHash,
       assetBalancesToSend
     } = this.props
 
     const { selectedAsset } = this.state
 
     const assetBalance = assetBalances[selectedAsset]
-    let token
-    if (tokenToMint) {
-      token = tokenBalances[tokenToMint]
-    }
     const balanceToSend = assetBalancesToSend[selectedAsset]
 
     return (
@@ -75,67 +64,40 @@ class SelectToken extends Component<Props, State> {
           <div className={styles.content}>
             <div className={styles.mint}>
               <div className={styles.mintBody}>
+                <div className={styles.label}>Enter ICO token script hash to purchase</div>
                 <div>
-                  <div className={styles.label}>
-                  Select ICO token to purchase
-                  </div>
-                  <div>
-                    <AssetInput
-                      placeholder='Choose token'
-                      symbols={Object.keys(tokenBalances)}
-                      value={tokenToMint}
-                      onChange={symbol => onChangeToken(symbol)}
-                      className={styles.assetInput}
-                    />
-                  </div>
+                  <input
+                    type='text'
+                    placeholder='Enter token script hash'
+                    value={scriptHash}
+                    className={styles.assetInput}
+                    onChange={(event) => onChangeScriptHash(event.target.value)}
+                  />
                 </div>
-                <div>
-                  <div className={styles.label}>
-                  Token not in the list?
-                  </div>
-                  <div>
-                    <Button onClick={() => showTokensModal()}
-                      className={styles.purchaseBtn}>
-                    + Add a new token to purchase
-                    </Button>
-                  </div>
-                </div>
-              </div>
-
-              <div className={styles.footer}>
-                {token &&
-                <div>
-                  <div><strong>Token Script Hash:</strong> {token.scriptHash}</div>
-                  <div><strong>Token Name:</strong> {token.name}</div>
-                </div>
-                }
               </div>
             </div>
 
             <div className={styles.assets}>
               <div className={styles.assetsBody}>
-                <div>
-                  <div className={styles.label}>What are you purchasing with?</div>
-                  <AssetInput
-                    symbols={Object.keys(assetBalances)}
-                    value={selectedAsset}
-                    onChange={asset => this.setState({ selectedAsset: asset }, () => {
-                      onChangeAmount(asset, '')
-                    })}
-                    className={styles.assetInput}
-                  />
-                </div>
-                <div>
-                  <div className={styles.label}>Amount of {selectedAsset}</div>
-                  <NumberInput
-                    className={styles.numberInput}
-                    max={assetBalance}
-                    value={balanceToSend}
-                    placeholder='Amount'
-                    options={{ numeralDecimalScale: COIN_DECIMAL_LENGTH }}
-                    onChange={amount => onChangeAmount(selectedAsset, amount)}
-                  />
-                </div>
+                <div className={styles.label}>What are you purchasing with?</div>
+                <AssetInput
+                  symbols={Object.keys(assetBalances)}
+                  value={selectedAsset}
+                  onChange={asset => this.setState({ selectedAsset: asset }, () => {
+                    onChangeAmount(asset, '')
+                  })}
+                  className={styles.assetInput}
+                />
+
+                <div className={styles.label}>Amount of {selectedAsset}</div>
+                <NumberInput
+                  className={styles.numberInput}
+                  max={assetBalance}
+                  value={balanceToSend}
+                  placeholder='Amount'
+                  options={{ numeralDecimalScale: COIN_DECIMAL_LENGTH }}
+                  onChange={amount => onChangeAmount(selectedAsset, amount)}
+                />
               </div>
               <div className={styles.footer}>
                 <strong>Your {selectedAsset} balance:</strong> {assetBalance}

--- a/app/components/Modals/TokenSaleModal/SelectToken/styles.scss
+++ b/app/components/Modals/TokenSaleModal/SelectToken/styles.scss
@@ -19,14 +19,16 @@
 
 .footer {
   background-color: #e8f4e4;
-  height: 80px;
+  height: 40px;
   line-height: 40px;
   padding: 0 12px;
   margin-top: 20px;
 }
 
 .assetInput {
+  box-sizing: border-box;
   width: 100%;
+  margin-bottom: 12px;
 }
 
 .numberInput {
@@ -43,35 +45,28 @@
 }
 
 .mint {
+  flex: 1 1 auto;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding-top: 30px;
-  border-right: 1px solid #206408;
 }
 
 .mintBody {
-  display: flex;
-  > div {
-    padding: 0 14px;
-  }
+  padding: 30px 14px 10px;
 }
 
 .label {
-  padding-bottom: 12px;
+  margin-bottom: 4px;
 }
 
 .assets {
-  display: flex;
+  flex: 1 1 auto;
   flex-direction: column;
   justify-content: space-between;
-  padding-top: 30px;
   width: 290px;
+  border-left: 1px solid #206408;
 }
 
 .assetsBody {
-  > div {
-    padding: 0 14px 10px 14px;
-  }
+  padding: 30px 14px 10px;
 }
-

--- a/app/components/Modals/TokenSaleModal/TokenSaleModal.jsx
+++ b/app/components/Modals/TokenSaleModal/TokenSaleModal.jsx
@@ -1,6 +1,6 @@
 // @flow
-import React, { Component } from 'react'
-import { get, map, every, times, constant } from 'lodash'
+import React from 'react'
+import { map, every, times, constant } from 'lodash'
 
 import { isZero, isNumber } from '../../../core/math'
 import { ASSETS } from '../../../core/constants'
@@ -31,15 +31,14 @@ type Props = {
   assetBalances: {
     [key: SymbolType]: string
   },
-  hideModal: () => void,
-  showTokensModal: () => void
+  hideModal: () => void
 }
 
 type State = {
   assetBalancesToSend: {
     [key: SymbolType]: string
   },
-  tokenToMint: SymbolType,
+  scriptHash: string,
   participationSuccessful: boolean,
   gasCost: string,
   loaded: boolean,
@@ -48,11 +47,10 @@ type State = {
 
 const initialBalancesToSend = { [ASSETS.NEO]: '', [ASSETS.GAS]: '' }
 
-export default class TokenSale extends Component<Props, State> {
-  // $FlowFixMe
+export default class TokenSale extends React.Component<Props, State> {
   state = {
     assetBalancesToSend: initialBalancesToSend,
-    tokenToMint: '',
+    scriptHash: '',
     participationSuccessful: false,
     loaded: false,
     gasCost: '0', // hard coded for now
@@ -60,11 +58,10 @@ export default class TokenSale extends Component<Props, State> {
   }
 
   participateInSale = async () => {
-    const { participateInSale, tokenBalances } = this.props
-    const { assetBalancesToSend, tokenToMint, gasCost } = this.state
+    const { participateInSale } = this.props
+    const { assetBalancesToSend, scriptHash, gasCost } = this.state
 
-    if (tokenToMint) {
-      const scriptHash = get(tokenBalances[tokenToMint], 'scriptHash')
+    if (scriptHash) {
       const amountNEO = assetBalancesToSend[ASSETS.NEO] || '0'
       const amountGAS = assetBalancesToSend[ASSETS.GAS] || '0'
       const success = await participateInSale(amountNEO, amountGAS, scriptHash, gasCost)
@@ -75,8 +72,8 @@ export default class TokenSale extends Component<Props, State> {
     }
   }
 
-  isValidAssetBalances = () => {
-    const { assetBalancesToSend, tokenToMint } = this.state
+  isValid = () => {
+    const { assetBalancesToSend } = this.state
     const NEO = assetBalancesToSend.NEO || '0'
     const GAS = assetBalancesToSend.GAS || '0'
 
@@ -88,7 +85,7 @@ export default class TokenSale extends Component<Props, State> {
       return false
     }
 
-    if (!tokenToMint) {
+    if (!every(this.state.agreements)) {
       return false
     }
 
@@ -110,42 +107,34 @@ export default class TokenSale extends Component<Props, State> {
   }
 
   renderSuccess = () => {
-    const { hideModal, tokenBalances } = this.props
-    const { assetBalancesToSend, tokenToMint } = this.state
+    const { hideModal } = this.props
+    const { assetBalancesToSend, scriptHash } = this.state
 
     return (
       <ParticipationSuccess
         hideModal={hideModal}
-        token={tokenBalances[tokenToMint]}
+        scriptHash={scriptHash}
         assetBalancesToSend={assetBalancesToSend}
       />
     )
   }
 
   renderPurchase = () => {
-    const { assetBalancesToSend, tokenToMint } = this.state
-    const { tokenBalances, assetBalances, showTokensModal } = this.props
-    const disabled = this.isDisabled()
+    const { assetBalancesToSend, scriptHash } = this.state
+    const { tokenBalances, assetBalances } = this.props
+    const valid = this.isValid()
 
     return (
       <div className={styles.tokenSale}>
         <SelectToken
-          onChangeToken={(symbol: SymbolType) =>
-            this.setState({ tokenToMint: symbol })
-          }
+          onChangeScriptHash={(scriptHash: string) => this.setState({ scriptHash })}
           onChangeAmount={(symbol: SymbolType, amount: string) =>
-            this.setState({
-              assetBalancesToSend: {
-                ...initialBalancesToSend,
-                [symbol]: amount
-              }
-            })
+            this.setState({ assetBalancesToSend: { ...initialBalancesToSend, [symbol]: amount } })
           }
           assetBalancesToSend={assetBalancesToSend}
           tokenBalances={tokenBalances}
           assetBalances={assetBalances}
-          tokenToMint={tokenToMint}
-          showTokensModal={showTokensModal}
+          scriptHash={scriptHash}
         />
 
         <WarningText>
@@ -153,11 +142,8 @@ export default class TokenSale extends Component<Props, State> {
         </WarningText>
 
         <div className={styles.purchaseButton}>
-          <Tooltip title='Please agree to the terms of purchase' position='top' disabled={!disabled}>
-            <Button
-              onClick={this.participateInSale}
-              disabled={disabled}
-            >
+          <Tooltip title='Please agree to the terms of purchase' position='top' disabled={valid}>
+            <Button onClick={this.participateInSale} disabled={!valid}>
               Purchase!
             </Button>
           </Tooltip>
@@ -179,10 +165,6 @@ export default class TokenSale extends Component<Props, State> {
         </label>
       </li>
     )
-  }
-
-  isDisabled = () => {
-    return !this.isValidAssetBalances() || !every(this.state.agreements)
   }
 
   handleChangeAgreementCurry = (index: number) => {

--- a/app/components/Modals/TokenSaleModal/TokenSaleModal.jsx
+++ b/app/components/Modals/TokenSaleModal/TokenSaleModal.jsx
@@ -96,60 +96,73 @@ export default class TokenSale extends Component<Props, State> {
   }
 
   render () {
-    const { assetBalancesToSend, tokenToMint, participationSuccessful } = this.state
-    const { hideModal, tokenBalances, assetBalances, showTokensModal } = this.props
-    const disabled = this.isDisabled()
+    const { participationSuccessful } = this.state
 
     return (
       <BaseModal
         title={participationSuccessful ? 'Participation successful' : 'Participate in a token sale'}
-        hideModal={hideModal}
+        hideModal={this.props.hideModal}
         style={{ content: { width: '925px', height: '700px' } }}
       >
-        {participationSuccessful ? (
-          <ParticipationSuccess
-            hideModal={hideModal}
-            token={tokenBalances[tokenToMint]}
-            assetBalancesToSend={assetBalancesToSend}
-          />
-        ) : (
-          <div className={styles.tokenSale}>
-            <SelectToken
-              onChangeToken={(symbol: SymbolType) =>
-                this.setState({ tokenToMint: symbol })
-              }
-              onChangeAmount={(symbol: SymbolType, amount: string) =>
-                this.setState({
-                  assetBalancesToSend: {
-                    ...initialBalancesToSend,
-                    [symbol]: amount
-                  }
-                })
-              }
-              assetBalancesToSend={assetBalancesToSend}
-              tokenBalances={tokenBalances}
-              assetBalances={assetBalances}
-              tokenToMint={tokenToMint}
-              showTokensModal={showTokensModal}
-            />
-
-            <WarningText>
-              {map(WARNINGS, this.renderWarning)}
-            </WarningText>
-
-            <div className={styles.purchaseButton}>
-              <Tooltip title='Please agree to the terms of purchase' position='top' disabled={!disabled}>
-                <Button
-                  onClick={this.participateInSale}
-                  disabled={disabled}
-                >
-                  Purchase!
-                </Button>
-              </Tooltip>
-            </div>
-          </div>
-        )}
+        {participationSuccessful ? this.renderSuccess() : this.renderPurchase()}
       </BaseModal>
+    )
+  }
+
+  renderSuccess = () => {
+    const { hideModal, tokenBalances } = this.props
+    const { assetBalancesToSend, tokenToMint } = this.state
+
+    return (
+      <ParticipationSuccess
+        hideModal={hideModal}
+        token={tokenBalances[tokenToMint]}
+        assetBalancesToSend={assetBalancesToSend}
+      />
+    )
+  }
+
+  renderPurchase = () => {
+    const { assetBalancesToSend, tokenToMint } = this.state
+    const { tokenBalances, assetBalances, showTokensModal } = this.props
+    const disabled = this.isDisabled()
+
+    return (
+      <div className={styles.tokenSale}>
+        <SelectToken
+          onChangeToken={(symbol: SymbolType) =>
+            this.setState({ tokenToMint: symbol })
+          }
+          onChangeAmount={(symbol: SymbolType, amount: string) =>
+            this.setState({
+              assetBalancesToSend: {
+                ...initialBalancesToSend,
+                [symbol]: amount
+              }
+            })
+          }
+          assetBalancesToSend={assetBalancesToSend}
+          tokenBalances={tokenBalances}
+          assetBalances={assetBalances}
+          tokenToMint={tokenToMint}
+          showTokensModal={showTokensModal}
+        />
+
+        <WarningText>
+          {map(WARNINGS, this.renderWarning)}
+        </WarningText>
+
+        <div className={styles.purchaseButton}>
+          <Tooltip title='Please agree to the terms of purchase' position='top' disabled={!disabled}>
+            <Button
+              onClick={this.participateInSale}
+              disabled={disabled}
+            >
+              Purchase!
+            </Button>
+          </Tooltip>
+        </div>
+      </div>
     )
   }
 

--- a/app/containers/WalletInfo/WalletInfo.jsx
+++ b/app/containers/WalletInfo/WalletInfo.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component } from 'react'
 import classNames from 'classnames'
-import { isNil, keyBy } from 'lodash'
+import { isNil } from 'lodash'
 
 import Claim from '../Claim'
 
@@ -9,7 +9,7 @@ import Tooltip from '../../components/Tooltip'
 import Button from '../../components/Button'
 
 import { formatGAS, formatFiat, formatNEO } from '../../core/formatters'
-import { ASSETS, CURRENCIES, MODAL_TYPES, ENDED_ICO_TOKENS } from '../../core/constants'
+import { ASSETS, CURRENCIES, MODAL_TYPES } from '../../core/constants'
 import { toNumber } from '../../core/math'
 
 import MdSync from 'react-icons/lib/md/sync'
@@ -24,16 +24,11 @@ type Props = {
   GAS: string,
   neoPrice: number,
   gasPrice: number,
-  icoTokenBalances: Array<TokenBalanceType>,
   tokenBalances: Array<TokenBalanceType>,
   loadWalletData: Function,
   currencyCode: string,
   showModal: Function,
-  participateInSale: Function,
-  allTokens: Array<TokenItemType>,
-  setUserGeneratedTokens: Function,
-  networks: Array<NetworkItemType>,
-  networkId: string,
+  participateInSale: Function
 }
 
 export default class WalletInfo extends Component<Props> {
@@ -45,14 +40,9 @@ export default class WalletInfo extends Component<Props> {
       neoPrice,
       gasPrice,
       tokenBalances,
-      icoTokenBalances,
       showModal,
       currencyCode,
       participateInSale,
-      networks,
-      networkId,
-      allTokens,
-      setUserGeneratedTokens,
       loadWalletData
     } = this.props
 
@@ -114,25 +104,7 @@ export default class WalletInfo extends Component<Props> {
           className={(styles.walletButton, styles.icoButton)}
           onClick={() =>
             showModal(MODAL_TYPES.ICO, {
-              assetBalances: {
-                [ASSETS.NEO]: NEO,
-                [ASSETS.GAS]: GAS
-              },
-              tokenBalances: keyBy(
-                icoTokenBalances.filter(
-                  token => !ENDED_ICO_TOKENS.includes(token.symbol)
-                ),
-                'symbol'
-              ),
-              showTokensModal: () => {
-                showModal(MODAL_TYPES.TOKEN, {
-                  tokens: allTokens,
-                  networks,
-                  networkId,
-                  setUserGeneratedTokens,
-                  onSave: loadWalletData
-                })
-              },
+              assetBalances: { [ASSETS.NEO]: NEO, [ASSETS.GAS]: GAS },
               participateInSale
             })
           }

--- a/app/containers/WalletInfo/index.js
+++ b/app/containers/WalletInfo/index.js
@@ -1,5 +1,5 @@
 // @flow
-import { connect, type MapStateToProps } from 'react-redux'
+import { connect } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import { compose } from 'recompose'
 import { values, omit, filter } from 'lodash'
@@ -8,37 +8,25 @@ import { withData, withActions } from 'spunky'
 import accountActions from '../../actions/accountActions'
 import pricesActions from '../../actions/pricesActions'
 import balancesActions from '../../actions/balancesActions'
-import withNetworkData from '../../hocs/withNetworkData'
 import withAuthData from '../../hocs/withAuthData'
 import withCurrencyData from '../../hocs/withCurrencyData'
 import withFilteredTokensData from '../../hocs/withFilteredTokensData'
 import withSuccessNotification from '../../hocs/withSuccessNotification'
 import withFailureNotification from '../../hocs/withFailureNotification'
-import { updateSettingsActions } from '../../actions/settingsActions'
-import { getNetworks } from '../../core/networks'
 import { showModal } from '../../modules/modal'
 import { participateInSale } from '../../modules/sale'
 
 import WalletInfo from './WalletInfo'
-
-const mapStateToProps: MapStateToProps<*, *, *> = (state: Object) => ({
-  networks: getNetworks()
-})
 
 const getTokenBalances = (balances) => {
   const tokens = values(omit(balances, 'NEO', 'GAS'))
   return filter(tokens, (token) => token.balance !== '0')
 }
 
-const getICOTokenBalances = (balances) => {
-  return values(omit(balances, 'NEO', 'GAS'))
-}
-
 const mapBalanceDataToProps = (balances) => ({
   NEO: balances.NEO,
   GAS: balances.GAS,
-  tokenBalances: getTokenBalances(balances),
-  icoTokenBalances: getICOTokenBalances(balances)
+  tokenBalances: getTokenBalances(balances)
 })
 
 const mapPricesDataToProps = ({ NEO, GAS }) => ({
@@ -53,23 +41,17 @@ const actionCreators = {
 
 const mapDispatchToProps = dispatch => bindActionCreators(actionCreators, dispatch)
 
-const mapSettingsActionsToProps = (actions) => ({
-  setUserGeneratedTokens: (tokens) => actions.call({ tokens })
-})
-
 const mapAccountActionsToProps = (actions, props) => ({
   loadWalletData: () => actions.call({ net: props.net, address: props.address, tokens: props.tokens })
 })
 
 export default compose(
-  connect(mapStateToProps, mapDispatchToProps),
+  connect(null, mapDispatchToProps),
   withData(pricesActions, mapPricesDataToProps),
   withData(balancesActions, mapBalanceDataToProps),
-  withNetworkData(),
   withAuthData(),
   withCurrencyData('currencyCode'),
   withFilteredTokensData(),
-  withActions(updateSettingsActions, mapSettingsActionsToProps),
   withActions(accountActions, mapAccountActionsToProps),
   withSuccessNotification(accountActions, 'Received latest blockchain information.'),
   withFailureNotification(accountActions, 'Failed to retrieve blockchain information.')

--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -81,8 +81,6 @@ export const TOKENS = {
   SWH: '78e6d16b914fe15bc16150aeb11d0c2a8e532bdd'
 }
 
-export const ENDED_ICO_TOKENS = ['DBC', 'RPX', 'QLC', 'RHT', 'ONT', 'SWH', 'NRVE']
-
 export const DEFAULT_WALLET = {
   name: 'userWallet',
   version: '1.0',


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
Users are blindly selecting tokens from the token sale modal and sending NEO/GAS after token sales end without understanding what they're doing.  This will prevent them from easily participating.  Instead, they will have to enter a valid script hash.

**How did you solve this problem?**
I replaced the asset dropdown with a script hash input field.  A lot of cleanup was also possible because there is no longer a need to look up a token based upon its symbol.

![token-sale-scripthash](https://user-images.githubusercontent.com/169093/38178751-f1e60a1a-35de-11e8-87ee-440e21675461.gif)

<img width="1112" alt="screen shot 2018-04-01 at 6 59 58 pm" src="https://user-images.githubusercontent.com/169093/38178753-f5e48ce0-35de-11e8-8b22-2b50cf170394.png">

**How did you make sure your solution works?**
* I successfully purchased THOR via script hash on TestNet at a verified address.
* I unsuccessfully purchased QLC via script hash on TestNet using an unverified address.
* I unsuccessfully purchased via invalid script hash on TestNet.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [x] Unit tests written?
