### PR TITLE
Added token details step when participating in token sale

### DIFF
--- a/app/actions/tokenActions.js
+++ b/app/actions/tokenActions.js
@@ -1,0 +1,17 @@
+// @flow
+import { api } from 'neon-js'
+import { createActions } from 'spunky'
+
+type Props = {
+  net: string,
+  scriptHash: string
+}
+
+export const ID = 'TOKEN'
+
+export default createActions(ID, ({ net, scriptHash }: Props = {}) => async () => {
+  const endpoint = await api.loadBalance(api.getRPCEndpointFrom, { net })
+  const response = await api.nep5.getTokenInfo(endpoint, scriptHash)
+
+  return { ...response, scriptHash }
+})

--- a/app/components/Modals/TokenSaleModal/ConfirmToken/ConfirmToken.jsx
+++ b/app/components/Modals/TokenSaleModal/ConfirmToken/ConfirmToken.jsx
@@ -1,0 +1,52 @@
+// @flow
+import React from 'react'
+import classNames from 'classnames'
+import { map } from 'lodash'
+
+import Button from '../../../Button'
+import { toFixedDecimals } from '../../../../core/formatters'
+import toSentence from '../../../../util/toSentence'
+import styles from './ConfirmToken.scss'
+
+type Props = {
+  className: ?string,
+  token: Object,
+  assetBalancesToSend: Object,
+  processing: boolean,
+  onConfirm: Function,
+  onCancel: Function
+}
+
+export default class ConfirmToken extends React.Component<Props> {
+  render () {
+    const { token, processing, onConfirm, onCancel } = this.props
+
+    return (
+      <div className={classNames(styles.confirmToken, this.props.className)}>
+        <div className={styles.heading}>
+          Verify Purchase Details
+        </div>
+        <div className={styles.details}>
+          <p>Sending <strong>{this.getAmounts()}</strong> to:</p>
+          <p>
+            Name: <strong>{token.name}</strong><br />
+            Symbol: <strong>{token.symbol}</strong><br />
+            Total Supply: <strong>{toFixedDecimals(token.totalSupply, token.decimals)}</strong><br />
+            Script Hash: <strong>{token.scriptHash}</strong><br />
+          </p>
+        </div>
+
+        <Button onClick={onCancel}>&laquo; Cancel</Button>
+        <Button onClick={onConfirm} disabled={processing}>Confirm Purchase &raquo;</Button>
+      </div>
+    )
+  }
+
+  getAmounts = () => {
+    const amounts = map(this.props.assetBalancesToSend, (amount, symbol) => (
+      [amount || 0, symbol].join(' ')
+    ))
+
+    return toSentence(amounts)
+  }
+}

--- a/app/components/Modals/TokenSaleModal/ConfirmToken/ConfirmToken.scss
+++ b/app/components/Modals/TokenSaleModal/ConfirmToken/ConfirmToken.scss
@@ -1,0 +1,20 @@
+.confirmToken {
+  text-align: center;
+  padding-top: 168px;
+
+  .heading {
+    padding-bottom: 5px;
+    color: #353535;
+    font-size: 34px;
+  }
+
+  .details {
+    padding: 15px;
+    background-color: #e8f4e4;
+    width: 450px;
+    margin: 0 auto;
+    text-align: left;
+    font-size: 14px;
+    margin-bottom: 30px;
+  }
+}

--- a/app/components/Modals/TokenSaleModal/ConfirmToken/Failed.jsx
+++ b/app/components/Modals/TokenSaleModal/ConfirmToken/Failed.jsx
@@ -1,0 +1,18 @@
+// @flow
+import React from 'react'
+
+import Button from '../../../Button'
+import styles from './Failed.scss'
+
+type Props = {
+  onCancel: Function
+}
+
+export default function Failed (props: Props) {
+  return (
+    <div className={styles.failed}>
+      <p>Failed to load token data</p>
+      <Button onClick={props.onCancel}>&laquo; Go back</Button>
+    </div>
+  )
+}

--- a/app/components/Modals/TokenSaleModal/ConfirmToken/Failed.scss
+++ b/app/components/Modals/TokenSaleModal/ConfirmToken/Failed.scss
@@ -1,0 +1,4 @@
+.failed {
+  text-align: center;
+  padding-top: 168px;
+}

--- a/app/components/Modals/TokenSaleModal/ConfirmToken/Loading.jsx
+++ b/app/components/Modals/TokenSaleModal/ConfirmToken/Loading.jsx
@@ -1,0 +1,13 @@
+// @flow
+import React from 'react'
+
+import Loader from '../../../Loader'
+import styles from './Loading.scss'
+
+export default function Loading (_props: Object) {
+  return (
+    <div className={styles.loading}>
+      <Loader />
+    </div>
+  )
+}

--- a/app/components/Modals/TokenSaleModal/ConfirmToken/Loading.scss
+++ b/app/components/Modals/TokenSaleModal/ConfirmToken/Loading.scss
@@ -1,0 +1,4 @@
+.loading {
+  text-align: center;
+  vertical-align: middle;
+}

--- a/app/components/Modals/TokenSaleModal/ConfirmToken/index.js
+++ b/app/components/Modals/TokenSaleModal/ConfirmToken/index.js
@@ -1,0 +1,23 @@
+// @flow
+import { compose } from 'recompose'
+import { withCall, withData, withProgressComponents, progressValues } from 'spunky'
+
+import ConfirmToken from './ConfirmToken'
+import Loading from './Loading'
+import Failed from './Failed'
+import tokenActions from '../../../../actions/tokenActions'
+import withNetworkData from '../../../../hocs/withNetworkData'
+
+const { LOADING, FAILED } = progressValues
+
+const mapTokenDataToProps = (token) => ({ token })
+
+export default compose(
+  withNetworkData(),
+  withCall(tokenActions),
+  withProgressComponents(tokenActions, {
+    [LOADING]: Loading,
+    [FAILED]: Failed
+  }),
+  withData(tokenActions, mapTokenDataToProps)
+)(ConfirmToken)

--- a/app/components/Modals/TokenSaleModal/ParticipationSuccess/index.jsx
+++ b/app/components/Modals/TokenSaleModal/ParticipationSuccess/index.jsx
@@ -1,50 +1,50 @@
 // @flow
 import React from 'react'
 import Check from 'react-icons/lib/fa/check'
+import { map } from 'lodash'
 
 import Button from '../../../../components/Button'
+import toSentence from '../../../../util/toSentence'
 
 import styles from './styles.scss'
 
 type Props = {
-  hideModal: () => any,
+  onClose: () => any,
   assetBalancesToSend: {
     [key: SymbolType]: string
   },
   scriptHash: string
 }
 
-const formatAssetBalances = assetBalancesToSend => {
-  const balances = []
-  Object.keys(assetBalancesToSend).forEach(symbol => {
-    const balance = assetBalancesToSend[symbol]
-    if (balance) {
-      balances.push(`${balance} ${symbol}`)
-    }
-  })
+export default class ParticipationSuccess extends React.Component<Props> {
+  render () {
+    const { onClose, scriptHash } = this.props
 
-  return balances.join(', ')
+    return (
+      <div className={styles.container}>
+        <div className={styles.iconContainer}>
+          <Check />
+        </div>
+        <div className={styles.heading}>Participation successful!</div>
+        <div className={styles.subHeading}>
+          Your balances may take time to update - please be patient
+        </div>
+        <div className={styles.confirmation}>
+          <div>You sent: <strong>{this.getAmounts()}</strong></div>
+          <div>To: <strong>{scriptHash}</strong></div>
+        </div>
+        <div className={styles.buttonContainer}>
+          <Button onClick={() => onClose()}>I'm Finished</Button>
+        </div>
+      </div>
+    )
+  }
+
+  getAmounts = () => {
+    const amounts = map(this.props.assetBalancesToSend, (amount, symbol) => (
+      [amount || 0, symbol].join(' ')
+    ))
+
+    return toSentence(amounts)
+  }
 }
-
-const ParticipationSuccess = ({ hideModal, scriptHash, assetBalancesToSend }: Props) => {
-  return (
-    <div className={styles.container}>
-      <div className={styles.iconContainer}>
-        <Check />
-      </div>
-      <div className={styles.heading}>Participation successful!</div>
-      <div className={styles.subHeading}>
-        Your balances may take time to update - please be patient
-      </div>
-      <div className={styles.confirmation}>
-        <div>You sent <strong>{formatAssetBalances(assetBalancesToSend)}</strong></div>
-        <div>To: <strong>{scriptHash}</strong></div>
-      </div>
-      <div className={styles.buttonContainer}>
-        <Button onClick={() => hideModal()}>I'm Finished</Button>
-      </div>
-    </div>
-  )
-}
-
-export default ParticipationSuccess

--- a/app/components/Modals/TokenSaleModal/ParticipationSuccess/styles.scss
+++ b/app/components/Modals/TokenSaleModal/ParticipationSuccess/styles.scss
@@ -1,5 +1,3 @@
-@import '../../../../styles/variables';
-
 .container {
   text-align: center;
   padding-top: 100px;
@@ -19,7 +17,7 @@
 .heading {
   padding-bottom: 5px;
   color: #353535;
-  font-size: 34px;  
+  font-size: 34px;
 }
 
 .confirmation {

--- a/app/util/toSentence.js
+++ b/app/util/toSentence.js
@@ -1,0 +1,18 @@
+// @flow
+type Options = {
+  punctuation: string,
+  conjunction: string
+}
+
+const toSentence = (array: Array<any>, { punctuation = ',', conjunction = 'and' }: Options = {}) => {
+  if (array.length <= 2) {
+    return array.join(` ${conjunction} `)
+  }
+
+  return [
+    array.slice(0, array.length - 1).join(`${punctuation} `),
+    array.slice(-1)
+  ].join(`${punctuation} ${conjunction} `)
+}
+
+export default toSentence


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
Now that participating in token sales requires the NEP5 script hash, we're no longer showing details about the token.  We should still provide these details though because it's useful for confirming that the correct script hash was entered.

**How did you solve this problem?**
I added an interim step to the token sale modal.  Now, before purchasing, the user sees a screen that provides details about the token, and they can then confirm the purchase from there.

![token-sale-confirmation](https://user-images.githubusercontent.com/169093/38227868-ed5a52d4-36c5-11e8-8fc3-da256cdb7139.gif)

**How did you make sure your solution works?**
I tried purchasing tokens with correct and incorrect script hashes.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
