### PR TITLE
Revert "Replace token sale asset dropdown with script hash input"

### DIFF
--- a/__tests__/components/__snapshots__/WalletInfo.test.js.snap
+++ b/__tests__/components/__snapshots__/WalletInfo.test.js.snap
@@ -1,7 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`WalletInfo renders without crashing 1`] = `
-<Connect(withData(Connect(withData(Connect(withData(Connect(withData(Connect(withData(withProps(Connect(withData(Connect(withActions(Connect(Connect(withProgress(LoadedNotifier))))))))))))))))))
+<Connect(withData(Connect(withData(Connect(withData(withProps(Connect(withData(Connect(withData(Connect(withData(withProps(Connect(withData(Connect(withActions(Connect(withActions(Connect(Connect(withProgress(LoadedNotifier)))))))))))))))))))))))
+  networks={
+    Array [
+      Object {
+        "id": "1",
+        "label": "MainNet",
+        "network": "MainNet",
+      },
+      Object {
+        "id": "2",
+        "label": "TestNet",
+        "network": "TestNet",
+      },
+    ]
+  }
   participateInSale={[Function]}
   showModal={[Function]}
   store={
@@ -12,6 +26,27 @@ exports[`WalletInfo renders without crashing 1`] = `
       "getState": [Function],
       "replaceReducer": [Function],
       "subscribe": [Function],
+    }
+  }
+  storeSubscription={
+    Subscription {
+      "listeners": Object {
+        "clear": [Function],
+        "get": [Function],
+        "notify": [Function],
+        "subscribe": [Function],
+      },
+      "onStateChange": [Function],
+      "parentSub": undefined,
+      "store": Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      },
+      "unsubscribe": [Function],
     }
   }
 />

--- a/app/components/Modals/TokenSaleModal/ParticipationSuccess/index.jsx
+++ b/app/components/Modals/TokenSaleModal/ParticipationSuccess/index.jsx
@@ -11,7 +11,7 @@ type Props = {
   assetBalancesToSend: {
     [key: SymbolType]: string
   },
-  scriptHash: string
+  token: TokenBalanceType
 }
 
 const formatAssetBalances = assetBalancesToSend => {
@@ -26,7 +26,12 @@ const formatAssetBalances = assetBalancesToSend => {
   return balances.join(', ')
 }
 
-const ParticipationSuccess = ({ hideModal, scriptHash, assetBalancesToSend }: Props) => {
+const ParticipationSuccess = ({
+  hideModal,
+  token,
+  assetBalancesToSend
+}: Props) => {
+  const { scriptHash, name, symbol } = token
   return (
     <div className={styles.container}>
       <div className={styles.iconContainer}>
@@ -39,6 +44,9 @@ const ParticipationSuccess = ({ hideModal, scriptHash, assetBalancesToSend }: Pr
       <div className={styles.confirmation}>
         <div>You sent <strong>{formatAssetBalances(assetBalancesToSend)}</strong></div>
         <div>To: <strong>{scriptHash}</strong></div>
+        <div>
+          For: <strong>{symbol} ({name})</strong>
+        </div>
       </div>
       <div className={styles.buttonContainer}>
         <Button onClick={() => hideModal()}>I'm Finished</Button>

--- a/app/components/Modals/TokenSaleModal/SelectToken/index.jsx
+++ b/app/components/Modals/TokenSaleModal/SelectToken/index.jsx
@@ -1,31 +1,36 @@
 // @flow
-import React from 'react'
+import React, { Component } from 'react'
 
 import { COIN_DECIMAL_LENGTH } from '../../../../core/formatters'
 
 import AssetInput from '../../../../components/Inputs/AssetInput'
 import NumberInput from '../../../../components/NumberInput'
+import Button from '../../../../components/Button'
 
 import styles from './styles.scss'
 import commonStyles from '../styles.scss'
 
 type Props = {
-  onChangeScriptHash: string => any,
+  onChangeToken: string => any,
   onChangeAmount: (SymbolType, string) => any,
   assetBalancesToSend: {
     [key: SymbolType]: string
   },
+  tokenBalances: {
+    [key: SymbolType]: TokenBalanceType
+  },
   assetBalances: {
     [key: SymbolType]: string
   },
-  scriptHash: string
+  tokenToMint: SymbolType,
+  showTokensModal: () => any,
 }
 
 type State = {
   selectedAsset: SymbolType
 }
 
-class SelectToken extends React.Component<Props, State> {
+class SelectToken extends Component<Props, State> {
   state = {
     selectedAsset: Object.keys(this.props.assetBalances)[0]
   }
@@ -40,16 +45,22 @@ class SelectToken extends React.Component<Props, State> {
 
   render () {
     const {
-      onChangeScriptHash,
+      onChangeToken,
+      showTokensModal,
       assetBalances,
       onChangeAmount,
-      scriptHash,
+      tokenBalances,
+      tokenToMint,
       assetBalancesToSend
     } = this.props
 
     const { selectedAsset } = this.state
 
     const assetBalance = assetBalances[selectedAsset]
+    let token
+    if (tokenToMint) {
+      token = tokenBalances[tokenToMint]
+    }
     const balanceToSend = assetBalancesToSend[selectedAsset]
 
     return (
@@ -64,40 +75,67 @@ class SelectToken extends React.Component<Props, State> {
           <div className={styles.content}>
             <div className={styles.mint}>
               <div className={styles.mintBody}>
-                <div className={styles.label}>Enter ICO token script hash to purchase</div>
                 <div>
-                  <input
-                    type='text'
-                    placeholder='Enter token script hash'
-                    value={scriptHash}
-                    className={styles.assetInput}
-                    onChange={(event) => onChangeScriptHash(event.target.value)}
-                  />
+                  <div className={styles.label}>
+                  Select ICO token to purchase
+                  </div>
+                  <div>
+                    <AssetInput
+                      placeholder='Choose token'
+                      symbols={Object.keys(tokenBalances)}
+                      value={tokenToMint}
+                      onChange={symbol => onChangeToken(symbol)}
+                      className={styles.assetInput}
+                    />
+                  </div>
                 </div>
+                <div>
+                  <div className={styles.label}>
+                  Token not in the list?
+                  </div>
+                  <div>
+                    <Button onClick={() => showTokensModal()}
+                      className={styles.purchaseBtn}>
+                    + Add a new token to purchase
+                    </Button>
+                  </div>
+                </div>
+              </div>
+
+              <div className={styles.footer}>
+                {token &&
+                <div>
+                  <div><strong>Token Script Hash:</strong> {token.scriptHash}</div>
+                  <div><strong>Token Name:</strong> {token.name}</div>
+                </div>
+                }
               </div>
             </div>
 
             <div className={styles.assets}>
               <div className={styles.assetsBody}>
-                <div className={styles.label}>What are you purchasing with?</div>
-                <AssetInput
-                  symbols={Object.keys(assetBalances)}
-                  value={selectedAsset}
-                  onChange={asset => this.setState({ selectedAsset: asset }, () => {
-                    onChangeAmount(asset, '')
-                  })}
-                  className={styles.assetInput}
-                />
-
-                <div className={styles.label}>Amount of {selectedAsset}</div>
-                <NumberInput
-                  className={styles.numberInput}
-                  max={assetBalance}
-                  value={balanceToSend}
-                  placeholder='Amount'
-                  options={{ numeralDecimalScale: COIN_DECIMAL_LENGTH }}
-                  onChange={amount => onChangeAmount(selectedAsset, amount)}
-                />
+                <div>
+                  <div className={styles.label}>What are you purchasing with?</div>
+                  <AssetInput
+                    symbols={Object.keys(assetBalances)}
+                    value={selectedAsset}
+                    onChange={asset => this.setState({ selectedAsset: asset }, () => {
+                      onChangeAmount(asset, '')
+                    })}
+                    className={styles.assetInput}
+                  />
+                </div>
+                <div>
+                  <div className={styles.label}>Amount of {selectedAsset}</div>
+                  <NumberInput
+                    className={styles.numberInput}
+                    max={assetBalance}
+                    value={balanceToSend}
+                    placeholder='Amount'
+                    options={{ numeralDecimalScale: COIN_DECIMAL_LENGTH }}
+                    onChange={amount => onChangeAmount(selectedAsset, amount)}
+                  />
+                </div>
               </div>
               <div className={styles.footer}>
                 <strong>Your {selectedAsset} balance:</strong> {assetBalance}

--- a/app/components/Modals/TokenSaleModal/SelectToken/styles.scss
+++ b/app/components/Modals/TokenSaleModal/SelectToken/styles.scss
@@ -19,16 +19,14 @@
 
 .footer {
   background-color: #e8f4e4;
-  height: 40px;
+  height: 80px;
   line-height: 40px;
   padding: 0 12px;
   margin-top: 20px;
 }
 
 .assetInput {
-  box-sizing: border-box;
   width: 100%;
-  margin-bottom: 12px;
 }
 
 .numberInput {
@@ -45,28 +43,35 @@
 }
 
 .mint {
-  flex: 1 1 auto;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  padding-top: 30px;
+  border-right: 1px solid #206408;
 }
 
 .mintBody {
-  padding: 30px 14px 10px;
+  display: flex;
+  > div {
+    padding: 0 14px;
+  }
 }
 
 .label {
-  margin-bottom: 4px;
+  padding-bottom: 12px;
 }
 
 .assets {
-  flex: 1 1 auto;
+  display: flex;
   flex-direction: column;
   justify-content: space-between;
+  padding-top: 30px;
   width: 290px;
-  border-left: 1px solid #206408;
 }
 
 .assetsBody {
-  padding: 30px 14px 10px;
+  > div {
+    padding: 0 14px 10px 14px;
+  }
 }
+

--- a/app/containers/WalletInfo/WalletInfo.jsx
+++ b/app/containers/WalletInfo/WalletInfo.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component } from 'react'
 import classNames from 'classnames'
-import { isNil } from 'lodash'
+import { isNil, keyBy } from 'lodash'
 
 import Claim from '../Claim'
 
@@ -9,7 +9,7 @@ import Tooltip from '../../components/Tooltip'
 import Button from '../../components/Button'
 
 import { formatGAS, formatFiat, formatNEO } from '../../core/formatters'
-import { ASSETS, CURRENCIES, MODAL_TYPES } from '../../core/constants'
+import { ASSETS, CURRENCIES, MODAL_TYPES, ENDED_ICO_TOKENS } from '../../core/constants'
 import { toNumber } from '../../core/math'
 
 import MdSync from 'react-icons/lib/md/sync'
@@ -24,11 +24,16 @@ type Props = {
   GAS: string,
   neoPrice: number,
   gasPrice: number,
+  icoTokenBalances: Array<TokenBalanceType>,
   tokenBalances: Array<TokenBalanceType>,
   loadWalletData: Function,
   currencyCode: string,
   showModal: Function,
-  participateInSale: Function
+  participateInSale: Function,
+  allTokens: Array<TokenItemType>,
+  setUserGeneratedTokens: Function,
+  networks: Array<NetworkItemType>,
+  networkId: string,
 }
 
 export default class WalletInfo extends Component<Props> {
@@ -40,9 +45,14 @@ export default class WalletInfo extends Component<Props> {
       neoPrice,
       gasPrice,
       tokenBalances,
+      icoTokenBalances,
       showModal,
       currencyCode,
       participateInSale,
+      networks,
+      networkId,
+      allTokens,
+      setUserGeneratedTokens,
       loadWalletData
     } = this.props
 
@@ -104,7 +114,25 @@ export default class WalletInfo extends Component<Props> {
           className={(styles.walletButton, styles.icoButton)}
           onClick={() =>
             showModal(MODAL_TYPES.ICO, {
-              assetBalances: { [ASSETS.NEO]: NEO, [ASSETS.GAS]: GAS },
+              assetBalances: {
+                [ASSETS.NEO]: NEO,
+                [ASSETS.GAS]: GAS
+              },
+              tokenBalances: keyBy(
+                icoTokenBalances.filter(
+                  token => !ENDED_ICO_TOKENS.includes(token.symbol)
+                ),
+                'symbol'
+              ),
+              showTokensModal: () => {
+                showModal(MODAL_TYPES.TOKEN, {
+                  tokens: allTokens,
+                  networks,
+                  networkId,
+                  setUserGeneratedTokens,
+                  onSave: loadWalletData
+                })
+              },
               participateInSale
             })
           }

--- a/app/containers/WalletInfo/index.js
+++ b/app/containers/WalletInfo/index.js
@@ -1,5 +1,5 @@
 // @flow
-import { connect } from 'react-redux'
+import { connect, type MapStateToProps } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import { compose } from 'recompose'
 import { values, omit, filter } from 'lodash'
@@ -8,25 +8,37 @@ import { withData, withActions } from 'spunky'
 import accountActions from '../../actions/accountActions'
 import pricesActions from '../../actions/pricesActions'
 import balancesActions from '../../actions/balancesActions'
+import withNetworkData from '../../hocs/withNetworkData'
 import withAuthData from '../../hocs/withAuthData'
 import withCurrencyData from '../../hocs/withCurrencyData'
 import withFilteredTokensData from '../../hocs/withFilteredTokensData'
 import withSuccessNotification from '../../hocs/withSuccessNotification'
 import withFailureNotification from '../../hocs/withFailureNotification'
+import { updateSettingsActions } from '../../actions/settingsActions'
+import { getNetworks } from '../../core/networks'
 import { showModal } from '../../modules/modal'
 import { participateInSale } from '../../modules/sale'
 
 import WalletInfo from './WalletInfo'
+
+const mapStateToProps: MapStateToProps<*, *, *> = (state: Object) => ({
+  networks: getNetworks()
+})
 
 const getTokenBalances = (balances) => {
   const tokens = values(omit(balances, 'NEO', 'GAS'))
   return filter(tokens, (token) => token.balance !== '0')
 }
 
+const getICOTokenBalances = (balances) => {
+  return values(omit(balances, 'NEO', 'GAS'))
+}
+
 const mapBalanceDataToProps = (balances) => ({
   NEO: balances.NEO,
   GAS: balances.GAS,
-  tokenBalances: getTokenBalances(balances)
+  tokenBalances: getTokenBalances(balances),
+  icoTokenBalances: getICOTokenBalances(balances)
 })
 
 const mapPricesDataToProps = ({ NEO, GAS }) => ({
@@ -41,17 +53,23 @@ const actionCreators = {
 
 const mapDispatchToProps = dispatch => bindActionCreators(actionCreators, dispatch)
 
+const mapSettingsActionsToProps = (actions) => ({
+  setUserGeneratedTokens: (tokens) => actions.call({ tokens })
+})
+
 const mapAccountActionsToProps = (actions, props) => ({
   loadWalletData: () => actions.call({ net: props.net, address: props.address, tokens: props.tokens })
 })
 
 export default compose(
-  connect(null, mapDispatchToProps),
+  connect(mapStateToProps, mapDispatchToProps),
   withData(pricesActions, mapPricesDataToProps),
   withData(balancesActions, mapBalanceDataToProps),
+  withNetworkData(),
   withAuthData(),
   withCurrencyData('currencyCode'),
   withFilteredTokensData(),
+  withActions(updateSettingsActions, mapSettingsActionsToProps),
   withActions(accountActions, mapAccountActionsToProps),
   withSuccessNotification(accountActions, 'Received latest blockchain information.'),
   withFailureNotification(accountActions, 'Failed to retrieve blockchain information.')

--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -81,6 +81,8 @@ export const TOKENS = {
   SWH: '78e6d16b914fe15bc16150aeb11d0c2a8e532bdd'
 }
 
+export const ENDED_ICO_TOKENS = ['DBC', 'RPX', 'QLC', 'RHT', 'ONT', 'SWH', 'NRVE']
+
 export const DEFAULT_WALLET = {
   name: 'userWallet',
   version: '1.0',


### PR DESCRIPTION
Reverts CityOfZion/neon-wallet#931

After following up @Ejhfast, his preference is to restore the token dropdown given that we're working towards implementing a `token.json` file that we can fetch in the near future.  This removes the script hash input and brings that dropdown back.