### PR TITLE
fix array slice bug of accounts array that has lenght 0

### DIFF
--- a/app/containers/Settings/Settings.jsx
+++ b/app/containers/Settings/Settings.jsx
@@ -214,27 +214,29 @@ export default class Settings extends Component<Props, State> {
               ))}
             </select>
           </div>
-          <div className='settingsItem'>
-            <div className='itemTitle'>Saved Wallet Accounts</div>
-            {map(accounts, account => {
-              return (
-                <div className='walletList' key={`wallet${account.key}`}>
-                  <div className='walletItem'>
-                    <div className='walletName'>{account.key.slice(0, 20)}</div>
-                    <div className='walletKey'>{account.label}</div>
-                    <div
-                      className='deleteWallet'
-                      onClick={() =>
-                        this.deleteWalletAccount(account.label, account.key)
-                      }
-                    >
-                      <Delete />
+          {this.props.accounts.length > 0 &&
+            <div className='settingsItem'>
+              <div className='itemTitle'>Saved Wallet Accounts</div>
+              {map(accounts, account => {
+                return (
+                  <div className='walletList' key={`wallet${account.key}`}>
+                    <div className='walletItem'>
+                      <div className='walletName'>{account.key.slice(0, 20)}</div>
+                      <div className='walletKey'>{account.label}</div>
+                      <div
+                        className='deleteWallet'
+                        onClick={() =>
+                          this.deleteWalletAccount(account.label, account.key)
+                        }
+                      >
+                        <Delete />
+                      </div>
                     </div>
                   </div>
-                </div>
-              )
-            })}
-          </div>
+                )
+              })}
+            </div>
+          }
           <Button onClick={() => this.saveWalletRecovery()}>
             Export wallet recovery file
           </Button>


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
#890
It fixes the white screen issue when loading recovery keys in the settings.

**What problem does this PR solve?**
It doesn't slice the accounts array if there are no accounts, this doesn't throw an error.

**How did you solve this problem?**
Inline If with Logical && Operator to check the accounts props length.

**How did you make sure your solution works?**
tested in production locally on my mac. I didn't test it on windows.

**Are there any special changes in the code that we should be aware of?**
No.

**Is there anything else we should know?**
No.

- [x] Unit tests written?

> Test Suites: 23 passed, 23 total
Tests:       89 passed, 89 total
Snapshots:   13 passed, 13 total
Time:        31.52s
Ran all test suites.
✨  Done in 37.43s.
