### PR TITLE
Added token sale verification screen

### DIFF
--- a/app/components/Modals/TokenSaleModal/ConfirmToken/ConfirmToken.jsx
+++ b/app/components/Modals/TokenSaleModal/ConfirmToken/ConfirmToken.jsx
@@ -1,0 +1,52 @@
+// @flow
+import React from 'react'
+import classNames from 'classnames'
+import { map } from 'lodash'
+
+import Button from '../../../Button'
+import { toFixedDecimals } from '../../../../core/formatters'
+import toSentence from '../../../../util/toSentence'
+import styles from './ConfirmToken.scss'
+
+type Props = {
+  className: ?string,
+  token: TokenBalanceType,
+  assetBalancesToSend: { [key: SymbolType]: string },
+  processing: boolean,
+  onConfirm: Function,
+  onCancel: Function
+}
+
+export default class ConfirmToken extends React.Component<Props> {
+  render () {
+    const { token, processing, onConfirm, onCancel } = this.props
+
+    return (
+      <div className={classNames(styles.confirmToken, this.props.className)}>
+        <div className={styles.heading}>
+          Verify Purchase Details
+        </div>
+        <div className={styles.details}>
+          <p>Sending <strong>{this.getAmounts()}</strong> to:</p>
+          <p>
+            Name: <strong>{token.name}</strong><br />
+            Symbol: <strong>{token.symbol}</strong><br />
+            Total Supply: <strong>{toFixedDecimals(token.totalSupply, token.decimals)}</strong><br />
+            Script Hash: <strong>{token.scriptHash}</strong><br />
+          </p>
+        </div>
+
+        <Button onClick={onCancel}>&laquo; Cancel</Button>
+        <Button onClick={onConfirm} disabled={processing}>Confirm Purchase &raquo;</Button>
+      </div>
+    )
+  }
+
+  getAmounts = () => {
+    const amounts = map(this.props.assetBalancesToSend, (amount, symbol) => (
+      [amount || 0, symbol].join(' ')
+    ))
+
+    return toSentence(amounts)
+  }
+}

--- a/app/components/Modals/TokenSaleModal/ConfirmToken/ConfirmToken.scss
+++ b/app/components/Modals/TokenSaleModal/ConfirmToken/ConfirmToken.scss
@@ -1,0 +1,20 @@
+.confirmToken {
+  text-align: center;
+  padding-top: 168px;
+
+  .heading {
+    padding-bottom: 5px;
+    color: #353535;
+    font-size: 34px;
+  }
+
+  .details {
+    padding: 15px;
+    background-color: #e8f4e4;
+    width: 450px;
+    margin: 0 auto;
+    text-align: left;
+    font-size: 14px;
+    margin-bottom: 30px;
+  }
+}

--- a/app/components/Modals/TokenSaleModal/ConfirmToken/Failed/Failed.jsx
+++ b/app/components/Modals/TokenSaleModal/ConfirmToken/Failed/Failed.jsx
@@ -1,0 +1,18 @@
+// @flow
+import React from 'react'
+
+import Button from '../../../../Button'
+import styles from './Failed.scss'
+
+type Props = {
+  onCancel: Function
+}
+
+export default function Failed (props: Props) {
+  return (
+    <div className={styles.failed}>
+      <p>Failed to load token data</p>
+      <Button onClick={props.onCancel}>&laquo; Go back</Button>
+    </div>
+  )
+}

--- a/app/components/Modals/TokenSaleModal/ConfirmToken/Failed/Failed.scss
+++ b/app/components/Modals/TokenSaleModal/ConfirmToken/Failed/Failed.scss
@@ -1,0 +1,4 @@
+.failed {
+  text-align: center;
+  padding-top: 168px;
+}

--- a/app/components/Modals/TokenSaleModal/ConfirmToken/Failed/index.js
+++ b/app/components/Modals/TokenSaleModal/ConfirmToken/Failed/index.js
@@ -1,0 +1,1 @@
+export { default } from './Failed'

--- a/app/components/Modals/TokenSaleModal/ConfirmToken/Loading/Loading.jsx
+++ b/app/components/Modals/TokenSaleModal/ConfirmToken/Loading/Loading.jsx
@@ -1,0 +1,13 @@
+// @flow
+import React from 'react'
+
+import Loader from '../../../../Loader'
+import styles from './Loading.scss'
+
+export default function Loading (_props: Object) {
+  return (
+    <div className={styles.loading}>
+      <Loader />
+    </div>
+  )
+}

--- a/app/components/Modals/TokenSaleModal/ConfirmToken/Loading/Loading.scss
+++ b/app/components/Modals/TokenSaleModal/ConfirmToken/Loading/Loading.scss
@@ -1,0 +1,4 @@
+.loading {
+  text-align: center;
+  vertical-align: middle;
+}

--- a/app/components/Modals/TokenSaleModal/ConfirmToken/Loading/index.js
+++ b/app/components/Modals/TokenSaleModal/ConfirmToken/Loading/index.js
@@ -1,0 +1,1 @@
+export { default } from './Loading'

--- a/app/components/Modals/TokenSaleModal/ConfirmToken/index.js
+++ b/app/components/Modals/TokenSaleModal/ConfirmToken/index.js
@@ -1,0 +1,2 @@
+// @flow
+export { default } from './ConfirmToken'

--- a/app/components/Modals/TokenSaleModal/ParticipationSuccess/index.jsx
+++ b/app/components/Modals/TokenSaleModal/ParticipationSuccess/index.jsx
@@ -1,58 +1,48 @@
 // @flow
 import React from 'react'
 import Check from 'react-icons/lib/fa/check'
+import { map } from 'lodash'
 
 import Button from '../../../../components/Button'
-
+import toSentence from '../../../../util/toSentence'
 import styles from './styles.scss'
 
 type Props = {
-  hideModal: () => any,
-  assetBalancesToSend: {
-    [key: SymbolType]: string
-  },
+  onClose: () => any,
+  assetBalancesToSend: { [key: SymbolType]: string },
   token: TokenBalanceType
 }
 
-const formatAssetBalances = assetBalancesToSend => {
-  const balances = []
-  Object.keys(assetBalancesToSend).forEach(symbol => {
-    const balance = assetBalancesToSend[symbol]
-    if (balance) {
-      balances.push(`${balance} ${symbol}`)
-    }
-  })
-
-  return balances.join(', ')
-}
-
-const ParticipationSuccess = ({
-  hideModal,
-  token,
-  assetBalancesToSend
-}: Props) => {
-  const { scriptHash, name, symbol } = token
-  return (
-    <div className={styles.container}>
-      <div className={styles.iconContainer}>
-        <Check />
-      </div>
-      <div className={styles.heading}>Participation successful!</div>
-      <div className={styles.subHeading}>
-        Your balances may take time to update - please be patient
-      </div>
-      <div className={styles.confirmation}>
-        <div>You sent <strong>{formatAssetBalances(assetBalancesToSend)}</strong></div>
-        <div>To: <strong>{scriptHash}</strong></div>
-        <div>
-          For: <strong>{symbol} ({name})</strong>
+export default class ParticipationSuccess extends React.Component<Props> {
+  render () {
+    const { onClose, token } = this.props
+    const { scriptHash, name, symbol } = token
+    return (
+      <div className={styles.container}>
+        <div className={styles.iconContainer}>
+          <Check />
+        </div>
+        <div className={styles.heading}>Participation successful!</div>
+        <div className={styles.subHeading}>
+          Your balances may take time to update - please be patient
+        </div>
+        <div className={styles.confirmation}>
+          <div>You sent <strong>{this.getAmounts()}</strong></div>
+          <div>To: <strong>{scriptHash}</strong></div>
+          <div>For: <strong>{symbol} ({name})</strong></div>
+        </div>
+        <div className={styles.buttonContainer}>
+          <Button onClick={() => onClose()}>I'm Finished</Button>
         </div>
       </div>
-      <div className={styles.buttonContainer}>
-        <Button onClick={() => hideModal()}>I'm Finished</Button>
-      </div>
-    </div>
-  )
-}
+    )
+  }
 
-export default ParticipationSuccess
+  getAmounts = () => {
+    const amounts = map(this.props.assetBalancesToSend, (amount, symbol) => (
+      [amount || 0, symbol].join(' ')
+    ))
+
+    return toSentence(amounts)
+  }
+}

--- a/app/components/Modals/TokenSaleModal/ParticipationSuccess/styles.scss
+++ b/app/components/Modals/TokenSaleModal/ParticipationSuccess/styles.scss
@@ -1,5 +1,3 @@
-@import '../../../../styles/variables';
-
 .container {
   text-align: center;
   padding-top: 100px;
@@ -19,7 +17,7 @@
 .heading {
   padding-bottom: 5px;
   color: #353535;
-  font-size: 34px;  
+  font-size: 34px;
 }
 
 .confirmation {

--- a/app/components/Modals/TokenSaleModal/SelectToken/index.jsx
+++ b/app/components/Modals/TokenSaleModal/SelectToken/index.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React, { Component } from 'react'
+import React from 'react'
 
 import { COIN_DECIMAL_LENGTH } from '../../../../core/formatters'
 
@@ -30,7 +30,7 @@ type State = {
   selectedAsset: SymbolType
 }
 
-class SelectToken extends Component<Props, State> {
+class SelectToken extends React.Component<Props, State> {
   state = {
     selectedAsset: Object.keys(this.props.assetBalances)[0]
   }
@@ -77,7 +77,7 @@ class SelectToken extends Component<Props, State> {
               <div className={styles.mintBody}>
                 <div>
                   <div className={styles.label}>
-                  Select ICO token to purchase
+                    Select ICO token to purchase
                   </div>
                   <div>
                     <AssetInput
@@ -91,12 +91,11 @@ class SelectToken extends Component<Props, State> {
                 </div>
                 <div>
                   <div className={styles.label}>
-                  Token not in the list?
+                    Token not in the list?
                   </div>
                   <div>
-                    <Button onClick={() => showTokensModal()}
-                      className={styles.purchaseBtn}>
-                    + Add a new token to purchase
+                    <Button onClick={() => showTokensModal()} className={styles.purchaseBtn}>
+                      + Add a new token to purchase
                     </Button>
                   </div>
                 </div>

--- a/app/components/Modals/TokenSaleModal/TokenSaleModal.jsx
+++ b/app/components/Modals/TokenSaleModal/TokenSaleModal.jsx
@@ -11,6 +11,7 @@ import Button from '../../Button'
 
 import WarningText from './WarningText'
 import SelectToken from './SelectToken'
+import ConfirmToken from './ConfirmToken'
 import ParticipationSuccess from './ParticipationSuccess'
 
 import styles from './styles.scss'
@@ -40,42 +41,46 @@ type State = {
     [key: SymbolType]: string
   },
   tokenToMint: SymbolType,
-  participationSuccessful: boolean,
+  step: number,
   gasCost: string,
-  loaded: boolean,
-  agreements: Array<boolean>
+  agreements: Array<boolean>,
+  processing: boolean
 }
-
-const initialBalancesToSend = { [ASSETS.NEO]: '', [ASSETS.GAS]: '' }
 
 export default class TokenSale extends Component<Props, State> {
   // $FlowFixMe
   state = {
-    assetBalancesToSend: initialBalancesToSend,
+    assetBalancesToSend: {},
     tokenToMint: '',
     participationSuccessful: false,
-    loaded: false,
+    step: 1,
     gasCost: '0', // hard coded for now
-    agreements: times(WARNINGS.length, constant(false))
+    agreements: times(WARNINGS.length, constant(false)),
+    processing: false
   }
 
   participateInSale = async () => {
     const { participateInSale, tokenBalances } = this.props
     const { assetBalancesToSend, tokenToMint, gasCost } = this.state
 
-    if (tokenToMint) {
-      const scriptHash = get(tokenBalances[tokenToMint], 'scriptHash')
-      const amountNEO = assetBalancesToSend[ASSETS.NEO] || '0'
-      const amountGAS = assetBalancesToSend[ASSETS.GAS] || '0'
-      const success = await participateInSale(amountNEO, amountGAS, scriptHash, gasCost)
+    if (!tokenToMint) {
+      return
+    }
 
-      if (success) {
-        this.setState({ participationSuccessful: true })
-      }
+    const scriptHash = get(tokenBalances[tokenToMint], 'scriptHash')
+    const amountNEO = assetBalancesToSend[ASSETS.NEO] || '0'
+    const amountGAS = assetBalancesToSend[ASSETS.GAS] || '0'
+
+    const success = await participateInSale(amountNEO, amountGAS, scriptHash, gasCost)
+
+    if (success) {
+      this.setState({ step: 3, processing: false })
+    } else {
+      this.setState({ processing: false })
     }
   }
 
-  isValidAssetBalances = () => {
+  isValid = () => {
     const { assetBalancesToSend, tokenToMint } = this.state
     const NEO = assetBalancesToSend.NEO || '0'
     const GAS = assetBalancesToSend.GAS || '0'
@@ -92,64 +97,102 @@ export default class TokenSale extends Component<Props, State> {
       return false
     }
 
+    if (!every(this.state.agreements)) {
+      return false
+    }
+
     return true
   }
 
   render () {
-    const { assetBalancesToSend, tokenToMint, participationSuccessful } = this.state
-    const { hideModal, tokenBalances, assetBalances, showTokensModal } = this.props
-    const disabled = this.isDisabled()
+    const { hideModal } = this.props
+    const { step } = this.state
 
     return (
       <BaseModal
-        title={participationSuccessful ? 'Participation successful' : 'Participate in a token sale'}
+        title={step === 3 ? 'Participation successful' : 'Participate in a token sale'}
         hideModal={hideModal}
         style={{ content: { width: '925px', height: '700px' } }}
       >
-        {participationSuccessful ? (
-          <ParticipationSuccess
-            hideModal={hideModal}
-            token={tokenBalances[tokenToMint]}
-            assetBalancesToSend={assetBalancesToSend}
-          />
-        ) : (
-          <div className={styles.tokenSale}>
-            <SelectToken
-              onChangeToken={(symbol: SymbolType) =>
-                this.setState({ tokenToMint: symbol })
-              }
-              onChangeAmount={(symbol: SymbolType, amount: string) =>
-                this.setState({
-                  assetBalancesToSend: {
-                    ...initialBalancesToSend,
-                    [symbol]: amount
-                  }
-                })
-              }
-              assetBalancesToSend={assetBalancesToSend}
-              tokenBalances={tokenBalances}
-              assetBalances={assetBalances}
-              tokenToMint={tokenToMint}
-              showTokensModal={showTokensModal}
-            />
-
-            <WarningText>
-              {map(WARNINGS, this.renderWarning)}
-            </WarningText>
-
-            <div className={styles.purchaseButton}>
-              <Tooltip title='Please agree to the terms of purchase' position='top' disabled={!disabled}>
-                <Button
-                  onClick={this.participateInSale}
-                  disabled={disabled}
-                >
-                  Purchase!
-                </Button>
-              </Tooltip>
-            </div>
-          </div>
-        )}
+        {this.renderStep()}
       </BaseModal>
+    )
+  }
+
+  renderStep = () => {
+    switch (this.state.step) {
+      case 1:
+      default:
+        return this.renderPurchase()
+      case 2:
+        return this.renderConfirm()
+      case 3:
+        return this.renderSuccess()
+    }
+  }
+
+  renderConfirm = () => {
+    const { tokenBalances } = this.props
+    const { assetBalancesToSend, tokenToMint, processing } = this.state
+
+    return (
+      /* $FlowFixMe */
+      <ConfirmToken
+        token={tokenBalances[tokenToMint]}
+        assetBalancesToSend={assetBalancesToSend}
+        processing={processing}
+        onConfirm={this.handleConfirm}
+        onCancel={this.handleCancel}
+      />
+    )
+  }
+
+  renderSuccess = () => {
+    const { hideModal, tokenBalances } = this.props
+    const { assetBalancesToSend, tokenToMint } = this.state
+
+    return (
+      <ParticipationSuccess
+        token={tokenBalances[tokenToMint]}
+        assetBalancesToSend={assetBalancesToSend}
+        onClose={hideModal}
+      />
+    )
+  }
+
+  renderPurchase = () => {
+    const { assetBalancesToSend, tokenToMint } = this.state
+    const { tokenBalances, assetBalances, showTokensModal } = this.props
+    const valid = this.isValid()
+
+    return (
+      <div className={styles.tokenSale}>
+        <SelectToken
+          onChangeToken={(symbol: SymbolType) =>
+            this.setState({ tokenToMint: symbol })
+          }
+          onChangeAmount={(symbol: SymbolType, amount: string) => (
+            this.setState({ assetBalancesToSend: { [symbol]: amount } })
+          )}
+          assetBalancesToSend={assetBalancesToSend}
+          tokenBalances={tokenBalances}
+          assetBalances={assetBalances}
+          tokenToMint={tokenToMint}
+          showTokensModal={showTokensModal}
+        />
+
+        <WarningText>
+          {map(WARNINGS, this.renderWarning)}
+        </WarningText>
+
+        <div className={styles.purchaseButton}>
+          <Tooltip title='Please agree to the terms of purchase' position='top' disabled={valid}>
+            <Button onClick={this.handleStep(2)} disabled={!valid}>
+              Continue &raquo;
+            </Button>
+          </Tooltip>
+        </div>
+      </div>
     )
   }
 
@@ -168,15 +211,25 @@ export default class TokenSale extends Component<Props, State> {
     )
   }
 
-  isDisabled = () => {
-    return !this.isValidAssetBalances() || !every(this.state.agreements)
-  }
-
   handleChangeAgreementCurry = (index: number) => {
     return (event: Object) => {
       const agreements = [...this.state.agreements]
       agreements.splice(index, 1, event.target.checked)
       this.setState({ agreements })
     }
+  }
+
+  handleStep = (step: number) => {
+    return () => {
+      this.setState({ step })
+    }
+  }
+
+  handleConfirm = () => {
+    this.setState({ processing: true }, this.participateInSale)
+  }
+
+  handleCancel = () => {
+    this.setState({ step: 1, assetBalancesToSend: {} })
   }
 }

--- a/app/util/toSentence.js
+++ b/app/util/toSentence.js
@@ -1,0 +1,18 @@
+// @flow
+type Options = {
+  punctuation: string,
+  conjunction: string
+}
+
+const toSentence = (array: Array<any>, { punctuation = ',', conjunction = 'and' }: Options = {}) => {
+  if (array.length <= 2) {
+    return array.join(` ${conjunction} `)
+  }
+
+  return [
+    array.slice(0, array.length - 1).join(`${punctuation} `),
+    array.slice(-1)
+  ].join(`${punctuation} ${conjunction} `)
+}
+
+export default toSentence


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
This adds the token verification screen.  I originally approached this as part of #932, but I closed that and refactored due to a change in direction from Ethan in terms of how we should approach the token sale window.

This extra step will help to ensure users re-read what they're sending, where they're sending it, etc. before actually confirming.

**How did you solve this problem?**
I added an extra step to the token sale modal.  It's now a 3 step process.

**How did you make sure your solution works?**
I smoke tested with various tokens and addresses and amounts.  The attempts that should have succeeded did, and the attempts that should have failed did.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
