### PR TITLE
Made wallet version more visible

### DIFF
--- a/app/containers/App/Header/Header.jsx
+++ b/app/containers/App/Header/Header.jsx
@@ -14,6 +14,7 @@ import styles from './Header.scss'
 import logo from '../../../images/neon-logo2.png'
 
 const Logo = () => <div><img src={logo} width='60px' /></div>
+const wallet = <WalletVersion version={version} />
 
 type Props = {
   address: string,
@@ -30,6 +31,7 @@ const Header = ({
 }: Props) => (
   <div className={styles.container}>
     <Logo />
+    {!address && wallet}
     {address &&
     <div className={styles.navBar}>
       <PriceDisplay
@@ -38,7 +40,7 @@ const Header = ({
         currencyCode={currencyCode}
       />
       <WalletBlockHeight />
-      <WalletVersion version={version} />
+      {wallet}
       <NetworkSwitch />
       <Logout />
     </div>


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
[#731](https://github.com/CityOfZion/neon-wallet/issues/731)

**What problem does this PR solve?**
This adds wallet version to the top right corner of the app

**How did you solve this problem?**
I added the wallet component to the header

**How did you make sure your solution works?**
I have tested locally on my macbook.

**Are there any special changes in the code that we should be aware of?**
nope

**Is there anything else we should know?**
nope

- [ ] Unit tests written?