### PR TITLE
Fixed community support link in footer

### DIFF
--- a/app/containers/App/Footer.jsx
+++ b/app/containers/App/Footer.jsx
@@ -7,23 +7,26 @@ import NetworkSwitch from './Sidebar/NetworkSwitch'
 
 import styles from './Footer.scss'
 
-const openDiscordLink = () => shell.openExternal('https://discordapp.com/invite/R8v48YA')
-
 type Props = {
   className?: string
 }
 
-const Footer = ({ className }: Props) => {
-  return (
-    <div className={classNames(styles.footer, className)}>
-      <span className={styles.item}>
-        <NetworkSwitch />
-      </span>
-      <span className={styles.item}>
-        <a href='#' onClick={openDiscordLink}>Community Support</a>
-      </span>
-    </div>
-  )
-}
+export default class Footer extends React.Component<Props> {
+  render () {
+    return (
+      <div className={classNames(styles.footer, this.props.className)}>
+        <span className={styles.item}>
+          <NetworkSwitch />
+        </span>
+        <span className={styles.item}>
+          <a href='#' onClick={this.handleSupport}>Community Support</a>
+        </span>
+      </div>
+    )
+  }
 
-export default Footer
+  handleSupport = (event: Object) => {
+    event.preventDefault()
+    shell.openExternal('https://discordapp.com/invite/R8v48YA')
+  }
+}


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Fixes #980.

**What problem does this PR solve?**
Clicking the "Community Support" link in the footer opens the link, but it also navigates the user back to the login screen.

**How did you solve this problem?**
I called `event.preventDefault()` to not have the link be handled by react-router.

**How did you make sure your solution works?**
Clicked the link.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
