### PR TITLE
Added v2 design for contacts

### DIFF
--- a/app/components/Button/Button.scss
+++ b/app/components/Button/Button.scss
@@ -7,9 +7,10 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  font-size: 16px;
+  font-size: 14px;
   font-weight: 100;
   padding: 10px;
+  white-space: nowrap;
   transition: opacity .2s;
 
   &[disabled] {
@@ -72,6 +73,11 @@
 
     &.light {
       // TODO
+    }
+
+    svg {
+      width: 100%;
+      height: 100%;
     }
   }
 }

--- a/app/components/Contacts/AddContactPanel/AddContactPanel.jsx
+++ b/app/components/Contacts/AddContactPanel/AddContactPanel.jsx
@@ -8,7 +8,7 @@ import Panel from '../../Panel'
 import ContactForm from '../ContactForm'
 import ArrowIcon from '../../../assets/icons/arrow.svg'
 import { ROUTES } from '../../../core/constants'
-import styles from './EditContactPanel.scss'
+import styles from './AddContactPanel.scss'
 
 type Props = {
   className: ?string,
@@ -17,7 +17,7 @@ type Props = {
   onSave: Function
 }
 
-export default class EditContactPanel extends React.Component<Props> {
+export default class AddContactPanel extends React.Component<Props> {
   static defaultProps = {
     name: '',
     address: '',
@@ -31,7 +31,7 @@ export default class EditContactPanel extends React.Component<Props> {
 
     return (
       <Panel
-        className={classNames(styles.editContactPanel, className)}
+        className={classNames(styles.addContactPanel, className)}
         renderHeader={this.renderHeader}
       >
         <ContactForm name={name} address={address} onSubmit={this.handleSubmit} />
@@ -43,7 +43,7 @@ export default class EditContactPanel extends React.Component<Props> {
     return (
       <span className={styles.header}>
         <Link to={ROUTES.CONTACTS} className={styles.back}><ArrowIcon /></Link>
-        <span>Edit Contact</span>
+        <span>Add Contact</span>
       </span>
     )
   }

--- a/app/components/Contacts/AddContactPanel/AddContactPanel.scss
+++ b/app/components/Contacts/AddContactPanel/AddContactPanel.scss
@@ -1,4 +1,4 @@
-.editContactPanel {
+.addContactPanel {
   max-width: 600px;
 
   .header {

--- a/app/components/Contacts/AddContactPanel/index.js
+++ b/app/components/Contacts/AddContactPanel/index.js
@@ -3,17 +3,17 @@ import { compose, withProps } from 'recompose'
 import { connect } from 'react-redux'
 import { trim } from 'lodash'
 
-import EditContactPanel from './EditContactPanel'
-import { updateAddress } from '../../../modules/addressBook'
+import AddContactPanel from './AddContactPanel'
+import { saveAddress } from '../../../modules/addressBook'
 
 const mapDispatchToProps = (dispatch, props) => ({
   onSave: (name, address) => {
     props.onSave && props.onSave()
-    return dispatch(updateAddress(props.oldName, trim(name), trim(address)))
+    return dispatch(saveAddress(trim(name), trim(address)))
   }
 })
 
 export default compose(
   withProps(({ name }) => ({ oldName: name })),
   connect(null, mapDispatchToProps)
-)(EditContactPanel)
+)(AddContactPanel)

--- a/app/components/Contacts/ContactForm/ContactForm.jsx
+++ b/app/components/Contacts/ContactForm/ContactForm.jsx
@@ -1,0 +1,72 @@
+// @flow
+import React from 'react'
+import { noop } from 'lodash'
+
+import Button from '../../Button'
+import TextInput from '../../Inputs/TextInput'
+import AddIcon from '../../../assets/icons/contacts-add.svg'
+import styles from './ContactForm.scss'
+
+type Props = {
+  submitLabel: string,
+  name: string,
+  address: string,
+  setName: Function,
+  setAddress: Function,
+  onSubmit: Function
+}
+
+export default class ContactForm extends React.Component<Props> {
+  static defaultProps = {
+    submitLabel: 'Save Contact',
+    name: '',
+    address: '',
+    setName: noop,
+    setAddress: noop,
+    onSubmit: noop
+  }
+
+  render () {
+    const { submitLabel, name, address } = this.props
+
+    return (
+      <form className={styles.contactForm} onSubmit={this.handleSubmit}>
+        <TextInput
+          className={styles.input}
+          placeholder='Contact Name'
+          value={name}
+          onChange={this.handleChangeName}
+        />
+        <TextInput
+          className={styles.input}
+          placeholder='Address'
+          value={address}
+          onChange={this.handleChangeAddress}
+        />
+        <Button
+          className={styles.button}
+          primary
+          type='submit'
+          renderIcon={AddIcon}
+        >
+          {submitLabel}
+        </Button>
+      </form>
+    )
+  }
+
+  handleChangeName = (event: Object) => {
+    this.props.setName(event.target.value)
+  }
+
+  handleChangeAddress = (event: Object) => {
+    this.props.setAddress(event.target.value)
+  }
+
+  handleSubmit = (event: Object) => {
+    const { onSubmit, name, address } = this.props
+
+    event.preventDefault()
+    onSubmit(name, address)
+  }
+}

--- a/app/components/Contacts/ContactForm/ContactForm.scss
+++ b/app/components/Contacts/ContactForm/ContactForm.scss
@@ -1,0 +1,8 @@
+.contactForm {
+  max-width: 385px;
+  margin: 0 auto;
+
+  .input {
+    margin-bottom: 10px;
+  }
+}

--- a/app/components/Contacts/ContactForm/index.js
+++ b/app/components/Contacts/ContactForm/index.js
@@ -1,0 +1,9 @@
+// @flow
+import { compose, withState } from 'recompose'
+
+import ContactForm from './ContactForm'
+
+export default compose(
+  withState('name', 'setName', ({ name }) => name || ''),
+  withState('address', 'setAddress', ({ address }) => address || '')
+)(ContactForm)

--- a/app/components/Contacts/ContactsPanel/ContactsPanel.jsx
+++ b/app/components/Contacts/ContactsPanel/ContactsPanel.jsx
@@ -1,0 +1,79 @@
+// @flow
+import React from 'react'
+import { map } from 'lodash'
+
+import Panel from '../../Panel'
+import Button from '../../Button'
+import AddIcon from '../../../assets/icons/contacts-add.svg'
+import EditIcon from '../../../assets/icons/edit.svg'
+import DeleteIcon from '../../../assets/icons/delete.svg'
+import styles from './ContactsPanel.scss'
+
+type Props = {
+  contacts: {
+    [name: string]: string
+  }
+}
+
+export default class ContactsPanel extends React.Component<Props> {
+  render () {
+    return (
+      <Panel className={styles.contactsPanel} renderHeader={this.renderHeader}>
+        <div className={styles.contacts}>
+          {map(this.props.contacts, this.renderContact)}
+        </div>
+      </Panel>
+    )
+  }
+
+  renderHeader = () => {
+    return (
+      <div className={styles.header}>
+        <span>Contacts</span>
+        <span id='add' className={styles.addButton} onClick={this.handleAdd}>
+          <AddIcon className={styles.addIcon} />
+          <span>New Contact</span>
+        </span>
+      </div>
+    )
+  }
+
+  renderContact = (address: string, name: string) => {
+    return (
+      <div key={address} className={styles.contact}>
+        <div className={styles.details}>
+          <div className={styles.name}>{name}</div>
+          <div className={styles.address}>{address}</div>
+        </div>
+        <div className={styles.actions}>
+          <Button
+            className={styles.editButton}
+            renderIcon={EditIcon}
+            onClick={this.handleEdit}
+          >
+            Edit
+          </Button>
+          <Button
+            className={styles.deleteButton}
+            renderIcon={DeleteIcon}
+            onClick={this.handleDelete}
+          >
+            Delete Contact
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  handleAdd = () => {
+    // TODO
+  }
+
+  handleEdit = () => {
+    // TODO
+  }
+
+  handleDelete = () => {
+    // TODO
+  }
+}

--- a/app/components/Contacts/ContactsPanel/ContactsPanel.jsx
+++ b/app/components/Contacts/ContactsPanel/ContactsPanel.jsx
@@ -12,7 +12,8 @@ import styles from './ContactsPanel.scss'
 type Props = {
   contacts: {
     [name: string]: string
-  }
+  },
+  deleteContact: Function
 }
 
 export default class ContactsPanel extends React.Component<Props> {
@@ -56,7 +57,7 @@ export default class ContactsPanel extends React.Component<Props> {
           <Button
             className={styles.deleteButton}
             renderIcon={DeleteIcon}
-            onClick={this.handleDelete}
+            onClick={this.handleDelete(name)}
           >
             Delete Contact
           </Button>
@@ -73,7 +74,11 @@ export default class ContactsPanel extends React.Component<Props> {
     // TODO
   }
 
-  handleDelete = () => {
-    // TODO
+  handleDelete = (name: string) => {
+    return () => {
+      if (window.confirm(`Are you sure you want to delete contact "${name}"?`)) {
+        this.props.deleteContact(name)
+      }
+    }
   }
 }

--- a/app/components/Contacts/ContactsPanel/ContactsPanel.jsx
+++ b/app/components/Contacts/ContactsPanel/ContactsPanel.jsx
@@ -71,7 +71,7 @@ export default class ContactsPanel extends React.Component<Props> {
 
   handleEdit = (name: string) => {
     return () => {
-      this.props.history.push(`/contacts/edit/${name}`)
+      this.props.history.push(`/contacts/edit/${encodeURIComponent(name)}`)
     }
   }
 

--- a/app/components/Contacts/ContactsPanel/ContactsPanel.jsx
+++ b/app/components/Contacts/ContactsPanel/ContactsPanel.jsx
@@ -10,6 +10,7 @@ import DeleteIcon from '../../../assets/icons/delete.svg'
 import styles from './ContactsPanel.scss'
 
 type Props = {
+  history: Object,
   contacts: {
     [name: string]: string
   },
@@ -50,7 +51,7 @@ export default class ContactsPanel extends React.Component<Props> {
           <Button
             className={styles.editButton}
             renderIcon={EditIcon}
-            onClick={this.handleEdit}
+            onClick={this.handleEdit(name)}
           >
             Edit
           </Button>
@@ -70,8 +71,10 @@ export default class ContactsPanel extends React.Component<Props> {
     // TODO
   }
 
-  handleEdit = () => {
-    // TODO
+  handleEdit = (name: string) => {
+    return () => {
+      this.props.history.push(`/contacts/edit/${name}`)
+    }
   }
 
   handleDelete = (name: string) => {

--- a/app/components/Contacts/ContactsPanel/ContactsPanel.jsx
+++ b/app/components/Contacts/ContactsPanel/ContactsPanel.jsx
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react'
+import { Link } from 'react-router-dom'
 import { map } from 'lodash'
 
 import Panel from '../../Panel'
@@ -7,6 +8,7 @@ import Button from '../../Button'
 import AddIcon from '../../../assets/icons/contacts-add.svg'
 import EditIcon from '../../../assets/icons/edit.svg'
 import DeleteIcon from '../../../assets/icons/delete.svg'
+import { ROUTES } from '../../../core/constants'
 import styles from './ContactsPanel.scss'
 
 type Props = {
@@ -32,17 +34,17 @@ export default class ContactsPanel extends React.Component<Props> {
     return (
       <div className={styles.header}>
         <span>Contacts</span>
-        <span id='add' className={styles.addButton} onClick={this.handleAdd}>
+        <Link id='add' className={styles.addButton} to={ROUTES.ADD_CONTACT}>
           <AddIcon className={styles.addIcon} />
           <span>New Contact</span>
-        </span>
+        </Link>
       </div>
     )
   }
 
   renderContact = (address: string, name: string) => {
     return (
-      <div key={address} className={styles.contact}>
+      <div key={name} className={styles.contact}>
         <div className={styles.details}>
           <div className={styles.name}>{name}</div>
           <div className={styles.address}>{address}</div>
@@ -65,10 +67,6 @@ export default class ContactsPanel extends React.Component<Props> {
         </div>
       </div>
     )
-  }
-
-  handleAdd = () => {
-    // TODO
   }
 
   handleEdit = (name: string) => {

--- a/app/components/Contacts/ContactsPanel/ContactsPanel.scss
+++ b/app/components/Contacts/ContactsPanel/ContactsPanel.scss
@@ -10,6 +10,8 @@
       display: flex;
       align-items: center;
       padding: 5px;
+      color: #515151;
+      text-decoration: none;
       cursor: pointer;
 
       .addIcon {

--- a/app/components/Contacts/ContactsPanel/ContactsPanel.scss
+++ b/app/components/Contacts/ContactsPanel/ContactsPanel.scss
@@ -1,0 +1,61 @@
+.contactsPanel {
+  max-width: 850px;
+
+  .header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    .addButton {
+      display: flex;
+      align-items: center;
+      padding: 5px;
+      cursor: pointer;
+
+      .addIcon {
+        margin-right: 15px;
+      }
+    }
+  }
+
+  .contacts {
+    padding: 24px;
+  }
+
+  .contact {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: nowrap;
+    margin-bottom: 45px;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    .details {
+      .name {
+        margin-bottom: 10px;
+        font-size: 20px;
+        font-weight: 600;
+      }
+
+      .address {
+        color: #939393;
+        font-size: 12px;
+      }
+    }
+
+    .actions {
+      display: flex;
+      align-items: center;
+
+      .editButton {
+        margin-right: 10px;
+      }
+
+      .deleteButton {
+      }
+    }
+  }
+}

--- a/app/components/Contacts/ContactsPanel/index.js
+++ b/app/components/Contacts/ContactsPanel/index.js
@@ -1,0 +1,1 @@
+export { default } from './ContactsPanel'

--- a/app/components/Contacts/ContactsPanel/index.js
+++ b/app/components/Contacts/ContactsPanel/index.js
@@ -1,1 +1,11 @@
-export { default } from './ContactsPanel'
+// @flow
+import { connect } from 'react-redux'
+
+import ContactsPanel from './ContactsPanel'
+import { deleteAddress } from '../../../modules/addressBook'
+
+const mapDispatchToProps = (dispatch) => ({
+  deleteContact: (...args) => dispatch(deleteAddress(...args))
+})
+
+export default connect(null, mapDispatchToProps)(ContactsPanel)

--- a/app/components/Contacts/ContactsPanel/index.js
+++ b/app/components/Contacts/ContactsPanel/index.js
@@ -1,5 +1,7 @@
 // @flow
+import { compose } from 'recompose'
 import { connect } from 'react-redux'
+import { withRouter } from 'react-router-dom'
 
 import ContactsPanel from './ContactsPanel'
 import { deleteAddress } from '../../../modules/addressBook'
@@ -8,4 +10,7 @@ const mapDispatchToProps = (dispatch) => ({
   deleteContact: (...args) => dispatch(deleteAddress(...args))
 })
 
-export default connect(null, mapDispatchToProps)(ContactsPanel)
+export default compose(
+  withRouter,
+  connect(null, mapDispatchToProps)
+)(ContactsPanel)

--- a/app/components/Contacts/EditContactPanel/EditContactPanel.jsx
+++ b/app/components/Contacts/EditContactPanel/EditContactPanel.jsx
@@ -1,0 +1,90 @@
+// @flow
+import React from 'react'
+import { Link } from 'react-router-dom'
+import classNames from 'classnames'
+import { noop } from 'lodash'
+
+import Panel from '../../Panel'
+import Button from '../../Button'
+import TextInput from '../../Inputs/TextInput'
+import AddIcon from '../../../assets/icons/contacts-add.svg'
+import ArrowIcon from '../../../assets/icons/arrow.svg'
+import { ROUTES } from '../../../core/constants'
+import styles from './EditContactPanel.scss'
+
+type Props = {
+  className: ?string,
+  name: string,
+  address: string,
+  setName: Function,
+  setAddress: Function,
+  onSave: Function
+}
+
+export default class EditContactPanel extends React.Component<Props> {
+  static defaultProps = {
+    name: '',
+    address: '',
+    setName: noop,
+    setAddress: noop,
+    onSave: noop
+  }
+
+  render () {
+    const { className, name, address } = this.props
+
+    return (
+      <Panel
+        className={classNames(styles.editContactPanel, className)}
+        renderHeader={this.renderHeader}
+      >
+        <form onSubmit={this.handleSubmit}>
+          <TextInput
+            className={styles.input}
+            placeholder='Contact Name'
+            value={name}
+            onChange={this.handleChangeName}
+          />
+          <TextInput
+            className={styles.input}
+            placeholder='Address'
+            value={address}
+            onChange={this.handleChangeAddress}
+          />
+          <Button
+            className={styles.button}
+            primary
+            type='submit'
+            renderIcon={AddIcon}
+          >
+            Save Contact
+          </Button>
+        </form>
+      </Panel>
+    )
+  }
+
+  renderHeader = () => {
+    return (
+      <span className={styles.header}>
+        <Link to={ROUTES.CONTACTS} className={styles.back}><ArrowIcon /></Link>
+        <span>Edit Contact</span>
+      </span>
+    )
+  }
+
+  handleChangeName = (event: Object) => {
+    this.props.setName(event.target.value)
+  }
+
+  handleChangeAddress = (event: Object) => {
+    this.props.setAddress(event.target.value)
+  }
+
+  handleSubmit = (event: Object) => {
+    const { name, address, onSave } = this.props
+
+    event.preventDefault()
+    onSave(name, address)
+  }
+}

--- a/app/components/Contacts/EditContactPanel/EditContactPanel.scss
+++ b/app/components/Contacts/EditContactPanel/EditContactPanel.scss
@@ -1,0 +1,21 @@
+.editContactPanel {
+  max-width: 600px;
+
+  .header {
+    display: flex;
+    align-items: center;
+
+    .back {
+      margin-right: 10px;
+    }
+  }
+
+  form {
+    max-width: 385px;
+    margin: 0 auto;
+
+    .input {
+      margin-bottom: 10px;
+    }
+  }
+}

--- a/app/components/Contacts/EditContactPanel/index.js
+++ b/app/components/Contacts/EditContactPanel/index.js
@@ -1,0 +1,21 @@
+// @flow
+import { compose, withProps, withState } from 'recompose'
+import { connect } from 'react-redux'
+import { trim } from 'lodash'
+
+import EditContactPanel from './EditContactPanel'
+import { updateAddress } from '../../../modules/addressBook'
+
+const mapDispatchToProps = (dispatch, props) => ({
+  onSave: (name, address) => {
+    props.onSave && props.onSave()
+    return dispatch(updateAddress(props.oldName, trim(name), trim(address)))
+  }
+})
+
+export default compose(
+  withProps(({ name }) => ({ oldName: name })),
+  connect(null, mapDispatchToProps),
+  withState('name', 'setName', ({ name }) => name),
+  withState('address', 'setAddress', ({ address }) => address)
+)(EditContactPanel)

--- a/app/components/Root/Routes.jsx
+++ b/app/components/Root/Routes.jsx
@@ -11,6 +11,7 @@ import CreateWallet from '../../containers/CreateWallet'
 import Dashboard from '../../containers/Dashboard'
 import Receive from '../../containers/Receive'
 import Contacts from '../../containers/Contacts'
+import EditContact from '../../containers/EditContact'
 import LoginLocalStorage from '../../containers/LoginLocalStorage'
 import LoginNep2 from '../../containers/LoginNep2'
 import Settings from '../../containers/Settings'
@@ -35,6 +36,7 @@ export default () => (
       <PrivateRoute exact path={ROUTES.DASHBOARD} component={Dashboard} />
       <PrivateRoute exact path={ROUTES.RECEIVE} component={Receive} />
       <PrivateRoute exact path={ROUTES.CONTACTS} component={Contacts} />
+      <PrivateRoute exact path={ROUTES.EDIT_CONTACT} component={EditContact} />
       <PrivateRoute exact path={ROUTES.TRANSACTION_HISTORY} component={TransactionHistory} />
       <Redirect to={ROUTES.DASHBOARD} />
     </Switch>

--- a/app/components/Root/Routes.jsx
+++ b/app/components/Root/Routes.jsx
@@ -11,6 +11,7 @@ import CreateWallet from '../../containers/CreateWallet'
 import Dashboard from '../../containers/Dashboard'
 import Receive from '../../containers/Receive'
 import Contacts from '../../containers/Contacts'
+import AddContact from '../../containers/AddContact'
 import EditContact from '../../containers/EditContact'
 import LoginLocalStorage from '../../containers/LoginLocalStorage'
 import LoginNep2 from '../../containers/LoginNep2'
@@ -36,6 +37,7 @@ export default () => (
       <PrivateRoute exact path={ROUTES.DASHBOARD} component={Dashboard} />
       <PrivateRoute exact path={ROUTES.RECEIVE} component={Receive} />
       <PrivateRoute exact path={ROUTES.CONTACTS} component={Contacts} />
+      <PrivateRoute exact path={ROUTES.ADD_CONTACT} component={AddContact} />
       <PrivateRoute exact path={ROUTES.EDIT_CONTACT} component={EditContact} />
       <PrivateRoute exact path={ROUTES.TRANSACTION_HISTORY} component={TransactionHistory} />
       <Redirect to={ROUTES.DASHBOARD} />

--- a/app/components/Root/Routes.jsx
+++ b/app/components/Root/Routes.jsx
@@ -10,6 +10,7 @@ import LoginLedgerNanoS from '../../containers/LoginLedgerNanoS'
 import CreateWallet from '../../containers/CreateWallet'
 import Dashboard from '../../containers/Dashboard'
 import Receive from '../../containers/Receive'
+import Contacts from '../../containers/Contacts'
 import LoginLocalStorage from '../../containers/LoginLocalStorage'
 import LoginNep2 from '../../containers/LoginNep2'
 import Settings from '../../containers/Settings'
@@ -33,6 +34,7 @@ export default () => (
       <Route exact path={ROUTES.SETTINGS} component={Settings} />
       <PrivateRoute exact path={ROUTES.DASHBOARD} component={Dashboard} />
       <PrivateRoute exact path={ROUTES.RECEIVE} component={Receive} />
+      <PrivateRoute exact path={ROUTES.CONTACTS} component={Contacts} />
       <PrivateRoute exact path={ROUTES.TRANSACTION_HISTORY} component={TransactionHistory} />
       <Redirect to={ROUTES.DASHBOARD} />
     </Switch>

--- a/app/containers/AddContact/AddContact.jsx
+++ b/app/containers/AddContact/AddContact.jsx
@@ -1,0 +1,30 @@
+// @flow
+import React from 'react'
+
+import AddContactPanel from '../../components/Contacts/AddContactPanel'
+import { ROUTES } from '../../core/constants'
+import styles from './AddContact.scss'
+
+type Props = {
+  history: Object,
+  name: string,
+  address: string
+}
+
+export default class AddContact extends React.Component<Props> {
+  render () {
+    return (
+      <div className={styles.addContact}>
+        <AddContactPanel
+          name={this.props.name}
+          address={this.props.address}
+          onSave={this.handleSave}
+        />
+      </div>
+    )
+  }
+
+  handleSave = () => {
+    return this.props.history.push(ROUTES.CONTACTS)
+  }
+}

--- a/app/containers/AddContact/AddContact.scss
+++ b/app/containers/AddContact/AddContact.scss
@@ -1,0 +1,4 @@
+.addContact {
+  display: flex;
+  justify-content: center;
+}

--- a/app/containers/AddContact/index.js
+++ b/app/containers/AddContact/index.js
@@ -1,0 +1,6 @@
+// @flow
+import { withRouter } from 'react-router-dom'
+
+import AddContact from './AddContact'
+
+export default withRouter(AddContact)

--- a/app/containers/App/Sidebar/Sidebar.jsx
+++ b/app/containers/App/Sidebar/Sidebar.jsx
@@ -64,7 +64,7 @@ const Sidebar = ({
       </Tooltip>
 
       <Tooltip title='Contacts' position='right'>
-        <NavLink id='contacts' exact to={ROUTES.CONTACTS} className={styles.navItem} activeClassName={styles.active}>
+        <NavLink id='contacts' to={ROUTES.CONTACTS} className={styles.navItem} activeClassName={styles.active}>
           <ContactsIcon />
         </NavLink>
       </Tooltip>

--- a/app/containers/App/Sidebar/Sidebar.jsx
+++ b/app/containers/App/Sidebar/Sidebar.jsx
@@ -10,6 +10,7 @@ import HomeIcon from '../../../assets/navigation/home.svg'
 import HistoryIcon from '../../../assets/navigation/history.svg'
 import SendIcon from '../../../assets/navigation/send.svg'
 import ReceiveIcon from '../../../assets/navigation/receive.svg'
+import ContactsIcon from '../../../assets/navigation/contacts.svg'
 import TokenSaleIcon from '../../../assets/navigation/tokens.svg'
 import { ROUTES } from '../../../core/constants'
 
@@ -59,6 +60,12 @@ const Sidebar = ({
       <Tooltip title='Receive' position='right'>
         <NavLink id='receive' exact to={ROUTES.RECEIVE} className={styles.navItem} activeClassName={styles.active}>
           <ReceiveIcon />
+        </NavLink>
+      </Tooltip>
+
+      <Tooltip title='Contacts' position='right'>
+        <NavLink id='contacts' exact to={ROUTES.CONTACTS} className={styles.navItem} activeClassName={styles.active}>
+          <ContactsIcon />
         </NavLink>
       </Tooltip>
 

--- a/app/containers/Contacts/Contacts.jsx
+++ b/app/containers/Contacts/Contacts.jsx
@@ -1,12 +1,25 @@
+// @flow
 import React from 'react'
 
+import ContactsPanel from '../../components/Contacts/ContactsPanel'
 import styles from './Contacts.scss'
 
-export default class Contacts extends React.Component {
+type Props = {
+  contacts: {
+    [address: string]: string
+  },
+  loadAddresses: Function
+}
+
+export default class Contacts extends React.Component<Props> {
+  componentWillMount () {
+    this.props.loadAddresses()
+  }
+
   render () {
     return (
       <div className={styles.contacts}>
-        Contacts
+        <ContactsPanel contacts={this.props.contacts} />
       </div>
     )
   }

--- a/app/containers/Contacts/Contacts.jsx
+++ b/app/containers/Contacts/Contacts.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+import styles from './Contacts.scss'
+
+export default class Contacts extends React.Component {
+  render () {
+    return (
+      <div className={styles.contacts}>
+        Contacts
+      </div>
+    )
+  }
+}

--- a/app/containers/Contacts/Contacts.scss
+++ b/app/containers/Contacts/Contacts.scss
@@ -1,0 +1,3 @@
+.contacts {
+  // TODO
+}

--- a/app/containers/Contacts/Contacts.scss
+++ b/app/containers/Contacts/Contacts.scss
@@ -1,3 +1,9 @@
 .contacts {
-  // TODO
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  .panel:not(:last-child) {
+    margin-bottom: 24px;
+  }
 }

--- a/app/containers/Contacts/index.js
+++ b/app/containers/Contacts/index.js
@@ -1,0 +1,1 @@
+export { default } from './Contacts'

--- a/app/containers/Contacts/index.js
+++ b/app/containers/Contacts/index.js
@@ -1,1 +1,14 @@
-export { default } from './Contacts'
+// @flow
+import { connect } from 'react-redux'
+import { bindActionCreators } from 'redux'
+
+import Contacts from './Contacts'
+import { loadAddresses, getAddresses } from '../../modules/addressBook'
+
+const mapStateToProps = (state: Object) => ({
+  contacts: getAddresses(state)
+})
+
+const mapDispatchToProps = (dispatch) => bindActionCreators({ loadAddresses }, dispatch)
+
+export default connect(mapStateToProps, mapDispatchToProps)(Contacts)

--- a/app/containers/EditContact/EditContact.jsx
+++ b/app/containers/EditContact/EditContact.jsx
@@ -1,0 +1,36 @@
+// @flow
+import React from 'react'
+
+import EditContactPanel from '../../components/Contacts/EditContactPanel'
+import { ROUTES } from '../../core/constants'
+import styles from './EditContact.scss'
+
+type Props = {
+  history: Object,
+  name: string,
+  address: string
+}
+
+export default class EditContact extends React.Component<Props> {
+  componentWillMount = () => {
+    if (!this.props.address) {
+      this.props.history.push(ROUTES.CONTACTS)
+    }
+  }
+
+  render () {
+    return (
+      <div className={styles.editContact}>
+        <EditContactPanel
+          name={this.props.name}
+          address={this.props.address}
+          onSave={this.handleSave}
+        />
+      </div>
+    )
+  }
+
+  handleSave = () => {
+    return this.props.history.push(ROUTES.CONTACTS)
+  }
+}

--- a/app/containers/EditContact/EditContact.scss
+++ b/app/containers/EditContact/EditContact.scss
@@ -1,0 +1,4 @@
+.editContact {
+  display: flex;
+  justify-content: center;
+}

--- a/app/containers/EditContact/index.js
+++ b/app/containers/EditContact/index.js
@@ -1,0 +1,22 @@
+// @flow
+import { compose, withProps, type MapStateToProps } from 'recompose'
+import { connect } from 'react-redux'
+import { withRouter } from 'react-router-dom'
+
+import EditContact from './EditContact'
+
+import { getAddresses } from '../../modules/addressBook'
+
+const mapNameToProps = (props) => ({
+  name: props.match.params.name
+})
+
+const mapStateToProps: MapStateToProps<*, *, *> = (state: Object, ownProps: Object) => ({
+  address: getAddresses(state)[ownProps.name]
+})
+
+export default compose(
+  withRouter,
+  withProps(mapNameToProps),
+  connect(mapStateToProps)
+)(EditContact)

--- a/app/containers/EditContact/index.js
+++ b/app/containers/EditContact/index.js
@@ -8,7 +8,7 @@ import EditContact from './EditContact'
 import { getAddresses } from '../../modules/addressBook'
 
 const mapNameToProps = (props) => ({
-  name: props.match.params.name
+  name: decodeURIComponent(props.match.params.name)
 })
 
 const mapStateToProps: MapStateToProps<*, *, *> = (state: Object, ownProps: Object) => ({

--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -19,6 +19,7 @@ export const ROUTES = {
   DASHBOARD: '/dashboard',
   RECEIVE: '/receive',
   CONTACTS: '/contacts',
+  EDIT_CONTACT: '/contacts/edit/:name',
   CREATE_WALLET: '/create',
   ENCRYPT_KEY: '/encrypt-key',
   LOGIN_PRIVATE_KEY: '/login-private-key',

--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -18,6 +18,7 @@ export const ROUTES = {
   HOME: '/',
   DASHBOARD: '/dashboard',
   RECEIVE: '/receive',
+  CONTACTS: '/contacts',
   CREATE_WALLET: '/create',
   ENCRYPT_KEY: '/encrypt-key',
   LOGIN_PRIVATE_KEY: '/login-private-key',

--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -19,6 +19,7 @@ export const ROUTES = {
   DASHBOARD: '/dashboard',
   RECEIVE: '/receive',
   CONTACTS: '/contacts',
+  ADD_CONTACT: '/contacts/new',
   EDIT_CONTACT: '/contacts/edit/:name',
   CREATE_WALLET: '/create',
   ENCRYPT_KEY: '/encrypt-key',

--- a/app/modules/addressBook.js
+++ b/app/modules/addressBook.js
@@ -40,14 +40,14 @@ export const loadAddresses = () => (dispatch: DispatchType) => {
   })
 }
 
-export const saveAddress = (address: string, name: string) => (dispatch: DispatchType) => {
+export const saveAddress = (name: string, address: string) => (dispatch: DispatchType) => {
   if (isEmpty(name)) {
-    dispatch(showErrorNotification({ message: 'Please enter a name for your contact.' }))
+    dispatch(showErrorNotification({ message: 'Name cannot be empty.' }))
     return null
   }
 
   if (!wallet.isAddress(address)) {
-    dispatch(showErrorNotification({ message: 'The address you entered was not valid.' }))
+    dispatch(showErrorNotification({ message: 'Invalid address.' }))
     return null
   }
 


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Most of #972.

**What problem does this PR solve?**
This implements the v2 designs around contacts:

* Contacts link in sidebar navigation.
* Contacts list screen.
* Add contact screen & functionality.
* Edit contact screen & functionality.
* Delete contact functionality.

![contacts](https://user-images.githubusercontent.com/169093/38835180-5e385a58-4190-11e8-9acb-c0c258b954a7.gif)

**How did you solve this problem?**
I added 3 new routes for the contacts list, add contact, and edit contact pages.  These pages are under the `containers` folder, while each of the associated components are in the `components` folder.

**How did you make sure your solution works?**
I managed my own contacts list!

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
There is still one known issue when trying to save a contact that has validation errors.  If a name/address is empty, the name is taken, or the address is invalid, an error message is shown as expected, but the user is then redirected back to the contacts list screen instead of staying on the add/edit form.

I'm planning to circle back on this by rewriting the reducer to use the newer actions architecture.

- [ ] Unit tests written?
