### PR TITLE
Open DevTools with "F12" hotkey while on Windows/Linux machine

### DIFF
--- a/main.js
+++ b/main.js
@@ -39,7 +39,7 @@ app.on('ready', () => {
     }
 
     if (process.platform !== 'darwin') {
-    // Windows/Linxu Menu
+    // Windows/Linux Menu
       mainWindow.setMenu(null)
     } else {
       // Menu is required for MacOS
@@ -109,4 +109,16 @@ app.on('ready', () => {
   } else {
     onAppReady()
   }
+})
+
+app.on('web-contents-created', (event, wc) => {
+  wc.on('before-input-event', (event, input) => {
+    // Windows/Linux hotkeys
+    if (process.platform !== 'darwin') {
+      if (input.key === 'F12') {
+        mainWindow.webContents.openDevTools()
+        event.preventDefault()
+      }
+    }
+  })
 })


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
#1012
**What problem does this PR solve?**
It solves an issue while dev tools can't be opened on Windows or Linux machines.
**How did you solve this problem?**
Added an ability to open dev tools using "F12" hotkey.
**How did you make sure your solution works?**
I've tested it on Linux and Windows machine manually by running the wallet and checking if dev tools are opening properly after pressing "F12" hotkey while window is active and if they don't open while window is deactivated.
**Are there any special changes in the code that we should be aware of?**
I don't think so.
**Is there anything else we should know?**
Nope.
- [ ] Unit tests written?
