### PR TITLE
Fixed portfolio chart scroll region

### DIFF
--- a/app/components/Dashboard/PortfolioPanel/PortfolioBreakdownChart.jsx
+++ b/app/components/Dashboard/PortfolioPanel/PortfolioBreakdownChart.jsx
@@ -29,8 +29,8 @@ export default class PortfolioBreakdownChart extends React.Component<Props> {
     const data = this.getData()
 
     return (
-      <ResponsiveContainer width={250} height={180} className={classNames(styles.priceHistoryChart, className)}>
-        <PieChart width={200} height={180}>
+      <ResponsiveContainer width={220} className={classNames(styles.priceHistoryChart, className)}>
+        <PieChart width={220} height={180}>
           <Pie data={data} dataKey='value' nameKey='symbol' innerRadius={40} outerRadius={75}>
             {times(data.length, (index) => (
               <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} stroke={COLORS[index]} />

--- a/app/components/Dashboard/PortfolioPanel/PortfolioPanel.jsx
+++ b/app/components/Dashboard/PortfolioPanel/PortfolioPanel.jsx
@@ -25,19 +25,21 @@ export default class PortfolioPanel extends React.Component<Props> {
     const { className, balances, currency } = this.props
 
     return (
-      <Panel className={classNames(styles.portfolioPanel, className)} renderHeader={this.renderHeader}>
-        <div className={styles.container}>
-          <PortfolioBreakdownChart
-            className={styles.chart}
-            balances={balances}
-            currency={currency}
-          />
-          <PortfolioTable
-            className={styles.table}
-            balances={balances}
-            currency={currency}
-          />
-        </div>
+      <Panel
+        className={classNames(styles.portfolioPanel, className)}
+        contentClassName={styles.content}
+        renderHeader={this.renderHeader}
+      >
+        <PortfolioBreakdownChart
+          className={styles.chart}
+          balances={balances}
+          currency={currency}
+        />
+        <PortfolioTable
+          className={styles.table}
+          balances={balances}
+          currency={currency}
+        />
       </Panel>
     )
   }

--- a/app/components/Dashboard/PortfolioPanel/PortfolioPanel.scss
+++ b/app/components/Dashboard/PortfolioPanel/PortfolioPanel.scss
@@ -1,7 +1,12 @@
 .portfolioPanel {
-  .container {
+  height: 100%;
+  overflow: hidden;
+
+  .content {
     display: flex;
     flex-direction: row;
+    align-items: stretch;
+    height: 100%;
 
     .chart {
       flex: 0 0 auto;
@@ -9,6 +14,8 @@
 
     .table {
       flex: 1 1 auto;
+      overflow-x: hidden;
+      overflow-y: auto;
     }
   }
 }

--- a/app/components/Panel/Panel.jsx
+++ b/app/components/Panel/Panel.jsx
@@ -8,6 +8,7 @@ import styles from './Panel.scss'
 
 type Props = {
   className: ?string,
+  contentClassName: ?string,
   children: React$Node,
   renderHeader: ?Function
 }
@@ -35,6 +36,10 @@ export default class Panel extends React.Component<Props> {
   }
 
   renderContent = () => {
-    return <Content className={styles.content}>{this.props.children}</Content>
+    const { contentClassName, children } = this.props
+
+    return (
+      <Content className={classNames(styles.content, contentClassName)}>{children}</Content>
+    )
   }
 }


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Fixes #995.

**What problem does this PR solve?**
The portfolio panel on the v2 dashboard was showing a scrollbar in Windows even when there was, for all intents and purposes, nothing to scroll.

**How did you solve this problem?**
I updated the flex layout to ensure that the chart is always displayed on the left (never scrollable), and the table along the right is only scrollable if there is enough content.

**How did you make sure your solution works?**
I smoke tested the new layout on Mac since I don't have Windows.  Will coordinate testing on Windows with @drptbl.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
