### PR TITLE
Added loading animation to refresh icon on v2 dashboard

### DIFF
--- a/__tests__/components/Dashboard/__snapshots__/AssetBalancesPanel.test.js.snap
+++ b/__tests__/components/Dashboard/__snapshots__/AssetBalancesPanel.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AssetBalancesPanel renders without crashing 1`] = `
-<withData(Connect(withData(Connect(withData(Connect(withData(withProps(Connect(withData(Connect(withData(withProps(Connect(withData(Connect(withActions(Connect(Connect(withProgress(LoadedNotifier))))))))))))))))))))
+<withData(Connect(withData(Connect(withData(Connect(withData(withProps(Connect(withData(Connect(withData(withProps(Connect(withData(Connect(withActions(Connect(withProgress(withProps(Connect(Connect(withProgress(LoadedNotifier)))))))))))))))))))))))
   dispatch={[Function]}
   gasPrice={18.1}
   neoPrice={25.48}

--- a/app/components/Dashboard/AssetBalancesPanel/AssetBalancesPanel.jsx
+++ b/app/components/Dashboard/AssetBalancesPanel/AssetBalancesPanel.jsx
@@ -18,10 +18,15 @@ type Props = {
   neoPrice: number,
   gasPrice: number,
   currencyCode: string,
+  loading: ?boolean,
   refresh: Function
 }
 
 export default class AssetBalancesPanel extends React.Component<Props> {
+  static defaultProps = {
+    loading: false
+  }
+
   render = () => {
     const { NEO, GAS, className } = this.props
 
@@ -59,11 +64,17 @@ export default class AssetBalancesPanel extends React.Component<Props> {
   }
 
   renderHeader = () => {
+    const { refresh, loading } = this.props
+
     return (
       <div className={styles.header}>
         <span>Balances</span>
         <Tooltip title='Refresh'>
-          <RefreshIcon id='refresh' className={styles.refresh} onClick={this.props.refresh} />
+          <RefreshIcon
+            id='refresh'
+            className={classNames(styles.refresh, { [styles.loading]: loading })}
+            onClick={refresh}
+          />
         </Tooltip>
       </div>
     )

--- a/app/components/Dashboard/AssetBalancesPanel/AssetBalancesPanel.scss
+++ b/app/components/Dashboard/AssetBalancesPanel/AssetBalancesPanel.scss
@@ -1,3 +1,5 @@
+@import '../../../styles/animations';
+
 .assetBalancesPanel {
   .header {
     display: flex;
@@ -11,6 +13,10 @@
       & path {
         color: #9599a2;
         fill: currentColor;
+      }
+
+      &.loading {
+        animation: spin 2s linear infinite;
       }
     }
   }

--- a/app/components/Dashboard/AssetBalancesPanel/index.js
+++ b/app/components/Dashboard/AssetBalancesPanel/index.js
@@ -10,6 +10,7 @@ import withNetworkData from '../../../hocs/withNetworkData'
 import withAuthData from '../../../hocs/withAuthData'
 import withCurrencyData from '../../../hocs/withCurrencyData'
 import withFilteredTokensData from '../../../hocs/withFilteredTokensData'
+import withLoadingProp from '../../../hocs/withLoadingProp'
 import withSuccessNotification from '../../../hocs/withSuccessNotification'
 import withFailureNotification from '../../../hocs/withFailureNotification'
 
@@ -38,6 +39,7 @@ export default compose(
   withAuthData(),
   withFilteredTokensData(),
   withActions(balancesActions, mapBalancesActionsToProps),
+  withLoadingProp(balancesActions),
   withSuccessNotification(balancesActions, 'Received latest blockchain information.'),
   withFailureNotification(balancesActions, 'Failed to retrieve blockchain information.')
 )(AssetBalancesPanel)

--- a/app/components/Dashboard/TokenBalancesPanel/TokenBalancesPanel.jsx
+++ b/app/components/Dashboard/TokenBalancesPanel/TokenBalancesPanel.jsx
@@ -10,10 +10,15 @@ import styles from './TokenBalancesPanel.scss'
 type Props = {
   className: ?string,
   balances: Array<TokenBalanceType>,
+  loading: ?boolean,
   refresh: Function
 }
 
 export default class TokenBalancesPanel extends React.Component<Props> {
+  static defaultProps = {
+    loading: false
+  }
+
   render = () => {
     const { className, balances } = this.props
 
@@ -30,11 +35,17 @@ export default class TokenBalancesPanel extends React.Component<Props> {
   }
 
   renderHeader = () => {
+    const { refresh, loading } = this.props
+
     return (
       <div className={styles.header}>
         <span>Token Balances</span>
         <Tooltip title='Refresh'>
-          <RefreshIcon id='refresh' className={styles.refresh} onClick={this.props.refresh} />
+          <RefreshIcon
+            id='refresh'
+            className={classNames(styles.refresh, { [styles.loading]: loading })}
+            onClick={refresh}
+          />
         </Tooltip>
       </div>
     )

--- a/app/components/Dashboard/TokenBalancesPanel/TokenBalancesPanel.scss
+++ b/app/components/Dashboard/TokenBalancesPanel/TokenBalancesPanel.scss
@@ -1,3 +1,5 @@
+@import '../../../styles/animations';
+
 .tokenBalancesPanel {
   .header {
     display: flex;
@@ -11,6 +13,10 @@
       & path {
         color: #9599a2;
         fill: currentColor;
+      }
+
+      &.loading {
+        animation: spin 2s linear infinite;
       }
     }
   }

--- a/app/components/Dashboard/TokenBalancesPanel/index.js
+++ b/app/components/Dashboard/TokenBalancesPanel/index.js
@@ -9,6 +9,7 @@ import withNetworkData from '../../../hocs/withNetworkData'
 import withAuthData from '../../../hocs/withAuthData'
 import withCurrencyData from '../../../hocs/withCurrencyData'
 import withFilteredTokensData from '../../../hocs/withFilteredTokensData'
+import withLoadingProp from '../../../hocs/withLoadingProp'
 import { toBigNumber } from '../../../core/math'
 
 const filterZeroBalanceTokens = (balances) => {
@@ -35,5 +36,6 @@ export default compose(
   withNetworkData(),
   withAuthData(),
   withFilteredTokensData(),
-  withActions(balancesActions, mapBalancesActionsToProps)
+  withActions(balancesActions, mapBalancesActionsToProps),
+  withLoadingProp(balancesActions)
 )(TokenBalancesPanel)

--- a/app/hocs/withLoadingProp.js
+++ b/app/hocs/withLoadingProp.js
@@ -1,0 +1,21 @@
+// @flow
+import { compose, withProps } from 'recompose'
+import { withProgress, progressValues, type Actions } from 'spunky'
+
+const { LOADING } = progressValues
+
+const LOADING_PROP: string = 'loading'
+const PROGRESS_PROP: string = '__progress__'
+
+type Options = {
+  propName: string
+}
+
+export default function withLoadingProp (actions: Actions, { propName = LOADING_PROP }: Options = {}) {
+  return compose(
+    withProgress(actions, { propName: PROGRESS_PROP }),
+    withProps((props) => ({
+      [LOADING_PROP]: props[PROGRESS_PROP] === LOADING
+    }))
+  )
+}

--- a/app/styles/animations.scss
+++ b/app/styles/animations.scss
@@ -1,0 +1,4 @@
+@keyframes spin {
+  from { transform:rotate(0deg); }
+  to { transform:rotate(360deg); }
+}


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Fixes #994.

**What problem does this PR solve?**
There is currently no feedback on the refresh buttons in the v2 dashboard, making it impossible to tell that anything is happening.  This adds a spin animation to those buttons while loading.

![refresh-icon](https://user-images.githubusercontent.com/169093/39341690-f3c3c3f8-4999-11e8-92d8-b9d264381d7b.gif)

**How did you solve this problem?**
I added a CSS animation to the refresh icon, which only spins when the progress is in a loading state.

**How did you make sure your solution works?**
I used the refresh button.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [x] Unit tests written?
