### PR TITLE
Fixed claim button styling

### DIFF
--- a/__mocks__/svgMock.js
+++ b/__mocks__/svgMock.js
@@ -1,0 +1,3 @@
+import React from 'react'
+
+module.exports = (props) => <svg {...props} />

--- a/__tests__/components/Dashboard/AssetBalancesPanel.test.js
+++ b/__tests__/components/Dashboard/AssetBalancesPanel.test.js
@@ -91,7 +91,7 @@ describe('AssetBalancesPanel', () => {
     const store = createStore(initialState)
     const wrapper = mount(provideStore(<AssetBalancesPanel />, store))
 
-    wrapper.find('#refresh').simulate('click')
+    wrapper.find('#refresh').hostNodes().simulate('click')
 
     expect(store.getActions()).toContainEqual(expect.objectContaining({
       type: 'BALANCES/ACTION/CALL',

--- a/__tests__/components/LoginNep2.test.js
+++ b/__tests__/components/LoginNep2.test.js
@@ -58,7 +58,7 @@ describe('LoginNep2', () => {
   test('the login button is working correctly with no passphrase or wif', (done) => {
     const { wrapper, store } = setup(false)
 
-    wrapper.find('#loginButton').first().simulate('click')
+    wrapper.find('#loginButton').hostNodes().simulate('click')
     Promise.resolve('pause').then(() => {
       const actions = store.getActions()
       expect(actions.length).toEqual(0)
@@ -77,7 +77,7 @@ describe('LoginNep2', () => {
     keyField.instance().value = '6PYUGtvXiT5TBetgWf77QyAFidQj61V8FJeFBFtYttmsSxcbmP4vCFRCWu'
     keyField.simulate('change')
 
-    wrapper.find('#loginButton').first().simulate('submit')
+    wrapper.find('#loginButton').hostNodes().simulate('submit')
 
     const actions = store.getActions()
     expect(actions.length).toEqual(1)

--- a/__tests__/components/TransactionHistoryPanel.test.js
+++ b/__tests__/components/TransactionHistoryPanel.test.js
@@ -98,8 +98,8 @@ describe('TransactionHistoryPanel', () => {
 
     const transactionList = wrapper.find('#transactionList')
     expect(transactionList.children().length).toEqual(2)
-    expect(transactionList.childAt(0).find('.txid').first().text()).toEqual(transactions[0].txid)
-    expect(transactionList.childAt(1).find('.txid').first().text()).toEqual(transactions[1].txid)
+    expect(transactionList.childAt(0).find('.txid').hostNodes().text()).toEqual(transactions[0].txid)
+    expect(transactionList.childAt(1).find('.txid').hostNodes().text()).toEqual(transactions[1].txid)
     expect(transactionList.childAt(0).find('.amountNEO').text()).toEqual('50 NEO')
     expect(transactionList.childAt(1).find('.amountGAS').text()).toEqual('0.40000000 GAS')
   })

--- a/__tests__/components/__snapshots__/Claim.test.js.snap
+++ b/__tests__/components/__snapshots__/Claim.test.js.snap
@@ -10,7 +10,8 @@ exports[`Claim should render claim GAS button as disabled 1`] = `
       disabled={true}
       id="claim"
       onClick={[Function]}
-      primary={true}
+      primary={false}
+      renderIcon={[Function]}
       type="button"
     >
       Claim 
@@ -31,7 +32,8 @@ exports[`Claim should render claim GAS button as enabled 1`] = `
       disabled={false}
       id="claim"
       onClick={[Function]}
-      primary={true}
+      primary={false}
+      renderIcon={[Function]}
       type="button"
     >
       Claim 

--- a/__tests__/components/__snapshots__/Logout.test.js.snap
+++ b/__tests__/components/__snapshots__/Logout.test.js.snap
@@ -5,6 +5,6 @@ exports[`Logout should render without crashing 1`] = `
   className="logout"
   onClick={[MockFunction]}
 >
-  <test-file-stub />
+  <Component />
 </div>
 `;

--- a/app/containers/Claim/Claim.jsx
+++ b/app/containers/Claim/Claim.jsx
@@ -5,6 +5,7 @@ import Button from '../../components/Button'
 import Tooltip from '../../components/Tooltip'
 import { formatGAS } from '../../core/formatters'
 import { toBigNumber } from '../../core/math'
+import ClaimIcon from '../../assets/icons/claim.svg'
 
 type Props = {
   className: ?string,
@@ -23,7 +24,13 @@ export default class Claim extends Component<Props> {
     return (
       <div>
         <Tooltip title='You can claim GAS once every 5 minutes' disabled={!disabled}>
-          <Button id='claim' primary className={className} disabled={disabled} onClick={this.handleClaim}>
+          <Button
+            id='claim'
+            className={className}
+            disabled={disabled}
+            renderIcon={ClaimIcon}
+            onClick={this.handleClaim}
+          >
             Claim {this.getFormattedAmount()} GAS
           </Button>
         </Tooltip>

--- a/package.json
+++ b/package.json
@@ -169,7 +169,8 @@
   },
   "jest": {
     "moduleNameMapper": {
-      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
+      "\\.(jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
+      "\\.(svg)$": "<rootDir>/__mocks__/svgMock.js",
       "\\.(css|less|sass|scss)$": "identity-obj-proxy"
     },
     "testPathIgnorePatterns": [


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Fixes #990.

**What problem does this PR solve?**
The v2 claim button was missing its icon and had the wrong colors.  We also were not properly mocking SVG's for use in jest.

**How did you solve this problem?**
I updated the button properties.  I added a new mock file used for SVG's to treat them as components.  I also fixed the way we're identifying ID'd components in tests by replacing `first` with `hostNodes`.

**How did you make sure your solution works?**
Viewed the button, ran the tests.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [x] Unit tests written?
