### PR TITLE
Updated neon-js to 3.7.0

### DIFF
--- a/app/actions/transactionHistoryActions.js
+++ b/app/actions/transactionHistoryActions.js
@@ -2,8 +2,7 @@
 import { api } from 'neon-js'
 import { createActions } from 'spunky'
 
-import { toBigNumber } from '../core/math'
-import { toFixedDecimals, COIN_DECIMAL_LENGTH } from '../core/formatters'
+import { COIN_DECIMAL_LENGTH } from '../core/formatters'
 import { ASSETS } from '../core/constants'
 
 type Props = {
@@ -16,9 +15,13 @@ export const ID = 'TRANSACTION_HISTORY'
 export default createActions(ID, ({ net, address }: Props = {}) => async (state: Object) => {
   const transactions = await api.neonDB.getTransactionHistory(net, address)
 
-  return transactions.map(({ NEO, GAS, txid }: TransactionHistoryType) => ({
-    txid,
-    [ASSETS.NEO]: toFixedDecimals(NEO, 0),
-    [ASSETS.GAS]: toBigNumber(GAS).round(COIN_DECIMAL_LENGTH).toString()
-  }))
+  return transactions.map(({ change, txid }: TransactionHistoryType) => {
+    const { NEO, GAS } = change
+
+    return {
+      txid,
+      [ASSETS.NEO]: NEO.toFixed(0),
+      [ASSETS.GAS]: GAS.round(COIN_DECIMAL_LENGTH).toString()
+    }
+  })
 })

--- a/flow-typed/declarations.js
+++ b/flow-typed/declarations.js
@@ -1,5 +1,7 @@
 // @flow
 
+import { type Fixed8 } from 'neon-js'
+
 import {
   EXPLORER,
   ROUTES,
@@ -38,12 +40,12 @@ declare type NotificationType = {
 }
 
 declare type TransactionHistoryType = {
-  NEO: number,
-  GAS: number,
+  change: {
+    NEO: Fixed8,
+    GAS: Fixed8,
+  },
   txid: string,
-  block_index: number,
-  neo_sent: boolean,
-  gas_sent: boolean
+  blockHeight: Fixed8
 }
 
 declare type ModalType = $Values<typeof MODAL_TYPES>

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "history": "4.7.2",
     "isomorphic-fetch": "2.2.1",
     "lodash": "4.17.4",
-    "neon-js": "git+https://github.com/cityofzion/neon-js.git#3.3.3",
+    "neon-js": "git+https://github.com/cityofzion/neon-js.git#dev",
     "nock": "^9.2.3",
     "qrcode": "0.9.0",
     "raf": "3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -725,11 +725,11 @@ axios@0.17.0:
     follow-redirects "^1.2.3"
     is-buffer "^1.1.5"
 
-axios@^0.17.1:
-  version "0.17.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.17.1.tgz#2d8e3e5d0bdbd7327f91bc814f5c57660f81824d"
+axios@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
   dependencies:
-    follow-redirects "^1.2.5"
+    follow-redirects "^1.3.0"
     is-buffer "^1.1.5"
 
 axobject-query@^0.1.0:
@@ -1559,7 +1559,7 @@ big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
 
-bignumber.js@5.0.0, bignumber.js@^5.0.0:
+bignumber.js@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-5.0.0.tgz#fbce63f09776b3000a83185badcde525daf34833"
 
@@ -4230,7 +4230,7 @@ fn-name@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
 
-follow-redirects@^1.2.3, follow-redirects@^1.2.5:
+follow-redirects@^1.2.3, follow-redirects@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.4.1.tgz#d8120f4518190f55aac65bb6fc7b85fcd666d6aa"
   dependencies:
@@ -6262,9 +6262,9 @@ log-symbols@^2.1.0:
   dependencies:
     chalk "^2.0.1"
 
-loglevel-plugin-prefix@^0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.7.2.tgz#938a5598b149d97b6de44e13547a764135b917b4"
+loglevel-plugin-prefix@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.3.tgz#3e46ee114f92ead1e1761100209349bda695995b"
 
 loglevel@^1.4.1, loglevel@^1.6.1:
   version "1.6.1"
@@ -6668,19 +6668,19 @@ neo-async@^2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.5.1.tgz#acb909e327b1e87ec9ef15f41b8a269512ad41ee"
 
-"neon-js@git+https://github.com/cityofzion/neon-js.git#3.3.3":
-  version "3.3.3"
-  resolved "git+https://github.com/cityofzion/neon-js.git#f962c255ef0790e4d64af3c825f3c2f44a9627f6"
+"neon-js@git+https://github.com/cityofzion/neon-js.git#dev":
+  version "3.6.2"
+  resolved "git+https://github.com/cityofzion/neon-js.git#059c136282d502951190def7a76522bbbe58fb67"
   dependencies:
-    axios "^0.17.1"
-    bignumber.js "^5.0.0"
+    axios "^0.18.0"
+    bignumber.js "5.0.0"
     bs58 "^4.0.1"
     bs58check "^2.1.1"
     crypto-js "^3.1.9-1"
     elliptic "^6.4.0"
     js-scrypt "^0.2.0"
     loglevel "^1.6.1"
-    loglevel-plugin-prefix "^0.7.2"
+    loglevel-plugin-prefix "^0.8.3"
     scrypt-js "^2.0.3"
     secure-random "^1.1.1"
     semver "^5.5.0"


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Fixes #1028.
Fixed #1039.

**What problem does this PR solve?**
* Some RPC servers are at the current block height, but they are unresponsive.  The latest version of neon-js helps to prevent those servers from being used.
* Claimable GAS calculation is returning 0 for some users.

**How did you solve this problem?**
I upgraded neon-js to 3.7.0, which fixes both issues.

**How did you make sure your solution works?**
I tried performing various RPC related actions, logging in & out (which fetches balances via RPC), and everything has been working for me.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
This can't be merged until neon-js 3.7.0 is released.  This is currently pointing at the dev branch in github.

- [ ] Unit tests written?
