### PR TITLE
Updated neon-js to 3.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "history": "4.7.2",
     "isomorphic-fetch": "2.2.1",
     "lodash": "4.17.4",
-    "neon-js": "git+https://github.com/cityofzion/neon-js.git#dev",
+    "neon-js": "git+https://github.com/cityofzion/neon-js.git#3.7.0",
     "nock": "^9.2.3",
     "qrcode": "0.9.0",
     "raf": "3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6668,9 +6668,9 @@ neo-async@^2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.5.1.tgz#acb909e327b1e87ec9ef15f41b8a269512ad41ee"
 
-"neon-js@git+https://github.com/cityofzion/neon-js.git#dev":
-  version "3.6.2"
-  resolved "git+https://github.com/cityofzion/neon-js.git#059c136282d502951190def7a76522bbbe58fb67"
+"neon-js@git+https://github.com/cityofzion/neon-js.git#3.7.0":
+  version "3.7.0"
+  resolved "git+https://github.com/cityofzion/neon-js.git#4b155ddf131d25208ffcc26571507509c24cf0ed"
   dependencies:
     axios "^0.18.0"
     bignumber.js "5.0.0"


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Fixes #1028.
Fixed #1039.

**What problem does this PR solve?**
* Some RPC servers are at the current block height, but they are unresponsive.  The latest version of neon-js helps to prevent those servers from being used.
* Claimable GAS calculation is returning 0 for some users.

**How did you solve this problem?**
I upgraded neon-js to 3.7.0, which fixes both issues.

**How did you make sure your solution works?**
I tried performing various RPC related actions, logging in & out (which fetches balances via RPC), and everything has been working for me.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
