### PR TITLE
Removed drop of GAS requirement for transfers

### DIFF
--- a/app/components/Modals/SendModal/AddRecipientDisplay.jsx
+++ b/app/components/Modals/SendModal/AddRecipientDisplay.jsx
@@ -11,7 +11,6 @@ import AssetInput from '../../Inputs/AssetInput'
 
 import { ASSETS } from '../../../core/constants'
 import { formatBalance, COIN_DECIMAL_LENGTH } from '../../../core/formatters'
-import { isToken } from '../../../core/wallet'
 
 import styles from './AddRecipientDisplay.scss'
 
@@ -75,11 +74,6 @@ export default class AddRecipientDisplay extends React.Component<Props, State> {
                 onChange={(value) => this.handleChange('address', value)} />
             </div>
           </div>
-        </div>
-        <div className={styles.messages}>
-          {isToken(symbol) && (
-            <div className={styles.tokenInfoMessage}>Sending NEP5 tokens requires holding at least 1 drop of GAS</div>
-          )}
         </div>
         <div className={styles.actions}>
           <Button onClick={onCancel}>

--- a/app/components/Modals/SendModal/AddRecipientDisplay.scss
+++ b/app/components/Modals/SendModal/AddRecipientDisplay.scss
@@ -1,5 +1,3 @@
-@import '../../../styles/variables';
-
 .addRecipientDisplay {
     flex: 1 1 auto;
     display: flex;
@@ -9,7 +7,6 @@
         flex: 1 0 auto;
     }
 
-    .messages,
     .actions {
         flex: 0 0 auto;
     }
@@ -41,13 +38,6 @@
             flex: 1 0 auto;
         }
     }
-}
-
-.messages {
-    margin-top: 20px;
-    text-align: right;
-    font-size: 13px;
-    color: $error-color;
 }
 
 .actions {

--- a/app/modules/transactions.js
+++ b/app/modules/transactions.js
@@ -19,7 +19,6 @@ import {
   getTokenBalances
 } from '../core/deprecated'
 import { isToken, validateTransactionsBeforeSending, getTokenBalancesMap } from '../core/wallet'
-import { ASSETS } from '../core/constants'
 import { toNumber } from '../core/math'
 
 import { log } from '../util/Logs'
@@ -43,25 +42,6 @@ const buildIntents = (sendEntries: Array<SendEntryType>) => {
       address
     )
   )
-}
-
-const buildIntentsForInvocation = (
-  sendEntries: Array<SendEntryType>,
-  fromAddress: string
-) => {
-  const intents = buildIntents(sendEntries)
-
-  if (intents.length > 0) {
-    return intents
-  } else {
-    return buildIntents([
-      {
-        address: fromAddress,
-        amount: '0.00000001',
-        symbol: ASSETS.GAS
-      }
-    ])
-  }
 }
 
 const buildTransferScript = (
@@ -104,7 +84,7 @@ const makeRequest = (sendEntries: Array<SendEntryType>, config: Object) => {
   } else {
     return api.doInvoke({
       ...config,
-      intents: buildIntentsForInvocation(sendEntries, config.address),
+      intents: buildIntents(sendEntries),
       script,
       gas: 0
     })


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
This removes the "1 drop of GAS" requirement for transferring NEP5 tokens.  Now that we're using the latest version of neon-js, transfers don't need to include an intent for sending 0.00000001 drop of GAS.  Instead, an attribute is used behind the scenes.

**How did you solve this problem?**
I removed the intent for sending 0.00000001 GAS to the currently authenticated account.  I also removed any messaging related to it.

**How did you make sure your solution works?**
I transfered NEP5 tokens.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
