### PR TITLE
Fixed CI build by upgrading upath dependency

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10034,8 +10034,8 @@ unzip-response@^2.0.1:
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
 
 upath@^1.0.0:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/upath/-/upath-1.0.4.tgz#ee2321ba0a786c50973db043a50b7bcba822361d"
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/upath/-/upath-1.0.5.tgz#02cab9ecebe95bbec6d5fc2566325725ab6d1a73"
 
 update-notifier@^2.3.0, update-notifier@^2.5.0:
   version "2.5.0"


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
This attempts to fix the build failure as seen here: https://circleci.com/gh/CityOfZion/neon-wallet/1943

**How did you solve this problem?**
I upgraded the deep `upath` dependency.

**How did you make sure your solution works?**
I pushed it to Github & let Circle build.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
