### PR TITLE
V2/retry

### DIFF
--- a/__tests__/components/__snapshots__/TransactionHistoryPanel.test.js.snap
+++ b/__tests__/components/__snapshots__/TransactionHistoryPanel.test.js.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TransactionHistoryPanel renders without crashing 1`] = `
-<withProgress(withProgressComponents(Connect(withData(TransactionHistory))))
-  dispatch={[Function]}
-  progress="LOADED"
+<withActions(Connect(withProgress(withProgressComponents(Connect(withData(TransactionHistory))))))
+  onRetry={[Function]}
   store={
     Object {
       "clearActions": [Function],
@@ -12,27 +11,6 @@ exports[`TransactionHistoryPanel renders without crashing 1`] = `
       "getState": [Function],
       "replaceReducer": [Function],
       "subscribe": [Function],
-    }
-  }
-  storeSubscription={
-    t {
-      "listeners": Object {
-        "clear": [Function],
-        "get": [Function],
-        "notify": [Function],
-        "subscribe": [Function],
-      },
-      "onStateChange": [Function],
-      "parentSub": undefined,
-      "store": Object {
-        "clearActions": [Function],
-        "dispatch": [Function],
-        "getActions": [Function],
-        "getState": [Function],
-        "replaceReducer": [Function],
-        "subscribe": [Function],
-      },
-      "unsubscribe": [Function],
     }
   }
 />

--- a/app/components/FailedPanel/FailedPanel.jsx
+++ b/app/components/FailedPanel/FailedPanel.jsx
@@ -24,7 +24,7 @@ export default class LoadingPanel extends React.Component<Props> {
         contentClassName={styles.content}
         renderHeader={this.renderHeader}
       >
-        Failed to load.{' '}{this.renderRetry}
+        Failed to load.{' '}{this.renderRetry()}
       </Panel>
     )
   }

--- a/app/hocs/withProgressPanel.js
+++ b/app/hocs/withProgressPanel.js
@@ -1,20 +1,27 @@
-import { withProps } from 'recompose'
-import { withProgressComponents, alreadyLoadedStrategy, progressValues } from 'spunky'
+import { compose, withProps } from 'recompose'
+import { withActions, withProgressComponents, alreadyLoadedStrategy, progressValues } from 'spunky'
 
 import LoadingPanel from '../components/LoadingPanel'
 import FailedPanel from '../components/FailedPanel'
 
 const { LOADING, FAILED } = progressValues
 
+const mapActionsToProps = (action, props) => ({
+  onRetry: () => action.call(props)
+})
+
 export default function withProgressPanel (actions, { title, strategy = alreadyLoadedStrategy, ...options } = {}) {
   const Loading = withProps({ title })(LoadingPanel)
-  const Failed = withProps({ title })(FailedPanel)
+  const Failed = withProps((props) => ({ title, onRetry: props.onRetry }))(FailedPanel)
 
-  return withProgressComponents(actions, {
-    [LOADING]: Loading,
-    [FAILED]: Failed
-  }, {
-    strategy,
-    ...options
-  })
+  return compose(
+    withActions(actions, mapActionsToProps),
+    withProgressComponents(actions, {
+      [LOADING]: Loading,
+      [FAILED]: Failed
+    }, {
+      strategy,
+      ...options
+    })
+  )
 }


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
This adds the ability to retry failed requests (e.g.: when data fails to load from an API or RPC server).

![retry-failed](https://user-images.githubusercontent.com/169093/39682834-cd452ede-5177-11e8-9728-249697ebb60c.gif)

**How did you solve this problem?**
I created an `onRetry` function prop that is passed to the `FailedPanel` component.  When that component renders, the user can click on a link to call that function.

**How did you make sure your solution works?**
I forced an error to be raised on the first instance that an action is called, but to continue processing normally on subsequent calls.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
@snowypowers I initially tried to test this by turning off my wifi, getting failed requests, then turning my wifi back on and retrying, but it did not work as expected.  After the first failed set of requests, the app continued to hit endpoints like http://localhost:3000/undefined/v2/network/nodes and http://localhost:3000/undefined/v1/get_all_nodes.  Manually switching between TestNet and MainNet resolved the issue.  I'm wondering if neon-js might be caching something?  If not, I'll dig in more on my end as a follow-up.

- [ ] Unit tests written?
