### PR TITLE
Updated NEP2 login to decrypt asynchronous & show loading state

### DIFF
--- a/__tests__/components/__snapshots__/LoginNep2.test.js.snap
+++ b/__tests__/components/__snapshots__/LoginNep2.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LoginNep2 renders without crashing 1`] = `
-<withActions(Connect(Connect(withError(Connect(withProgress(ErrorNotifier))))))
+<withActions(Connect(withProgress(withProps(Connect(Connect(withError(Connect(withProgress(ErrorNotifier)))))))))
   loginNep2={[Function]}
   store={
     Object {

--- a/app/actions/authActions.js
+++ b/app/actions/authActions.js
@@ -50,7 +50,7 @@ export const nep2LoginActions = createActions(ID, ({ passphrase, encryptedWIF }:
     throw new Error('That is not a valid encrypted key')
   }
 
-  const wif = wallet.decrypt(encryptedWIF, passphrase)
+  const wif = await wallet.decryptAsync(encryptedWIF, passphrase)
   const account = new wallet.Account(wif)
 
   await upgradeNEP6AddAddresses(encryptedWIF, wif)

--- a/app/containers/Home/Home.jsx
+++ b/app/containers/Home/Home.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React, { Component } from 'react'
+import React from 'react'
 
 import LoginPrivateKey from '../LoginPrivateKey'
 import LoginNep2 from '../LoginNep2'
@@ -16,7 +16,9 @@ type State = {
   option: string
 }
 
-type Props = {}
+type Props = {
+  loading: boolean
+}
 
 const LOGIN_OPTIONS = {
   LOCAL_STORAGE: {
@@ -37,7 +39,7 @@ const LOGIN_OPTIONS = {
   }
 }
 
-class Home extends Component<Props, State> {
+export default class Home extends React.Component<Props, State> {
   state = {
     option: LOGIN_OPTIONS.LOCAL_STORAGE.display
   }
@@ -64,36 +66,39 @@ class Home extends Component<Props, State> {
     )
   }
 
-  render = () => (
-    <div id="home" className={styles.home}>
-      <div className={styles.loginContainer}>
-        <img className={styles.logo} src={neonLogo} />
-        <div className={styles.loginText}>Login</div>
+  render = () => {
+    const { loading } = this.props
 
-        <div className={styles.inputContainer}>
-          <SelectInput
-            className={styles.input}
-            onChange={value => this.handleSelect(value)}
-            value={this.state.option}
-            readOnly
-            items={this.options}
-            getItemValue={item => item}
-          />
+    return (
+      <div id="home" className={styles.home}>
+        <div className={styles.loginContainer}>
+          <img className={styles.logo} src={neonLogo} />
+          <div className={styles.loginText}>Login</div>
 
-          {this.renderLoginBasedOnOption(this.state.option)}
+          <div className={styles.inputContainer}>
+            <SelectInput
+              className={styles.input}
+              onChange={value => this.handleSelect(value)}
+              value={this.state.option}
+              readOnly
+              disabled={loading}
+              items={this.options}
+              getItemValue={item => item}
+            />
 
-          <div className={styles.buttonRow}>
-            <div style={{ flex: 0.45 }}>
-              <Button renderIcon={AddIcon}>New Wallet</Button>
-            </div>
-            <div style={{ flex: 0.45 }}>
-              <Button renderIcon={WalletIcon}>Wallet Manager</Button>
+            {this.renderLoginBasedOnOption(this.state.option)}
+
+            <div className={styles.buttonRow}>
+              <div style={{ flex: 0.45 }}>
+                <Button disabled={loading} renderIcon={AddIcon}>New Wallet</Button>
+              </div>
+              <div style={{ flex: 0.45 }}>
+                <Button disabled={loading} renderIcon={WalletIcon}>Wallet Manager</Button>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-  )
+    )
+  }
 }
-
-export default Home

--- a/app/containers/Home/index.js
+++ b/app/containers/Home/index.js
@@ -1,1 +1,7 @@
-export { default } from './Home'
+// @flow
+import Home from './Home'
+import authActions from '../../actions/authActions'
+import withLoadingProp from '../../hocs/withLoadingProp'
+import pureStrategy from '../../hocs/helpers/pureStrategy'
+
+export default withLoadingProp(authActions, { strategy: pureStrategy })(Home)

--- a/app/containers/LoginLocalStorage/LoginLocalStorage.jsx
+++ b/app/containers/LoginLocalStorage/LoginLocalStorage.jsx
@@ -8,6 +8,7 @@ import LoginIcon from '../../assets/icons/login.svg'
 import styles from '../Home/Home.scss'
 
 type Props = {
+  loading: boolean,
   loginNep2: Function,
   accounts: Object
 }
@@ -24,7 +25,7 @@ export default class LoginLocalStorage extends Component<Props, State> {
   }
 
   render () {
-    const { accounts } = this.props
+    const { loading, accounts } = this.props
     const { passphrase, encryptedWIF } = this.state
     const { label } = accounts.find(account => account.key === encryptedWIF) || {}
 
@@ -36,6 +37,7 @@ export default class LoginLocalStorage extends Component<Props, State> {
               items={accounts.map(account => account.label)}
               value={label || ''}
               placeholder="Select account"
+              disabled={loading}
               onChange={value => this.setState({ encryptedWIF: value })}
               getItemValue={value =>
                 accounts.find(account => account.label === value).key
@@ -46,6 +48,7 @@ export default class LoginLocalStorage extends Component<Props, State> {
             <PasswordInput
               placeholder="Enter your passphrase here"
               value={passphrase}
+              disabled={loading}
               onChange={e => this.setState({ passphrase: e.target.value })}
             />
           </div>
@@ -55,8 +58,8 @@ export default class LoginLocalStorage extends Component<Props, State> {
               primary
               type="submit"
               className={styles.loginButtonMargin}
+              disabled={loading || !this.isValid()}
               renderIcon={LoginIcon}
-              disabled={!this.isValid()}
             >
               Login
             </Button>
@@ -67,11 +70,14 @@ export default class LoginLocalStorage extends Component<Props, State> {
   }
 
   handleSubmit = (event: Object) => {
-    const { loginNep2 } = this.props
+    const { loading, loginNep2 } = this.props
     const { passphrase, encryptedWIF } = this.state
 
     event.preventDefault()
-    loginNep2(passphrase, encryptedWIF)
+
+    if (!loading) {
+      loginNep2(passphrase, encryptedWIF)
+    }
   }
 
   isValid = () => {

--- a/app/containers/LoginLocalStorage/index.js
+++ b/app/containers/LoginLocalStorage/index.js
@@ -3,9 +3,11 @@ import { compose } from 'recompose'
 import { withData, withActions } from 'spunky'
 
 import LoginLocalStorage from './LoginLocalStorage'
-import withFailureNotification from '../../hocs/withFailureNotification'
 import accountsActions from '../../actions/accountsActions'
 import { nep2LoginActions } from '../../actions/authActions'
+import withLoadingProp from '../../hocs/withLoadingProp'
+import withFailureNotification from '../../hocs/withFailureNotification'
+import pureStrategy from '../../hocs/helpers/pureStrategy'
 
 const mapAccountsDataToProps = (accounts) => ({
   accounts
@@ -18,5 +20,6 @@ const mapActionsToProps = (actions) => ({
 export default compose(
   withData(accountsActions, mapAccountsDataToProps),
   withActions(nep2LoginActions, mapActionsToProps),
+  withLoadingProp(nep2LoginActions, { strategy: pureStrategy }),
   withFailureNotification(nep2LoginActions)
 )(LoginLocalStorage)

--- a/app/containers/LoginNep2/LoginNep2.jsx
+++ b/app/containers/LoginNep2/LoginNep2.jsx
@@ -7,6 +7,7 @@ import LoginIcon from '../../assets/icons/login.svg'
 import styles from '../Home/Home.scss'
 
 type Props = {
+  loading: boolean,
   loginNep2: Function
 }
 
@@ -22,29 +23,25 @@ export default class LoginNep2 extends Component<Props, State> {
   }
 
   render () {
-    const { loginNep2 } = this.props
+    const { loading } = this.props
     const { encryptedWIF, passphrase } = this.state
-    const loginButtonDisabled = encryptedWIF === '' || passphrase === ''
 
     return (
       <div id="loginNep2" className={styles.flexContainer}>
-        <form
-          onSubmit={e => {
-            e.preventDefault()
-            loginNep2(passphrase, encryptedWIF)
-          }}
-        >
+        <form onSubmit={this.handleSubmit}>
           <div className={styles.inputMargin}>
             <PasswordInput
               placeholder="Enter your encrypted key here"
               autoFocus
               value={encryptedWIF}
+              disabled={loading}
               onChange={e => this.setState({ encryptedWIF: e.target.value })}
             />
           </div>
           <PasswordInput
             placeholder="Enter your passphrase here"
             value={passphrase}
+            disabled={loading}
             onChange={e => this.setState({ passphrase: e.target.value })}
           />
           <Button
@@ -53,12 +50,27 @@ export default class LoginNep2 extends Component<Props, State> {
             type="submit"
             className={styles.loginButtonMargin}
             renderIcon={LoginIcon}
-            disabled={loginButtonDisabled}
+            disabled={loading || !this.isValid()}
           >
             Login
           </Button>
         </form>
       </div>
     )
+  }
+
+  handleSubmit = (event: Object) => {
+    const { loading, loginNep2 } = this.props
+    const { passphrase, encryptedWIF } = this.state
+
+    event.preventDefault()
+
+    if (!loading) {
+      loginNep2(passphrase, encryptedWIF)
+    }
+  }
+
+  isValid = () => {
+    return this.state.encryptedWIF !== '' && this.state.passphrase !== ''
   }
 }

--- a/app/containers/LoginNep2/LoginNep2.jsx
+++ b/app/containers/LoginNep2/LoginNep2.jsx
@@ -37,15 +37,15 @@ export default class LoginNep2 extends Component<Props, State> {
           <div className={styles.inputMargin}>
             <PasswordInput
               placeholder="Enter your encrypted key here"
-              onChange={e => this.setState({ encryptedWIF: e.target.value })}
+              autoFocus
               value={encryptedWIF}
+              onChange={e => this.setState({ encryptedWIF: e.target.value })}
             />
           </div>
           <PasswordInput
             placeholder="Enter your passphrase here"
-            onChange={e => this.setState({ passphrase: e.target.value })}
             value={passphrase}
-            autoFocus
+            onChange={e => this.setState({ passphrase: e.target.value })}
           />
           <Button
             id="loginButton"

--- a/app/containers/LoginNep2/index.js
+++ b/app/containers/LoginNep2/index.js
@@ -3,7 +3,9 @@ import { compose } from 'recompose'
 import { withActions } from 'spunky'
 
 import LoginNep2 from './LoginNep2'
+import withLoadingProp from '../../hocs/withLoadingProp'
 import withFailureNotification from '../../hocs/withFailureNotification'
+import pureStrategy from '../../hocs/helpers/pureStrategy'
 import { nep2LoginActions } from '../../actions/authActions'
 
 const mapActionsToProps = (actions) => ({
@@ -12,5 +14,6 @@ const mapActionsToProps = (actions) => ({
 
 export default compose(
   withActions(nep2LoginActions, mapActionsToProps),
+  withLoadingProp(nep2LoginActions, { strategy: pureStrategy }),
   withFailureNotification(nep2LoginActions)
 )(LoginNep2)

--- a/app/hocs/withLoadingProp.js
+++ b/app/hocs/withLoadingProp.js
@@ -8,12 +8,13 @@ const LOADING_PROP: string = 'loading'
 const PROGRESS_PROP: string = '__progress__'
 
 type Options = {
-  propName: string
+  propName?: string,
+  [key: string]: mixed
 }
 
-export default function withLoadingProp (actions: Actions, { propName = LOADING_PROP }: Options = {}) {
+export default function withLoadingProp (actions: Actions, { propName = LOADING_PROP, ...options }: Options = {}) {
   return compose(
-    withProgress(actions, { propName: PROGRESS_PROP }),
+    withProgress(actions, { propName: PROGRESS_PROP, ...options }),
     withProps((props) => ({
       [LOADING_PROP]: props[PROGRESS_PROP] === LOADING
     }))


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
This updates the NEP2 login action perform asynchronously.

**How did you solve this problem?**
I updated the NEP authentication action to use `decryptAsync` instead of `decrypt`.  This prevents the app from seemingly hanging while authenticated.  Since the user can continue to interact with the app with this change, it was also necessary to add loading state & disable fields while decrypting.

![decrypt-async](https://user-images.githubusercontent.com/169093/39707798-09223aba-51db-11e8-9f69-d6898f5b2c65.gif)

**How did you make sure your solution works?**
I tested all forms of login.  I also tried interacting with form elements and buttons/links on the screen while decrypting.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
