### PR TITLE
Fix PortfolioRow flex

### DIFF
--- a/app/components/Dashboard/PortfolioPanel/PortfolioRow.scss
+++ b/app/components/Dashboard/PortfolioPanel/PortfolioRow.scss
@@ -9,8 +9,7 @@
   .balance,
   .value,
   .percent {
-    flex: 1 1 auto;
-    width: 50%;
+    flex: 1 1 0;
     margin-right: 24px;
     color: #282828;
     overflow: hidden;
@@ -27,7 +26,6 @@
   .balance,
   .value {
     flex-grow: 2;
-    width: 100%;
   }
 
   .percent {


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
None

**What problem does this PR solve?**
Currently flex styles in the PortfolioRow component do not actually do anything due to percentage widths being applied. Relying on flex will allow easier customisation of ratios in the future.

**How did you solve this problem?**
Remove `width: 50%` and `width: 100%` styles and instead rely on `flex-grow`.

**How did you make sure your solution works?**
I've tested on macOS that the behaviour when resizing is the same as before.

**Are there any special changes in the code that we should be aware of?**
`flex-basis` changed from auto to 0 to keep the same behaviour as before when using `width`.

**Is there anything else we should know?**
I originally wanted to take a look at https://github.com/CityOfZion/neon-wallet/issues/996. I don't think this is an issue anymore though now that the scrollbar isn't there by default.

- [ ] Unit tests written?
