### PR TITLE
Removed IAM and PKC from ICO tokens list

### DIFF
--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -84,7 +84,9 @@ export const TOKENS = {
   PKC: 'af7c7328eee5a275a3bcaee2bf0cf662b5e739be'
 }
 
-export const ENDED_ICO_TOKENS = ['DBC', 'RPX', 'QLC', 'RHT', 'ONT', 'SWH', 'NRVE', 'EFX', 'THOR', 'CGE', 'MCT']
+export const ENDED_ICO_TOKENS = [
+  'DBC', 'RPX', 'RHT', 'QLC', 'NRVE', 'IAM', 'ONT', 'THOR', 'CGE', 'SWH', 'EFX', 'MCT', 'PKC'
+]
 
 export const DEFAULT_WALLET = {
   name: 'userWallet',


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
It adds IAM and PKC from the list of ended token ICOs.

**How did you solve this problem?**
Added the token symbols to the constant that tracks ended ICOs.

**How did you make sure your solution works?**
Ensure they don't appear in the token sale modal dropdown.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
