### PR TITLE
Fixed copy tooltips

### DIFF
--- a/app/containers/DisplayWalletAccounts/DisplayWalletAccounts.jsx
+++ b/app/containers/DisplayWalletAccounts/DisplayWalletAccounts.jsx
@@ -37,12 +37,12 @@ class DisplayWalletAccounts extends Component<Props> {
   render () {
     const { passphrase, address, encryptedWIF, wif, walletName } = this.props
     const fields = [
-      { label: 'Passphrase:', value: passphrase },
-      { label: 'Public Address:', value: address },
-      { label: 'Encrypted Key:', value: encryptedWIF },
-      { label: 'Private Key:', value: wif }
+      { label: 'Passphrase', value: passphrase },
+      { label: 'Public Address', value: address },
+      { label: 'Encrypted Key', value: encryptedWIF },
+      { label: 'Private Key', value: wif }
     ]
-    walletName && fields.push({ label: 'Wallet Name:', value: walletName })
+    walletName && fields.push({ label: 'Wallet Name', value: walletName })
     return (
       <HomeLayout
         excludeLogo
@@ -84,11 +84,11 @@ class DisplayWalletAccounts extends Component<Props> {
           <div className={styles.detailsContainer}>
             {fields.map(item => (
               <div key={item.label} className={styles.detailRow}>
-                <span className={styles.label}>{item.label}</span>
+                <span className={styles.label}>{item.label}:</span>
                 <div className={styles.input}>
                   <TextInput value={item.value} disabled />
                 </div>
-                <CopyToClipboard text={item.value} tooltip="Copy Passphrase" />
+                <CopyToClipboard text={item.value} tooltip={`Copy ${item.label}`} />
               </div>
             ))}
           </div>


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
The tooltips for copying aspects of a new wallet all read "Copy Passphrase".

**How did you solve this problem?**
I updated the tooltips to use the correct label to match the item being copied.

**How did you make sure your solution works?**
I hovered over each copy icon to ensure the tooltip is correct.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
