### PR TITLE
Updated transaction API fetches to use paginated neoscan endpoint

### DIFF
--- a/__tests__/components/__snapshots__/TransactionHistory.test.js.snap
+++ b/__tests__/components/__snapshots__/TransactionHistory.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TransactionHistory renders without crashing 1`] = `
-<withData(withProps(Connect(withData(Connect(withData(Connect(withProgress(withProps(withoutProps(TransactionHistory))))))))))
+<withData(withProps(Connect(withData(Connect(withProgress(Connect(withProgress(withProgressComponents(withProps(Connect(withData(withoutProps(TransactionHistory)))))))))))))
   dispatch={[Function]}
   networkId="1"
   store={

--- a/app/actions/transactionHistoryActions.js
+++ b/app/actions/transactionHistoryActions.js
@@ -1,27 +1,40 @@
 // @flow
+import axios from 'axios'
 import { api } from 'neon-js'
 import { createActions } from 'spunky'
+import { filter, reduce } from 'lodash'
 
 import { COIN_DECIMAL_LENGTH } from '../core/formatters'
 import { ASSETS } from '../core/constants'
+import { toBigNumber } from '../core/math'
+
+export const NEO_ID = 'c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b'
+export const GAS_ID = '602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7'
 
 type Props = {
   net: string,
   address: string
 }
 
+function sum (txns, address, asset) {
+  const matchingTxns = filter(txns, (txn) => {
+    return txn.asset === asset && txn.address_hash === address
+  })
+
+  return reduce(matchingTxns, (sum, txn) => {
+    return sum.plus(txn.value)
+  }, toBigNumber(0))
+}
+
 export const ID = 'TRANSACTION_HISTORY'
 
 export default createActions(ID, ({ net, address }: Props = {}) => async (state: Object) => {
-  const transactions = await api.getTransactionHistoryFrom({ net, address }, api.neoscan)
+  const endpoint = api.neoscan.getAPIEndpoint(net)
+  const { data } = await axios.get(`${endpoint}/v1/get_last_transactions_by_address/${address}`)
 
-  return transactions.map(({ change, txid, ...rest }: TransactionHistoryType) => {
-    const { NEO, GAS } = change
-
-    return {
-      txid,
-      [ASSETS.NEO]: NEO ? NEO.toFixed(0) : '0',
-      [ASSETS.GAS]: GAS ? GAS.round(COIN_DECIMAL_LENGTH).toString() : '0'
-    }
-  })
+  return data.map(({ txid, vin, vouts }) => ({
+    txid,
+    [ASSETS.NEO]: sum(vin, address, NEO_ID).minus(sum(vouts, address, NEO_ID)).toFixed(0),
+    [ASSETS.GAS]: sum(vin, address, GAS_ID).minus(sum(vouts, address, GAS_ID)).round(COIN_DECIMAL_LENGTH).toString()
+  }))
 })

--- a/app/containers/TransactionHistory/index.js
+++ b/app/containers/TransactionHistory/index.js
@@ -1,6 +1,7 @@
 // @flow
+import React from 'react'
 import { compose, withProps } from 'recompose'
-import { withData, withProgress, progressValues } from 'spunky'
+import { withData, withProgress, withProgressComponents, alreadyLoadedStrategy, progressValues } from 'spunky'
 
 import TransactionHistory from './TransactionHistory'
 import transactionHistoryActions from '../../actions/transactionHistoryActions'
@@ -8,7 +9,7 @@ import withNetworkData from '../../hocs/withNetworkData'
 import withAuthData from '../../hocs/withAuthData'
 import withoutProps from '../../hocs/withoutProps'
 
-const { LOADING } = progressValues
+const { LOADING, FAILED } = progressValues
 
 const PROGRESS_PROP = 'progress'
 
@@ -20,13 +21,20 @@ const mapLoadingProp = (props) => ({
   loading: props[PROGRESS_PROP] === LOADING
 })
 
+const Failed = <div>Failed to load.</div>
+
 export default compose(
   withNetworkData(),
   withAuthData(),
-  withData(transactionHistoryActions, mapTransactionsDataToProps),
 
   // pass `loading` boolean to component
   withProgress(transactionHistoryActions, { propName: PROGRESS_PROP }),
+  withProgressComponents(transactionHistoryActions, {
+    [FAILED]: Failed
+  }, {
+    strategy: alreadyLoadedStrategy
+  }),
   withProps(mapLoadingProp),
+  withData(transactionHistoryActions, mapTransactionsDataToProps),
   withoutProps(PROGRESS_PROP)
 )(TransactionHistory)


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
This changes the transaction history fetch to get the latest page of transactions from neoscan rather than the full history.  It also updates the transaction history sidebar to gracefully fail if the fetch does not succeed, preventing the white screen of death.

**How did you solve this problem?**
I replaced the neon-js call with a raw axios call.

**How did you make sure your solution works?**
I smoke tested several addresses and compared the results to neoscan.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
@snowypowers In case you want to mimic this behavior in neon-js, this is what I did.

- [ ] Unit tests written?
