### PR TITLE
fix(dashboard): Allow dashboard to load despite having bad cmc response

### DIFF
--- a/app/actions/pricesActions.js
+++ b/app/actions/pricesActions.js
@@ -7,10 +7,16 @@ import { ASSETS, DEFAULT_CURRENCY_CODE } from '../core/constants'
 type Props = {
   symbols?: Array<string>,
   currency?: string
-}
+};
 
 export const ID = 'PRICES'
 
-export default createActions(ID, ({ symbols = [ASSETS.NEO, ASSETS.GAS], currency = DEFAULT_CURRENCY_CODE }: Props = {}) => (state: Object) => {
-  return api.cmc.getPrices(symbols, currency)
-})
+export default createActions(
+  ID,
+  ({
+    symbols = [ASSETS.NEO, ASSETS.GAS],
+    currency = DEFAULT_CURRENCY_CODE
+  }: Props = {}) => (state: Object): ?Prices => {
+    return api.cmc.getPrices(symbols, currency)
+  }
+)

--- a/app/actions/pricesActions.js
+++ b/app/actions/pricesActions.js
@@ -7,7 +7,7 @@ import { ASSETS, DEFAULT_CURRENCY_CODE } from '../core/constants'
 type Props = {
   symbols?: Array<string>,
   currency?: string
-};
+}
 
 export const ID = 'PRICES'
 

--- a/app/containers/App/Header/Header.jsx
+++ b/app/containers/App/Header/Header.jsx
@@ -17,8 +17,8 @@ const Logo = () => <div><img src={logo} width='60px' /></div>
 
 type Props = {
   address: string,
-  neoPrice: number,
-  gasPrice: number,
+  neoPrice: ?number,
+  gasPrice: ?number,
   currencyCode: string
 }
 

--- a/app/containers/App/Header/PriceDisplay/PriceDisplay.jsx
+++ b/app/containers/App/Header/PriceDisplay/PriceDisplay.jsx
@@ -7,8 +7,8 @@ import { CURRENCIES } from '../../../../core/constants'
 import headerStyles from '../Header.scss'
 
 type Props = {
-  neoPrice: number,
-  gasPrice: number,
+  neoPrice: ?number,
+  gasPrice: ?number,
   currencyCode: string
 }
 

--- a/app/containers/App/Header/index.js
+++ b/app/containers/App/Header/index.js
@@ -8,7 +8,10 @@ import withAuthData from '../../../hocs/withAuthData'
 import withCurrencyData from '../../../hocs/withCurrencyData'
 import pricesActions from '../../../actions/pricesActions'
 
-const mapPricesDataToProps = (prices: ?Prices) => ({
+const mapPricesDataToProps = (prices: ?Prices): {
+  neoPrice: ?number,
+  gasPrice: ?number
+} => ({
   neoPrice: get(prices, 'NEO'),
   gasPrice: get(prices, 'GAS')
 })

--- a/app/containers/App/Header/index.js
+++ b/app/containers/App/Header/index.js
@@ -1,4 +1,5 @@
 // @flow
+import { get } from 'lodash'
 import { compose } from 'recompose'
 import { withData } from 'spunky'
 
@@ -7,9 +8,9 @@ import withAuthData from '../../../hocs/withAuthData'
 import withCurrencyData from '../../../hocs/withCurrencyData'
 import pricesActions from '../../../actions/pricesActions'
 
-const mapPricesDataToProps = ({ NEO, GAS }) => ({
-  neoPrice: NEO,
-  gasPrice: GAS
+const mapPricesDataToProps = (prices: ?Prices) => ({
+  neoPrice: get(prices, 'NEO'),
+  gasPrice: get(prices, 'GAS')
 })
 
 export default compose(

--- a/app/containers/WalletInfo/WalletInfo.jsx
+++ b/app/containers/WalletInfo/WalletInfo.jsx
@@ -10,7 +10,7 @@ import Button from '../../components/Button'
 
 import { formatGAS, formatFiat, formatNEO } from '../../core/formatters'
 import { ASSETS, CURRENCIES, MODAL_TYPES, ENDED_ICO_TOKENS } from '../../core/constants'
-import { toNumber } from '../../core/math'
+import { toBigNumber } from '../../core/math'
 
 import MdSync from 'react-icons/lib/md/sync'
 
@@ -22,8 +22,8 @@ type Props = {
   address: string,
   NEO: string,
   GAS: string,
-  neoPrice: number,
-  gasPrice: number,
+  neoPrice: ?number,
+  gasPrice: ?number,
   icoTokenBalances: Array<TokenBalanceType>,
   tokenBalances: Array<TokenBalanceType>,
   loadWalletData: Function,
@@ -60,10 +60,13 @@ export default class WalletInfo extends Component<Props> {
       return null
     }
 
-    let neoValue = neoPrice && NEO !== '0' ? neoPrice * toNumber(NEO) : 0
-    let gasValue = gasPrice && GAS !== '0' ? gasPrice * toNumber(GAS) : 0
+    const neoValue = neoPrice && NEO !== '0'
+      ? toBigNumber(neoPrice).mul(NEO) : toBigNumber(0)
 
-    let totalValue = neoValue + gasValue
+    const gasValue = gasPrice && GAS !== '0'
+      ? toBigNumber(gasPrice).mul(GAS) : toBigNumber(0)
+
+    const totalValue = neoValue.plus(gasValue).toString()
 
     const displayCurrencyCode = currencyCode.toUpperCase()
     const currencySymbol = CURRENCIES[currencyCode].symbol

--- a/app/containers/WalletInfo/index.js
+++ b/app/containers/WalletInfo/index.js
@@ -2,7 +2,7 @@
 import { connect, type MapStateToProps } from 'react-redux'
 import { bindActionCreators } from 'redux'
 import { compose } from 'recompose'
-import { values, omit, filter } from 'lodash'
+import { values, omit, filter, get } from 'lodash'
 import { withData, withActions } from 'spunky'
 
 import accountActions from '../../actions/accountActions'
@@ -41,9 +41,9 @@ const mapBalanceDataToProps = (balances) => ({
   icoTokenBalances: getICOTokenBalances(balances)
 })
 
-const mapPricesDataToProps = ({ NEO, GAS }) => ({
-  neoPrice: NEO,
-  gasPrice: GAS
+const mapPricesDataToProps = (prices: ?Prices) => ({
+  neoPrice: get(prices, 'NEO'),
+  gasPrice: get(prices, 'GAS')
 })
 
 const actionCreators = {

--- a/app/containers/WalletInfo/index.js
+++ b/app/containers/WalletInfo/index.js
@@ -41,7 +41,10 @@ const mapBalanceDataToProps = (balances) => ({
   icoTokenBalances: getICOTokenBalances(balances)
 })
 
-const mapPricesDataToProps = (prices: ?Prices) => ({
+const mapPricesDataToProps = (prices: ?Prices): {
+  neoPrice: ?number,
+  gasPrice: ?number
+} => ({
   neoPrice: get(prices, 'NEO'),
   gasPrice: get(prices, 'GAS')
 })

--- a/flow-typed/declarations.js
+++ b/flow-typed/declarations.js
@@ -87,3 +87,7 @@ declare type SendEntryType = {
   address: string,
   symbol: SymbolType
 }
+
+declare type Prices = {
+  [key: string]: number
+}


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
https://github.com/CityOfZion/neon-wallet/issues/1122

**What problem does this PR solve?**
When CMC is down the dashboard will turn blank.

**How did you solve this problem?**
Using lodash `get` when getting the prices, and also made a new `Prices` type, and marked all prices as optionals.
In addition to that, I also replaced the `neoValue/gasValue` calculations to use BigNumber.

**How did you make sure your solution works?**
Tested it with cmc with null/undefined/bad values

**Are there any special changes in the code that we should be aware of?**
No.

**Is there anything else we should know?**
No.

- [ ] Unit tests written?
No.