### PR TITLE
Fixed save contact button label

### DIFF
--- a/app/components/Contacts/AddContactPanel/AddContactPanel.jsx
+++ b/app/components/Contacts/AddContactPanel/AddContactPanel.jsx
@@ -34,7 +34,12 @@ export default class AddContactPanel extends React.Component<Props> {
         className={classNames(styles.addContactPanel, className)}
         renderHeader={this.renderHeader}
       >
-        <ContactForm name={name} address={address} onSubmit={this.handleSubmit} />
+        <ContactForm
+          name={name}
+          address={address}
+          submitLabel="Add to Contacts"
+          onSubmit={this.handleSubmit}
+        />
       </Panel>
     )
   }


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Fixes #1145.

**What problem does this PR solve?**
The new contact form button was labeled "Save Contact" instead of "Add to Contacts".

**How did you solve this problem?**
I passed a prop to apply the correct button label.

**How did you make sure your solution works?**
I navigated to the add & edit contact screens to ensure each displays the correct label.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?