### PR TITLE
Move blockHeight action into WalletBlockHeight component

### DIFF
--- a/app/actions/appActions.js
+++ b/app/actions/appActions.js
@@ -2,13 +2,11 @@
 import { createBatchActions } from 'spunky'
 
 import accountsActions from './accountsActions'
-import blockHeightActions from './blockHeightActions'
 import settingsActions from './settingsActions'
 
 export const ID = 'APP'
 
 export default createBatchActions(ID, {
   accounts: accountsActions,
-  blockHeight: blockHeightActions,
   settings: settingsActions
 })

--- a/app/containers/App/Header/WalletBlockHeight/WalletBlockHeight.jsx
+++ b/app/containers/App/Header/WalletBlockHeight/WalletBlockHeight.jsx
@@ -4,13 +4,13 @@ import React from 'react'
 import headerStyles from '../Header.scss'
 
 type Props = {
-  blockHeight: number
+  blockHeight: ?number
 }
 
 const WalletBlockHeight = ({ blockHeight }: Props) => (
   <div className={headerStyles.navBarItem}>
     <span className={headerStyles.navBarItemLabel}>Block</span>
-    <span>{blockHeight}</span>
+    <span>{blockHeight || '-'}</span>
   </div>
 )
 

--- a/app/containers/App/Header/WalletBlockHeight/index.js
+++ b/app/containers/App/Header/WalletBlockHeight/index.js
@@ -1,14 +1,20 @@
 // @flow
 import { compose } from 'recompose'
-import { withData } from 'spunky'
+import { withCall, withData, withRecall } from 'spunky'
 
 import WalletBlockHeight from './WalletBlockHeight'
-import appActions from '../../../../actions/appActions'
+import withNetworkData from '../../../../hocs/withNetworkData'
+import blockHeightActions from '../../../../actions/blockHeightActions'
 
-const mapAppDataToProps = ({ blockHeight }): Object => ({
+const mapBlockHeightDataToProps = (blockHeight: ?number): {
+  blockHeight: ?number
+} => ({
   blockHeight
 })
 
 export default compose(
-  withData(appActions, mapAppDataToProps)
+  withNetworkData(),
+  withCall(blockHeightActions),
+  withData(blockHeightActions, mapBlockHeightDataToProps),
+  withRecall(blockHeightActions, ['networkId'])
 )(WalletBlockHeight)


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
https://github.com/CityOfZion/neon-wallet/issues/1128

**What problem does this PR solve?**
This PR solves the infinite loader that shows when block height action fails on initial wallet load.

**How did you solve this problem?**
I moved blockHeight actions from the batched app actions to WalletBlockHeight component. The batched app actions should only be for critical stuff, because if one of them fails, then the wallet won't load. It is much safer, and performant to move it to the consumer of the data, which is the WalletBlockHeight.

**How did you make sure your solution works?**
Saw that the block height shows correct numbers for MainNet/TestNet, and that it shows a dash '-' when its undefined/null.

**Are there any special changes in the code that we should be aware of?**
No

**Is there anything else we should know?**
No