### PR TITLE
Fixed contact button sizes & icon clipping

### DIFF
--- a/app/components/Contacts/ContactsPanel/ContactsPanel.scss
+++ b/app/components/Contacts/ContactsPanel/ContactsPanel.scss
@@ -53,10 +53,12 @@
       align-items: center;
 
       .editButton {
+        width: 130px;
         margin-right: 10px;
       }
 
       .deleteButton {
+        width: 250px;
       }
     }
   }


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Fixes #1141.
Fixes #1142.

**What problem does this PR solve?**
The contacts screen's "Edit" and "Delete" buttons were too narrow, and the pencil icon in the "Edit" button was being clipped.

**How did you solve this problem?**
I made the buttons wider, which also fixed the icon clipping.

<img width="875" alt="screen shot 2018-05-28 at 3 22 15 pm" src="https://user-images.githubusercontent.com/169093/40628571-69a1a9aa-628b-11e8-99f3-b75797d86ee7.png">

**How did you make sure your solution works?**
Viewed the screen.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
