### PR TITLE
Updated to fetch block height from RPC

### DIFF
--- a/__tests__/actions/blockHeightActions.test.js
+++ b/__tests__/actions/blockHeightActions.test.js
@@ -1,4 +1,5 @@
 import { api } from 'neon-js'
+import nock from 'nock'
 
 import blockHeightActions from '../../app/actions/blockHeightActions'
 import { TEST_NETWORK_ID } from '../../app/core/constants'
@@ -6,9 +7,13 @@ import { mockPromiseResolved } from '../testHelpers'
 
 describe('blockHeightActions', () => {
   beforeEach(() => {
-    jest.spyOn(api.neoscan, 'getWalletDBHeight').mockImplementation(
-      mockPromiseResolved(586435)
-    )
+    const rpcHost = 'http://seed1.cityofzion.io:8080'
+
+    jest.spyOn(api.neoscan, 'getRPCEndpoint').mockImplementation(mockPromiseResolved(rpcHost))
+
+    nock(rpcHost)
+      .post('/', (body) => body.method === 'getblockcount')
+      .reply(200, { id: 1234, jsonrpc: '2.0', result: 586435 }, { 'Access-Control-Allow-Origin': '*' })
   })
 
   afterEach(() => {

--- a/app/actions/blockHeightActions.js
+++ b/app/actions/blockHeightActions.js
@@ -1,5 +1,5 @@
 // @flow
-import { api } from 'neon-js'
+import { api, rpc } from 'neon-js'
 import { createActions } from 'spunky'
 
 import { getNetworkById } from '../core/deprecated'
@@ -11,6 +11,8 @@ type Props = {
 export const ID = 'BLOCK_HEIGHT'
 
 export default createActions(ID, ({ networkId }: Props = {}) => async (state: Object) => {
-  const network = getNetworkById(networkId)
-  return api.getWalletDBHeightFrom({ net: network }, api.neoscan)
+  const net = getNetworkById(networkId)
+  const endpoint = await api.getRPCEndpointFrom({ net }, api.neoscan)
+  const client = new rpc.RPCClient(endpoint)
+  return client.getBlockCount()
 })


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Fixes #1127.

**What problem does this PR solve?**
This replaces the API call for the current block height with an RPC call.

**How did you solve this problem?**
I update the `blockHeightActions` file to use RPC for getting the current block height.

**How did you make sure your solution works?**
I logged into an account and ensured the block height displayed in the header.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [x] Unit tests written?