### PR TITLE
Update new wallet information qrcodes

### DIFF
--- a/app/containers/DisplayWalletAccounts/DisplayWalletAccounts.jsx
+++ b/app/containers/DisplayWalletAccounts/DisplayWalletAccounts.jsx
@@ -26,14 +26,18 @@ class DisplayWalletAccounts extends Component<Props, State> {
   }
 
   publicCanvas: ?HTMLCanvasElement
+  encryptedCanvas: ?HTMLCanvasElement
   privateCanvas: ?HTMLCanvasElement
 
   componentDidMount () {
-    const { address, encryptedWIF } = this.props
+    const { address, encryptedWIF, wif } = this.props
     QRCode.toCanvas(this.publicCanvas, address, { version: 5 }, (err) => {
       if (err) console.log(err)
     })
-    QRCode.toCanvas(this.privateCanvas, encryptedWIF, { version: 5 }, (err) => {
+    QRCode.toCanvas(this.encryptedCanvas, encryptedWIF, { version: 5 }, (err) => {
+      if (err) console.log(err)
+    })
+    QRCode.toCanvas(this.privateCanvas, wif, { version: 5 }, (err) => {
       if (err) console.log(err)
     })
   }
@@ -48,13 +52,19 @@ class DisplayWalletAccounts extends Component<Props, State> {
           You can click "Save Key" to save the encrypted key in local application storage.
           Verify that you can log in to the account and see the correct public address before sending anything to the address below!
         </div>
-        <div className='addressBox'>
-          <canvas ref={(node) => { this.publicCanvas = node }} />
-          <div>Public Address</div>
-        </div>
-        <div className='privateKeyBox'>
-          <canvas ref={(node) => { this.privateCanvas = node }} />
-          <div>Encrypted Private Key</div>
+        <div className='qrcode-container'>
+          <div className='addressBox'>
+            <canvas ref={(node) => { this.publicCanvas = node }} />
+            <div>Public Address</div>
+          </div>
+          <div className='encryptedKeyBox'>
+            <canvas ref={(node) => { this.encryptedCanvas = node }} />
+            <div>Encrypted Key</div>
+          </div>
+          <div className='privateKeyBox'>
+            <canvas ref={(node) => { this.privateCanvas = node }} />
+            <div>Private Key</div>
+          </div>
         </div>
         <div className='keyList'>
           <div className='keyListItem'>

--- a/app/styles/main.global.scss
+++ b/app/styles/main.global.scss
@@ -118,18 +118,15 @@ input {
     font-size: 1.4em;
     font-weight: 200;
   }
+  .qrcode-container {
+    display: flex;
+  }
   .addressBox,
+  .encryptedKeyBox,
   .privateKeyBox {
     margin-bottom: 20px;
-    display: inline-block;
-    width: 40%;
+    flex: 1;
     text-align: center;
-  }
-  .addressBox {
-    margin-right: 9%;
-  }
-  .privateKeyBox {
-    margin-left: 9%;
   }
   .keyList {
     margin-bottom: 20px;


### PR DESCRIPTION
**What problem does this PR solve?**
- QR code for the private key is missing
- The subtitle of the QR code for the encrypted key is possibly confusing to new users.

**How did you solve this problem?**
- Added a third QR code for the private key.
- Updated the subtitle on the QR code for the encrypted key to match the value that was provided below. 

As far as security is concerned, the private key is already provided in this screen, so adding the QR code for it's value does not reveal any additional information that is not already present.

Since the names will now match between the each of the 3 QR codes and the values provided below them, it will make it more clear for users.

Current
![image](https://user-images.githubusercontent.com/6342442/40636861-86bff3dc-633c-11e8-8234-f14578408ce0.png)

Updated
![image](https://user-images.githubusercontent.com/6342442/40636877-9f00cc32-633c-11e8-9ad5-2ee6698b4953.png)

*These are random values from newly created wallets