### PR TITLE
Add ability to recall saved wallet address credentials

### DIFF
--- a/app/actions/authActions.js
+++ b/app/actions/authActions.js
@@ -61,7 +61,7 @@ export const nep2LoginActions = createActions(ID, ({ passphrase, encryptedWIF }:
   return { wif: account.WIF, address: account.address, isHardwareLogin: false }
 })
 
-export const nep2DetailsLoginActions = (passphrase: string,  encryptedWIF: string, history: Object) => (dispatch: DispatchType) => {
+export const nep2DetailsLoginActions = (passphrase: string,  encryptedWIF: string, history: Object) => (dispatch: DispatchType): Promise<*> => {
   return new Promise((resolve, reject) => {
     if (!validatePassphraseLength(passphrase)) {
       reject('Passphrase too short')

--- a/app/actions/authActions.js
+++ b/app/actions/authActions.js
@@ -62,26 +62,32 @@ export const nep2LoginActions = createActions(ID, ({ passphrase, encryptedWIF }:
 })
 
 export const nep2DetailsLoginActions = (passphrase: string,  encryptedWIF: string, history: Object) => (dispatch: DispatchType) => {
-  if (!validatePassphraseLength(passphrase)) {
-    return Promise.reject('Passphrase too short')
-  }
+  return new Promise((resolve, reject) => {
+    if (!validatePassphraseLength(passphrase)) {
+      reject('Passphrase too short')
+    }
 
-  if (!wallet.isNEP2(encryptedWIF)) {
-    return Promise.reject('That is not a valid encrypted key')
-  }
+    if (!wallet.isNEP2(encryptedWIF)) {
+      reject('That is not a valid encrypted key')
+    }
 
-  const wif = wallet.decrypt(encryptedWIF, passphrase)
-  const account = new wallet.Account(wif)
-  const { address } = account
+    try {
+      const wif = wallet.decrypt(encryptedWIF, passphrase)
+      const account = new wallet.Account(wif)
+      const { address } = account
 
-  dispatch(newWalletAccount({
-    wif,
-    address,
-    passphrase,
-    encryptedWIF
-  }))
-  history.push(ROUTES.DISPLAY_WALLET_KEYS)
-  return Promise.resolve()
+      dispatch(newWalletAccount({
+        wif,
+        address,
+        passphrase,
+        encryptedWIF
+      }))
+      history.push(ROUTES.DISPLAY_WALLET_KEYS)
+      resolve()
+    } catch (error) {
+      reject(error.message)
+    }
+  })
 }
 
 export const ledgerLoginActions = createActions(ID, ({ publicKey }: LedgerLoginProps) => (state: Object): AccountType => {

--- a/app/actions/authActions.js
+++ b/app/actions/authActions.js
@@ -61,14 +61,14 @@ export const nep2LoginActions = createActions(ID, ({ passphrase, encryptedWIF }:
   return { wif: account.WIF, address: account.address, isHardwareLogin: false }
 })
 
-export const nep2DetailsLoginActions = (passphrase: string,  encryptedWIF: string, history: Object) => (dispatch: DispatchType): Promise<*> => {
+export const nep2DetailsLoginActions = (passphrase: string, encryptedWIF: string, history: Object) => (dispatch: DispatchType): Promise<*> => {
   return new Promise((resolve, reject) => {
     if (!validatePassphraseLength(passphrase)) {
-      reject('Passphrase too short')
+      reject(new Error('Passphrase too short'))
     }
 
     if (!wallet.isNEP2(encryptedWIF)) {
-      reject('That is not a valid encrypted key')
+      reject(new Error('That is not a valid encrypted key'))
     }
 
     try {
@@ -85,7 +85,7 @@ export const nep2DetailsLoginActions = (passphrase: string,  encryptedWIF: strin
       history.push(ROUTES.DISPLAY_WALLET_KEYS)
       resolve()
     } catch (error) {
-      reject(error.message)
+      reject(error)
     }
   })
 }

--- a/app/components/Modals/EncryptedLoginModal/EncryptedLoginModal.jsx
+++ b/app/components/Modals/EncryptedLoginModal/EncryptedLoginModal.jsx
@@ -95,10 +95,10 @@ export default class EncryptedLoginModal extends Component<Props, State> {
               cancel
               disabled={pendingLogin}
               onClick={hideModal}>Cancel</Button>
+            <div className={styles.errorMessage}>{errorMsg}</div>
           </div>
         </form>
         {pendingLogin && <Loader />}
-        <div className={styles.errorMessage}>{errorMsg}</div>
       </BaseModal>
     )
   }

--- a/app/components/Modals/EncryptedLoginModal/EncryptedLoginModal.jsx
+++ b/app/components/Modals/EncryptedLoginModal/EncryptedLoginModal.jsx
@@ -55,8 +55,6 @@ export default class EncryptedLoginModal extends Component<Props, State> {
     const loginButtonDisabled = passphrase == ''
     const { handleLoginSubmit } = this
 
-    console.log(pendingLogin);
-
     return (
       <BaseModal
         title={title}
@@ -90,7 +88,7 @@ export default class EncryptedLoginModal extends Component<Props, State> {
           </div>
         </form>
         {pendingLogin && <Loader />}
-        <div className='errorMessage'>{errorMsg}</div>
+        <div className={styles.errorMessage}>{errorMsg}</div>
       </BaseModal>
     )
   }

--- a/app/components/Modals/EncryptedLoginModal/EncryptedLoginModal.jsx
+++ b/app/components/Modals/EncryptedLoginModal/EncryptedLoginModal.jsx
@@ -10,8 +10,6 @@ import PasswordField from '../../PasswordField'
 type Props = {
   title: string,
   text: string,
-  label: string,
-  encryptedWIF: string,
   hideModal: Function,
   width: string,
   height: string,
@@ -33,11 +31,15 @@ export default class EncryptedLoginModal extends Component<Props, State> {
   state = {
     passphrase: '',
     errorMsg: '',
-    pendingLogin: false,
+    pendingLogin: false
+  }
+
+  componentWillMount() {
+    this.handleLoginSubmit = this.handleLoginSubmit.bind(this)
   }
 
   handleLoginSubmit (e: Object) {
-    e.preventDefault();
+    e.preventDefault()
     const {onClick, hideModal} = this.props
     const {passphrase} = this.state
     this.setState({ pendingLogin: true })
@@ -45,20 +47,20 @@ export default class EncryptedLoginModal extends Component<Props, State> {
     // Run on separate thread so that state change can pass through
     setTimeout(() => {
       onClick(passphrase)
-      .then(hideModal)
-      .catch(err => {
-        this.setState({
-          errorMsg: err,
-          pendingLogin: false
+        .then(hideModal)
+        .catch(err => {
+          this.setState({
+            errorMsg: err && err.message,
+            pendingLogin: false
+          })
         })
-      })
     }, 100)
   }
 
   render () {
-    const { hideModal, title, text, width, height, onClick } = this.props
+    const { hideModal, title, text, width, height } = this.props
     const { errorMsg, passphrase, pendingLogin } = this.state
-    const loginButtonDisabled = passphrase == ''
+    const loginButtonDisabled = passphrase === ''
     const { handleLoginSubmit } = this
 
     return (
@@ -75,7 +77,7 @@ export default class EncryptedLoginModal extends Component<Props, State> {
         <div className={styles.textContainer}>
           <strong className={styles.text}>{text}</strong>
         </div>
-        <form onSubmit={handleLoginSubmit.bind(this)}>
+        <form onSubmit={handleLoginSubmit}>
           <div className={styles.modalFooter}>
             <PasswordField
               placeholder='Enter your passphrase here'

--- a/app/components/Modals/EncryptedLoginModal/EncryptedLoginModal.jsx
+++ b/app/components/Modals/EncryptedLoginModal/EncryptedLoginModal.jsx
@@ -89,7 +89,7 @@ export default class EncryptedLoginModal extends Component<Props, State> {
             <Button
               type='submit'
               disabled={loginButtonDisabled || pendingLogin}
-            >Login</Button>
+            >Authenticate</Button>
             <Button
               id='cancel'
               cancel

--- a/app/components/Modals/EncryptedLoginModal/EncryptedLoginModal.jsx
+++ b/app/components/Modals/EncryptedLoginModal/EncryptedLoginModal.jsx
@@ -43,7 +43,7 @@ export default class EncryptedLoginModal extends Component<Props, State> {
   render () {
     const { hideModal, title, text, width, height, onClick } = this.props
     const { errorMsg, passphrase } = this.state
-    const loginButtonDisabled = passphrase === ''
+    const loginButtonDisabled = passphrase == ''
     const { handleLoginSubmit } = this
 
     return (
@@ -60,21 +60,23 @@ export default class EncryptedLoginModal extends Component<Props, State> {
         <div className={styles.textContainer}>
           <strong className={styles.text}>{text}</strong>
         </div>
-        <div className={styles.modalFooter}>
-          <PasswordField
-            placeholder='Enter your passphrase here'
-            onChange={(e) => this.setState({ passphrase: e.target.value })}
-            autoFocus
-          />
-          <Button
-            disabled={loginButtonDisabled}
-            onClick={handleLoginSubmit.bind(this)}
-          >Login</Button>
-          <Button
-            id='cancel'
-            cancel
-            onClick={hideModal}>Cancel</Button>
-        </div>
+        <form onSubmit={handleLoginSubmit.bind(this)}>
+          <div className={styles.modalFooter}>
+            <PasswordField
+              placeholder='Enter your passphrase here'
+              onChange={(e) => this.setState({ passphrase: e.target.value })}
+              autoFocus
+            />
+            <Button
+              type='submit'
+              disabled={loginButtonDisabled}
+            >Login</Button>
+            <Button
+              id='cancel'
+              cancel
+              onClick={hideModal}>Cancel</Button>
+          </div>
+        </form>
         <div className='errorMessage'>{errorMsg}</div>
       </BaseModal>
     )

--- a/app/components/Modals/EncryptedLoginModal/EncryptedLoginModal.jsx
+++ b/app/components/Modals/EncryptedLoginModal/EncryptedLoginModal.jsx
@@ -1,0 +1,87 @@
+// @flow
+import React, { Component } from 'react'
+
+import BaseModal from '../BaseModal'
+import Button from '../../Button'
+import styles from './EncryptedLoginModal.scss'
+import PasswordField from '../../PasswordField'
+
+type Props = {
+  title: string,
+  text: string,
+  label: string,
+  encryptedWIF: string,
+  hideModal: Function,
+  width: string,
+  height: string,
+  onClick: Function
+}
+
+type State = {
+  passphrase: string,
+  errorMsg: string
+}
+
+export default class EncryptedLoginModal extends Component<Props, State> {
+  state = {
+    passphrase: '',
+    errorMsg: ''
+  }
+
+  handleLoginSubmit (e) {
+    e.preventDefault();
+    const {onClick, hideModal} = this.props
+    const {passphrase} = this.state
+
+    onClick(passphrase)
+    .then(hideModal)
+    .catch(err => {
+      this.setState({ errorMsg: err })
+    })
+  }
+
+  render () {
+    const { hideModal, title, text, width, height, onClick } = this.props
+    const { errorMsg, passphrase } = this.state
+    const loginButtonDisabled = passphrase === ''
+    const { handleLoginSubmit } = this
+
+    return (
+      <BaseModal
+        title={title}
+        hideModal={hideModal}
+        style={{
+          content: {
+            width,
+            height
+          }
+        }}
+      >
+        <div className={styles.textContainer}>
+          <strong className={styles.text}>{text}</strong>
+        </div>
+        <div className={styles.modalFooter}>
+          <PasswordField
+            placeholder='Enter your passphrase here'
+            onChange={(e) => this.setState({ passphrase: e.target.value })}
+            autoFocus
+          />
+          <Button
+            disabled={loginButtonDisabled}
+            onClick={handleLoginSubmit.bind(this)}
+          >Login</Button>
+          <Button
+            id='cancel'
+            cancel
+            onClick={hideModal}>Cancel</Button>
+        </div>
+        <div className='errorMessage'>{errorMsg}</div>
+      </BaseModal>
+    )
+  }
+}
+
+EncryptedLoginModal.defaultProps = {
+  width: '450px',
+  height: '225px'
+}

--- a/app/components/Modals/EncryptedLoginModal/EncryptedLoginModal.jsx
+++ b/app/components/Modals/EncryptedLoginModal/EncryptedLoginModal.jsx
@@ -34,7 +34,7 @@ export default class EncryptedLoginModal extends Component<Props, State> {
     pendingLogin: false
   }
 
-  componentWillMount() {
+  componentWillMount () {
     this.handleLoginSubmit = this.handleLoginSubmit.bind(this)
   }
 

--- a/app/components/Modals/EncryptedLoginModal/EncryptedLoginModal.jsx
+++ b/app/components/Modals/EncryptedLoginModal/EncryptedLoginModal.jsx
@@ -20,17 +20,23 @@ type Props = {
 
 type State = {
   passphrase: string,
-  errorMsg: string
+  errorMsg: string,
+  pendingLogin: boolean
 }
 
 export default class EncryptedLoginModal extends Component<Props, State> {
+  static defaultProps = {
+    width: '450px',
+    height: '225px'
+  }
+
   state = {
     passphrase: '',
     errorMsg: '',
     pendingLogin: false,
   }
 
-  handleLoginSubmit (e) {
+  handleLoginSubmit (e: Object) {
     e.preventDefault();
     const {onClick, hideModal} = this.props
     const {passphrase} = this.state
@@ -92,9 +98,4 @@ export default class EncryptedLoginModal extends Component<Props, State> {
       </BaseModal>
     )
   }
-}
-
-EncryptedLoginModal.defaultProps = {
-  width: '450px',
-  height: '225px'
 }

--- a/app/components/Modals/EncryptedLoginModal/EncryptedLoginModal.jsx
+++ b/app/components/Modals/EncryptedLoginModal/EncryptedLoginModal.jsx
@@ -34,6 +34,8 @@ export default class EncryptedLoginModal extends Component<Props, State> {
     pendingLogin: false
   }
 
+  handleLoginSubmit: Function
+
   componentWillMount () {
     this.handleLoginSubmit = this.handleLoginSubmit.bind(this)
   }

--- a/app/components/Modals/EncryptedLoginModal/EncryptedLoginModal.scss
+++ b/app/components/Modals/EncryptedLoginModal/EncryptedLoginModal.scss
@@ -1,0 +1,20 @@
+.modalFooter {
+    padding-top: 20px;
+    text-align: right;
+}
+
+.actionButton {
+    background-color: red;
+    &:hover {
+        background-color: red;
+    }
+}
+
+.cancelButton {
+    background: none;
+    border: 1px solid #999;
+    color: #000;
+    &:hover {
+        background: none
+    }
+}

--- a/app/components/Modals/EncryptedLoginModal/EncryptedLoginModal.scss
+++ b/app/components/Modals/EncryptedLoginModal/EncryptedLoginModal.scss
@@ -15,4 +15,5 @@
 .errorMessage {
     color: red;
     float: left;
+    padding-top: 7px;
 }

--- a/app/components/Modals/EncryptedLoginModal/EncryptedLoginModal.scss
+++ b/app/components/Modals/EncryptedLoginModal/EncryptedLoginModal.scss
@@ -3,13 +3,6 @@
     text-align: right;
 }
 
-.actionButton {
-    background-color: red;
-    &:hover {
-        background-color: red;
-    }
-}
-
 .cancelButton {
     background: none;
     border: 1px solid #999;
@@ -17,4 +10,8 @@
     &:hover {
         background: none
     }
+}
+
+.errorMessage {
+    color: red;
 }

--- a/app/components/Modals/EncryptedLoginModal/EncryptedLoginModal.scss
+++ b/app/components/Modals/EncryptedLoginModal/EncryptedLoginModal.scss
@@ -14,4 +14,5 @@
 
 .errorMessage {
     color: red;
+    float: left;
 }

--- a/app/components/Modals/EncryptedLoginModal/index.js
+++ b/app/components/Modals/EncryptedLoginModal/index.js
@@ -1,0 +1,1 @@
+export { default } from './EncryptedLoginModal'

--- a/app/components/PasswordField/PasswordField.scss
+++ b/app/components/PasswordField/PasswordField.scss
@@ -1,17 +1,18 @@
 .passwordField {
     width: 100%;
-    display: inline-block;
+    position: relative;
 
     input {
-        width: 95%;
-        float: left;
+        width: 100%;
         margin-bottom: 10px;
+        padding-right: 40px;
+        box-sizing: border-box;
     }
 
     .viewKey {
-        position: relative;
+        position: absolute;
         cursor: pointer;
-        margin-left: -25px;
-        margin-top: 10px;
+        top: 11px;
+        right: 14px;
     }
 }

--- a/app/containers/DisplayWalletAccounts/DisplayWalletAccounts.jsx
+++ b/app/containers/DisplayWalletAccounts/DisplayWalletAccounts.jsx
@@ -13,7 +13,8 @@ type Props = {
   wif: string,
   encryptedWIF: string,
   passphrase: string,
-  history: Object
+  history: Object,
+  isSaved?: boolean
 }
 
 type State = {

--- a/app/containers/DisplayWalletAccounts/DisplayWalletAccounts.jsx
+++ b/app/containers/DisplayWalletAccounts/DisplayWalletAccounts.jsx
@@ -39,7 +39,7 @@ class DisplayWalletAccounts extends Component<Props, State> {
   }
 
   render () {
-    const { passphrase, address, encryptedWIF, wif, saveAccount } = this.props
+    const { passphrase, address, encryptedWIF, wif, saveAccount, isSaved } = this.props
     const { keyName } = this.state
     return (
       <div id='newWallet'>
@@ -79,10 +79,14 @@ class DisplayWalletAccounts extends Component<Props, State> {
             <CopyToClipboard text={wif} tooltip='Copy Private Key' />
           </div>
         </div>
-        <div className='saveAccount'>
-          <input autoFocus type='text' placeholder='Name this account' value={keyName} onChange={(e) => this.setState({ keyName: e.target.value })} />
-          <Button onClick={() => saveAccount(keyName, address, encryptedWIF)}>Save Account</Button>
-        </div>
+        {(() => {
+          return !isSaved && (
+            <div className='saveAccount'>
+              <input autoFocus type='text' placeholder='Name this account' value={keyName} onChange={(e) => this.setState({ keyName: e.target.value })} />
+              <Button onClick={() => saveAccount(keyName, address, encryptedWIF)}>Save Account</Button>
+            </div>
+          )
+        })()}
         <Button onClick={this.handleBack}>Back</Button>
         <Button onClick={this.handlePrint}>Print</Button>
       </div>

--- a/app/containers/DisplayWalletAccounts/index.js
+++ b/app/containers/DisplayWalletAccounts/index.js
@@ -13,14 +13,16 @@ import {
   getWIF,
   getAddress,
   getEncryptedWIF,
-  getPassphrase
+  getPassphrase,
+  isSaved
 } from '../../modules/generateWallet'
 
 const mapStateToProps = (state: Object) => ({
   wif: getWIF(state),
   address: getAddress(state),
   encryptedWIF: getEncryptedWIF(state),
-  passphrase: getPassphrase(state)
+  passphrase: getPassphrase(state),
+  isSaved: isSaved(state)
 })
 
 const mapDispatchToProps = dispatch => bindActionCreators({ resetKey }, dispatch)

--- a/app/containers/ModalRenderer/ModalRenderer.jsx
+++ b/app/containers/ModalRenderer/ModalRenderer.jsx
@@ -21,7 +21,7 @@ const MODAL_COMPONENTS = {
   [TOKEN_INFO]: TokenInfoModal,
   [TOKEN]: TokenModal,
   [ICO]: TokenSaleModal,
-  [ENCRYPTED_LOGIN]: EncryptedLoginModal,
+  [ENCRYPTED_LOGIN]: EncryptedLoginModal
 }
 
 type Props = {

--- a/app/containers/ModalRenderer/ModalRenderer.jsx
+++ b/app/containers/ModalRenderer/ModalRenderer.jsx
@@ -8,10 +8,11 @@ import SendModal from '../../components/Modals/SendModal'
 import TokenInfoModal from '../../components/Modals/TokenInfoModal'
 import TokenModal from '../../components/Modals/TokenModal'
 import TokenSaleModal from '../../components/Modals/TokenSaleModal'
+import EncryptedLoginModal from '../../components/Modals/EncryptedLoginModal'
 
 import { MODAL_TYPES } from '../../core/constants'
 
-const { CONFIRM, RECEIVE, SEND, TOKEN_INFO, TOKEN, ICO } = MODAL_TYPES
+const { CONFIRM, RECEIVE, SEND, TOKEN_INFO, TOKEN, ICO, ENCRYPTED_LOGIN } = MODAL_TYPES
 
 const MODAL_COMPONENTS = {
   [CONFIRM]: ConfirmModal,
@@ -19,7 +20,8 @@ const MODAL_COMPONENTS = {
   [SEND]: SendModal,
   [TOKEN_INFO]: TokenInfoModal,
   [TOKEN]: TokenModal,
-  [ICO]: TokenSaleModal
+  [ICO]: TokenSaleModal,
+  [ENCRYPTED_LOGIN]: EncryptedLoginModal,
 }
 
 type Props = {

--- a/app/containers/Settings/Settings.jsx
+++ b/app/containers/Settings/Settings.jsx
@@ -27,7 +27,8 @@ type Props = {
   showSuccessNotification: Object => any,
   showErrorNotification: Object => any,
   setUserGeneratedTokens: () => any,
-  networks: Array<NetworkItemType>
+  networks: Array<NetworkItemType>,
+  nep2DetailsLoginActions: (string, string, Object) => any
 }
 
 type State = {

--- a/app/containers/Settings/Settings.jsx
+++ b/app/containers/Settings/Settings.jsx
@@ -146,7 +146,7 @@ export default class Settings extends Component<Props, State> {
       encryptedWIF: account.key,
       onClick: (passphrase) => {
         return nep2DetailsLoginActions(passphrase, account.key, history)
-      },
+      }
     })
   }
 

--- a/app/containers/Settings/Settings.jsx
+++ b/app/containers/Settings/Settings.jsx
@@ -11,10 +11,12 @@ import HomeButtonLink from '../../components/HomeButtonLink'
 import { EXPLORERS, MODAL_TYPES, CURRENCIES } from '../../core/constants'
 
 import Delete from 'react-icons/lib/md/delete'
+import Lock from 'react-icons/lib/fa/lock'
 
 const { dialog } = require('electron').remote
 
 type Props = {
+  history: Object,
   setAccounts: (Array<Object>) => any,
   setBlockExplorer: string => any,
   explorer: string,
@@ -129,6 +131,24 @@ export default class Settings extends Component<Props, State> {
     setCurrency(e.target.value)
   }
 
+  walletAccountDetailsLogin = (account: Object) => {
+    const {
+      showModal,
+      history,
+      nep2DetailsLoginActions
+    } = this.props
+
+    showModal(MODAL_TYPES.ENCRYPTED_LOGIN, {
+      title: 'Authenticate',
+      text: `Please enter your passphrase to continue`,
+      label: account.label,
+      encryptedWIF: account.key,
+      onClick: (passphrase) => {
+        return nep2DetailsLoginActions(passphrase, account.key, history)
+      },
+    })
+  }
+
   deleteWalletAccount = (label: string, key: string) => {
     const {
       showSuccessNotification,
@@ -222,6 +242,14 @@ export default class Settings extends Component<Props, State> {
                   <div className='walletItem'>
                     <div className='walletName'>{account.key.slice(0, 20)}</div>
                     <div className='walletKey'>{account.label}</div>
+                    <div
+                      className='walletCredentials'
+                      onClick={() =>
+                        this.walletAccountDetailsLogin(account)
+                      }
+                    >
+                      <Lock />
+                    </div>
                     <div
                       className='deleteWallet'
                       onClick={() =>

--- a/app/containers/Settings/index.js
+++ b/app/containers/Settings/index.js
@@ -9,6 +9,7 @@ import withExplorerData from '../../hocs/withExplorerData'
 import withCurrencyData from '../../hocs/withCurrencyData'
 import accountsActions, { updateAccountsActions } from '../../actions/accountsActions'
 import { updateSettingsActions } from '../../actions/settingsActions'
+import { nep2DetailsLoginActions } from '../../actions/authActions'
 import { getNetworks } from '../../core/networks'
 import { showErrorNotification, showSuccessNotification } from '../../modules/notifications'
 import { showModal } from '../../modules/modal'
@@ -20,7 +21,8 @@ const mapStateToProps = (state: Object) => ({
 const actionCreators = {
   showModal,
   showErrorNotification,
-  showSuccessNotification
+  showSuccessNotification,
+  nep2DetailsLoginActions
 }
 
 const mapDispatchToProps = (dispatch) => bindActionCreators(actionCreators, dispatch)

--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -53,7 +53,8 @@ export const MODAL_TYPES = {
   CONFIRM: 'CONFIRM',
   TOKEN_INFO: 'TOKEN_INFO',
   TOKEN: 'TOKEN',
-  ICO: 'ICO'
+  ICO: 'ICO',
+  ENCRYPTED_LOGIN: 'ENCRYPTED_LOGIN'
 }
 
 export const MAIN_NETWORK_ID = '1'

--- a/app/modules/generateWallet.js
+++ b/app/modules/generateWallet.js
@@ -183,6 +183,11 @@ export const getWIF = (state: Object) => state.generateWallet.wif
 export const getAddress = (state: Object) => state.generateWallet.address
 export const getPassphrase = (state: Object) => state.generateWallet.passphrase
 export const getEncryptedWIF = (state: Object) => state.generateWallet.encryptedWIF
+export const isSaved = (state: Object) => {
+  const savedAddresses = state.spunky.ACCOUNTS.data
+  const address = state.generateWallet.address
+  return Boolean(savedAddresses.find(addressData => addressData.address === address))
+}
 
 const initialState = {
   wif: null,

--- a/app/styles/main.global.scss
+++ b/app/styles/main.global.scss
@@ -107,10 +107,6 @@ input {
 }
 
 #newWallet {
-  input {
-    width: 95%;
-    margin-bottom: 10px;
-  }
 
   .disclaimer {
     margin-bottom: 20px;

--- a/app/styles/main.global.scss
+++ b/app/styles/main.global.scss
@@ -71,6 +71,7 @@ input {
   }
   .walletName,
   .walletKey,
+  .walletCredentials,
   .deleteWallet {
     display: inline-block;
     margin-right: 10px;
@@ -83,10 +84,16 @@ input {
     font-size: 0.8em;
     font-family: 'courier', monospace;
   }
+  .walletCredentials,
   .deleteWallet {
-    width: 10%;
     opacity: 0.6;
     cursor: pointer;
+  }
+  .deleteWallet {
+    width: 10%;
+  }
+  .walletCredentials {
+    width: 5%;
   }
 }
 


### PR DESCRIPTION
**What problem does this PR solve?**
Currently there is no way for users who have created their wallets with neon-wallet to recall the credentials screen that was displayed when they first created the wallet. While it could be argued that it is for their own security that they not be able to pull up this information again, and that it's their responsibility to save these details upon creation. However, the sad reality is that there are many people who save their wallet, and blow past this screen without a second thought. While users are able to export their wallet recovery JSON file with their encrypted key, many less technical people have no idea what this file is or how to make sense of it.

**How did you solve this problem?**
In order to remedy this, an option was added to the wallet management screen to allow users to recall the credentials screen in order to reference or print their address details after the creation of the wallet. The reason that this was added to the wallet management screen rather than the main wallet screen, to create a user flow that will allow them to only pull up this information if it's what they are specifically looking for. Rather than having it on the main wallet page, where they may leave that open on accident, or press on the icon to bring it up when the didn't intend to.

The addition of this feature improves the portability of addresses created with neon-wallet, and provides user with the option to recall and print their credentials at a later point in time.

**How did you make sure your solution works?**
In order to test this:
- Navigate to the "Manage Neon settings" screen from the home screen. 
- Click on the small lock icon to the right of the address that you want to pull up the details for
- Enter the passphrase for the address to unlock this information
- Upon entry of the correct passphrase, you will be brought to the credentials screen

- If an incorrect passphrase in entered, you will remain on the settings page with the modal present
- An error message will be shown at the bottom of the modal

**Are there any special changes in the code that we should be aware of?**
As a side affect of this change, when saving the address upon wallet creation, the field for saving will disappear once saved. Unlike it's current state, where no indication that it was saved or not, which sometimes lead to people clicking on it multiple times and saving it multiple times.

**Design V2 Plans**
Will add this to design-v2 once https://github.com/CityOfZion/neon-wallet/pull/1173 is merged