### PR TITLE
Add option to save account NEP2 login screen

### DIFF
--- a/__tests__/components/__snapshots__/LoginNep2.test.js.snap
+++ b/__tests__/components/__snapshots__/LoginNep2.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LoginNep2 renders without crashing 1`] = `
-<withActions(Connect(Connect(withError(Connect(withProgress(ErrorNotifier))))))
+<withActions(Connect(withActions(Connect(Connect(withError(Connect(withProgress(ErrorNotifier))))))))
   loginNep2={[Function]}
   store={
     Object {

--- a/app/actions/accountsActions.js
+++ b/app/actions/accountsActions.js
@@ -1,70 +1,23 @@
 // @flow
 import { createActions } from 'spunky'
-import { isEmpty } from 'lodash'
 
 import { getStorage, setStorage } from '../core/storage'
 import { DEFAULT_WALLET } from '../core/constants'
-import { Account } from '../core/schemas'
+import { saveAccount, updateAccount, getWallet } from '../core/account'
 
 type Props = {
   networkId: string
 }
 
-const STORAGE_KEY = 'userWallet'
-
-const getWallet = async (): Promise<Object> => {
-  return await getStorage(STORAGE_KEY) || DEFAULT_WALLET
-}
-
-const setWallet = async (wallet: Object) => {
-  setStorage(STORAGE_KEY, wallet)
-}
-
-const walletHasKey = (wallet: Object, key: string) => {
-  return wallet.accounts.some(account => account.key === key)
-}
-
-const walletHasLabel = (wallet: Object, label: string) => {
-  return wallet.accounts.some(account => account.label === label)
-}
-
 export const ID = 'ACCOUNTS'
 
 export const updateAccountsActions = createActions(ID, (accounts: Array<Object>) => async (): Promise<Array<Object>> => {
-  const wallet = await getWallet()
-  const newWallet = { ...wallet, accounts }
-  await setStorage(STORAGE_KEY, newWallet)
-
+  await updateAccount(accounts)
   return accounts
 })
 
-export const saveAccountActions = createActions(ID, ({ label, address, key }: Object) => async () => {
-  if (isEmpty(label)) {
-    throw new Error('A valid name is required.')
-  }
-
-  if (isEmpty(address)) {
-    throw new Error('A valid address is required.')
-  }
-
-  if (isEmpty(key)) {
-    throw new Error('A valid key is required.')
-  }
-
-  const wallet = await getWallet()
-
-  if (walletHasKey(wallet, key)) {
-    throw new Error(`Address '${address}' already exists.`)
-  }
-
-  if (walletHasLabel(wallet, label)) {
-    throw new Error(`Account '${label}' already exists.`)
-  }
-
-  wallet.accounts.push(new Account({ address, label, key }))
-  await setWallet(wallet)
-
-  return wallet.accounts
+export const saveAccountActions = createActions(ID, ({ label, address, key }: Object) => async (): Promise<Array<Object>> => {
+  return await saveAccount(label, address, key)
 })
 
 export default createActions(ID, ({ networkId }: Props = {}) => async (): Promise<Object> => {

--- a/app/actions/accountsActions.js
+++ b/app/actions/accountsActions.js
@@ -1,7 +1,6 @@
 // @flow
 import { createActions } from 'spunky'
 
-import { getStorage, setStorage } from '../core/storage'
 import { saveAccount, updateAccount, getWallet } from '../core/account'
 
 type Props = {
@@ -16,7 +15,8 @@ export const updateAccountsActions = createActions(ID, (accounts: Array<Object>)
 })
 
 export const saveAccountActions = createActions(ID, ({ label, address, key }: Object) => async (): Promise<Array<Object>> => {
-  return await saveAccount(label, address, key)
+  const accounts = await saveAccount(label, address, key)
+  return accounts
 })
 
 export default createActions(ID, ({ networkId }: Props = {}) => async (): Promise<Object> => {

--- a/app/actions/accountsActions.js
+++ b/app/actions/accountsActions.js
@@ -2,7 +2,6 @@
 import { createActions } from 'spunky'
 
 import { getStorage, setStorage } from '../core/storage'
-import { DEFAULT_WALLET } from '../core/constants'
 import { saveAccount, updateAccount, getWallet } from '../core/account'
 
 type Props = {

--- a/app/actions/authActions.js
+++ b/app/actions/authActions.js
@@ -20,7 +20,7 @@ type LedgerLoginProps = {
 type Nep2LoginProps = {
   passphrase: string,
   encryptedWIF: string,
-  label: string,
+  label?: string,
   callback?: Function
 }
 
@@ -62,7 +62,7 @@ export const nep2LoginActions = createActions(ID, ({ passphrase, encryptedWIF, l
       accounts = await saveAccount(label, address, encryptedWIF)
       // Execute on next thread
       setTimeout(() => {
-        callback(accounts)
+        callback && callback(accounts)
       }, 100)
     } catch (error) {
       if (error.message !== `Address '${address}' already exists.`) {

--- a/app/actions/authActions.js
+++ b/app/actions/authActions.js
@@ -60,7 +60,7 @@ export const nep2LoginActions = createActions(ID, ({ passphrase, encryptedWIF, l
     try {
       accounts = await saveAccount(label, address, encryptedWIF)
       // Execute on next thread
-      setTimeout(() => {
+      const timeoutInstance = await setTimeout(() => {
         callback && callback(accounts)
       }, 100)
     } catch (error) {

--- a/app/actions/authActions.js
+++ b/app/actions/authActions.js
@@ -3,9 +3,8 @@ import { wallet } from 'neon-js'
 import { noop } from 'lodash'
 import { createActions } from 'spunky'
 
-import { upgradeNEP6AddAddresses } from '../core/account'
+import { upgradeNEP6AddAddresses, saveAccount } from '../core/account'
 import { validatePassphraseLength } from '../core/wallet'
-import { saveAccount } from '../core/account'
 import { ledgerNanoSCreateSignatureAsync } from '../ledger/ledgerNanoS'
 
 type WifLoginProps = {
@@ -56,7 +55,7 @@ export const nep2LoginActions = createActions(ID, ({ passphrase, encryptedWIF, l
   const wif = wallet.decrypt(encryptedWIF, passphrase)
   const account = new wallet.Account(wif)
   const { address } = account
-  let accounts;
+  let accounts
   if (label) {
     try {
       accounts = await saveAccount(label, address, encryptedWIF)

--- a/app/actions/authActions.js
+++ b/app/actions/authActions.js
@@ -5,6 +5,7 @@ import { createActions } from 'spunky'
 
 import { upgradeNEP6AddAddresses } from '../core/account'
 import { validatePassphraseLength } from '../core/wallet'
+import { saveAccount } from '../core/account'
 import { ledgerNanoSCreateSignatureAsync } from '../ledger/ledgerNanoS'
 
 type WifLoginProps = {
@@ -18,7 +19,9 @@ type LedgerLoginProps = {
 
 type Nep2LoginProps = {
   passphrase: string,
-  encryptedWIF: string
+  encryptedWIF: string,
+  label: string,
+  callback?: Function
 }
 
 type AccountType = ?{
@@ -41,7 +44,7 @@ export const wifLoginActions = createActions(ID, ({ wif }: WifLoginProps) => (st
   return { wif: account.WIF, address: account.address, isHardwareLogin: false }
 })
 
-export const nep2LoginActions = createActions(ID, ({ passphrase, encryptedWIF }: Nep2LoginProps) => async (state: Object): Promise<AccountType> => {
+export const nep2LoginActions = createActions(ID, ({ passphrase, encryptedWIF, label, callback }: Nep2LoginProps) => async (state: Object): Promise<AccountType> => {
   if (!validatePassphraseLength(passphrase)) {
     throw new Error('Passphrase too short')
   }
@@ -52,10 +55,25 @@ export const nep2LoginActions = createActions(ID, ({ passphrase, encryptedWIF }:
 
   const wif = wallet.decrypt(encryptedWIF, passphrase)
   const account = new wallet.Account(wif)
+  const { address } = account
+  let accounts;
+  if (label) {
+    try {
+      accounts = await saveAccount(label, address, encryptedWIF)
+      // Execute on next thread
+      setTimeout(() => {
+        callback(accounts)
+      }, 100)
+    } catch (error) {
+      if (error.message !== `Address '${address}' already exists.`) {
+        throw error
+      }
+    }
+  }
 
   await upgradeNEP6AddAddresses(encryptedWIF, wif)
 
-  return { wif: account.WIF, address: account.address, isHardwareLogin: false }
+  return { wif: account.WIF, address, isHardwareLogin: false }
 })
 
 export const ledgerLoginActions = createActions(ID, ({ publicKey }: LedgerLoginProps) => (state: Object): AccountType => {

--- a/app/actions/authActions.js
+++ b/app/actions/authActions.js
@@ -60,7 +60,7 @@ export const nep2LoginActions = createActions(ID, ({ passphrase, encryptedWIF, l
     try {
       accounts = await saveAccount(label, address, encryptedWIF)
       // Execute on next thread
-      const timeoutInstance = await setTimeout(() => {
+      await setTimeout(() => {
         callback && callback(accounts)
       }, 100)
     } catch (error) {

--- a/app/containers/LoginNep2/LoginNep2.jsx
+++ b/app/containers/LoginNep2/LoginNep2.jsx
@@ -4,6 +4,7 @@ import React, { Component } from 'react'
 import Button from '../../components/Button'
 import HomeButtonLink from '../../components/HomeButtonLink'
 import PasswordField from '../../components/PasswordField'
+import { showSuccessNotification } from '../../modules/notifications'
 
 import loginStyles from '../../styles/login.scss'
 
@@ -28,7 +29,7 @@ export default class LoginNep2 extends Component<Props, State> {
   }
 
   render () {
-    const { loginNep2, updateAccounts } = this.props
+    const { loginNep2, updateAccounts, dispatch } = this.props
     const { encryptedWIF, passphrase, label, save } = this.state
     const loginButtonDisabled = encryptedWIF === '' || passphrase === '' || (save && !label)
 
@@ -37,7 +38,10 @@ export default class LoginNep2 extends Component<Props, State> {
         <div className={loginStyles.title}>Login using an encrypted key:</div>
         <form onSubmit={async (e) => {
           e.preventDefault()
-          loginNep2(passphrase, encryptedWIF, save && label, updateAccounts)
+          loginNep2(passphrase, encryptedWIF, save && label, accounts => {
+            dispatch(showSuccessNotification({ message: 'Account saved!' }))
+            updateAccounts(accounts)
+          })
         }}>
           <div className={loginStyles.loginForm}>
             <PasswordField

--- a/app/containers/LoginNep2/LoginNep2.jsx
+++ b/app/containers/LoginNep2/LoginNep2.jsx
@@ -8,30 +8,36 @@ import PasswordField from '../../components/PasswordField'
 import loginStyles from '../../styles/login.scss'
 
 type Props = {
-  loginNep2: Function,
-  history: Object
+  loginNep2: Function
 }
 
 type State = {
   encryptedWIF: string,
-  passphrase: string
+  passphrase: string,
+  label: string,
+  save: false
 }
 
 export default class LoginNep2 extends Component<Props, State> {
   state = {
     encryptedWIF: '',
-    passphrase: ''
+    passphrase: '',
+    label: '',
+    save: false
   }
 
   render () {
-    const { loginNep2, history } = this.props
-    const { encryptedWIF, passphrase } = this.state
-    const loginButtonDisabled = encryptedWIF === '' || passphrase === ''
+    const { loginNep2, updateAccounts } = this.props
+    const { encryptedWIF, passphrase, label, save } = this.state
+    const loginButtonDisabled = encryptedWIF === '' || passphrase === '' || (save && !label)
 
     return (
       <div id='loginPage' className={loginStyles.loginPage}>
         <div className={loginStyles.title}>Login using an encrypted key:</div>
-        <form onSubmit={(e) => { e.preventDefault(); loginNep2(passphrase, encryptedWIF, history) }}>
+        <form onSubmit={async (e) => {
+          e.preventDefault();
+          loginNep2(passphrase, encryptedWIF, save && label, updateAccounts)
+        }}>
           <div className={loginStyles.loginForm}>
             <PasswordField
               placeholder='Enter your passphrase here'
@@ -44,6 +50,14 @@ export default class LoginNep2 extends Component<Props, State> {
               onChange={(e) => this.setState({ encryptedWIF: e.target.value })}
               value={encryptedWIF}
             />
+            <input type="checkbox" onClick={event => this.setState({save: event.target.checked})} /> Save Account
+            {save && <input
+              type='text'
+              placeholder='Name this account'
+              className={loginStyles.accountLabel}
+              onChange={(e) => this.setState({ label: e.target.value })}
+              value={label}
+            />}
           </div>
           <div>
             <Button
@@ -57,3 +71,4 @@ export default class LoginNep2 extends Component<Props, State> {
     )
   }
 }
+// 6PYQvNv1trceF7yAVNNHFcmsst4Qfp8qGaLsTRiBhHDMcKiuaRtbWVdNVR

--- a/app/containers/LoginNep2/LoginNep2.jsx
+++ b/app/containers/LoginNep2/LoginNep2.jsx
@@ -8,7 +8,8 @@ import PasswordField from '../../components/PasswordField'
 import loginStyles from '../../styles/login.scss'
 
 type Props = {
-  loginNep2: Function
+  loginNep2: Function,
+  updateAccounts: Function
 }
 
 type State = {

--- a/app/containers/LoginNep2/LoginNep2.jsx
+++ b/app/containers/LoginNep2/LoginNep2.jsx
@@ -10,7 +10,8 @@ import loginStyles from '../../styles/login.scss'
 
 type Props = {
   loginNep2: Function,
-  updateAccounts: Function
+  updateAccounts: Function,
+  dispatch: Function
 }
 
 type State = {

--- a/app/containers/LoginNep2/LoginNep2.jsx
+++ b/app/containers/LoginNep2/LoginNep2.jsx
@@ -71,4 +71,3 @@ export default class LoginNep2 extends Component<Props, State> {
     )
   }
 }
-// 6PYQvNv1trceF7yAVNNHFcmsst4Qfp8qGaLsTRiBhHDMcKiuaRtbWVdNVR

--- a/app/containers/LoginNep2/LoginNep2.jsx
+++ b/app/containers/LoginNep2/LoginNep2.jsx
@@ -36,7 +36,7 @@ export default class LoginNep2 extends Component<Props, State> {
       <div id='loginPage' className={loginStyles.loginPage}>
         <div className={loginStyles.title}>Login using an encrypted key:</div>
         <form onSubmit={async (e) => {
-          e.preventDefault();
+          e.preventDefault()
           loginNep2(passphrase, encryptedWIF, save && label, updateAccounts)
         }}>
           <div className={loginStyles.loginForm}>
@@ -51,7 +51,7 @@ export default class LoginNep2 extends Component<Props, State> {
               onChange={(e) => this.setState({ encryptedWIF: e.target.value })}
               value={encryptedWIF}
             />
-            <input type="checkbox" onClick={event => this.setState({save: event.target.checked})} /> Save Account
+            <input type='checkbox' onClick={event => this.setState({save: event.target.checked})} /> Save Account
             {save && <input
               type='text'
               placeholder='Name this account'

--- a/app/containers/LoginNep2/index.js
+++ b/app/containers/LoginNep2/index.js
@@ -5,12 +5,18 @@ import { withActions } from 'spunky'
 import LoginNep2 from './LoginNep2'
 import withFailureNotification from '../../hocs/withFailureNotification'
 import { nep2LoginActions } from '../../actions/authActions'
+import { updateAccountsActions } from '../../actions/accountsActions'
 
-const mapActionsToProps = (actions) => ({
-  loginNep2: (passphrase, encryptedWIF) => actions.call({ passphrase, encryptedWIF })
+const mapLoginActionsToProps = (actions) => ({
+  loginNep2: (passphrase, encryptedWIF, label, callback) => actions.call({ passphrase, encryptedWIF, label, callback })
+})
+
+const mapAccountsActionsToProps = (actions) => ({
+  updateAccounts: (accounts) => actions.call(accounts)
 })
 
 export default compose(
-  withActions(nep2LoginActions, mapActionsToProps),
+  withActions(nep2LoginActions, mapLoginActionsToProps),
+  withActions(updateAccountsActions, mapAccountsActionsToProps),
   withFailureNotification(nep2LoginActions)
 )(LoginNep2)

--- a/app/core/account.js
+++ b/app/core/account.js
@@ -1,7 +1,9 @@
 // @flow
 import { wallet } from 'neon-js'
+import { isEmpty } from 'lodash'
 
 import { getStorage, setStorage } from './storage'
+import { Account } from './schemas'
 
 function getNEP6AddressData (matchesEncryptedWIF: boolean, address: string) {
   if (matchesEncryptedWIF) {
@@ -23,4 +25,59 @@ export async function upgradeNEP6AddAddresses (encryptedWIF: string, wif: string
 
     await setStorage('userWallet', { ...data, accounts })
   }
+}
+
+const STORAGE_KEY = 'userWallet'
+
+export const getWallet = async (): Promise<Object> => {
+  return await getStorage(STORAGE_KEY) || DEFAULT_WALLET
+}
+
+const setWallet = async (wallet: Object) => {
+  setStorage(STORAGE_KEY, wallet)
+}
+
+const walletHasKey = (wallet: Object, key: string) => {
+  return wallet.accounts.some(account => account.key === key)
+}
+
+const walletHasLabel = (wallet: Object, label: string) => {
+  return wallet.accounts.some(account => account.label === label)
+}
+
+export async function updateAccount (accounts: Array<Object>) {
+  const wallet = await getWallet()
+  const newWallet = { ...wallet, accounts }
+  await setWallet(newWallet)
+
+  return accounts
+}
+
+export async function saveAccount (label, address, key) {
+  if (isEmpty(label)) {
+    throw new Error('A valid name is required.')
+  }
+
+  if (isEmpty(address)) {
+    throw new Error('A valid address is required.')
+  }
+
+  if (isEmpty(key)) {
+    throw new Error('A valid key is required.')
+  }
+
+  const wallet = await getWallet()
+
+  if (walletHasKey(wallet, key)) {
+    throw new Error(`Address '${address}' already exists.`)
+  }
+
+  if (walletHasLabel(wallet, label)) {
+    throw new Error(`Account '${label}' already exists.`)
+  }
+
+  wallet.accounts.push(new Account({ address, label, key }))
+  await setWallet(wallet)
+
+  return wallet.accounts
 }

--- a/app/core/account.js
+++ b/app/core/account.js
@@ -2,6 +2,7 @@
 import { wallet } from 'neon-js'
 import { isEmpty } from 'lodash'
 
+import { DEFAULT_WALLET } from './constants'
 import { getStorage, setStorage } from './storage'
 import { Account } from './schemas'
 
@@ -53,7 +54,7 @@ export async function updateAccount (accounts: Array<Object>) {
   return accounts
 }
 
-export async function saveAccount (label, address, key) {
+export async function saveAccount (label: string, address: string, key: string) {
   if (isEmpty(label)) {
     throw new Error('A valid name is required.')
   }

--- a/app/styles/login.scss
+++ b/app/styles/login.scss
@@ -24,5 +24,10 @@
         select {
             margin-bottom: 10px;
         }
+
+        .accountLabel {
+            width: 300px;
+            margin-left: 20px;
+        }
     }
 }


### PR DESCRIPTION
**What problem does this PR solve?**
Users who have have a encrypted key that was not created in neon-wallet or imported via JSON, need to have an easy option to allow them to save their account when logging in.

**How did you solve this problem?**
Added an options to set a account name, and save the account upon logging in.

**How did you make sure your solution works?**
- Naivigate to "Login using an encrypted key"
- Enter passphrase and encrypted key
- Check the option for save account
- Enter a account label
- Login
- If successful, you will be taken to the normal account dashbaord

Corner cases
- If the user already saved this encrypted key, it will simply ignore the new label, and log in the user
- If the user enters a label that is conflicting with one that is already saved, it will show them an error notification
