### PR TITLE
Fixed duration button on price history graph (fixes #1100)

### DIFF
--- a/app/components/Dashboard/PriceHistoryPanel/index.js
+++ b/app/components/Dashboard/PriceHistoryPanel/index.js
@@ -17,7 +17,7 @@ const mapPricesDataToProps = (prices, props) => ({
 const mapPriceHistoryActionsToProps = (actions, props) => ({
   setDuration: (duration: Duration) => {
     props.setDuration(duration)
-    actions.call({ duration, currency: props.currency })
+    return actions.call({ duration, currency: props.currency })
   }
 })
 


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Issue #1100 

**What problem does this PR solve?**
Currently, clicking on the "duration" tab in the wallet dashboard throws a js error

**How did you solve this problem?**
In all places other than the priceHistory panel, Spunky's ```withActions``` is passed a JSON object of one-line lambda functions. In these instances, the result of the ```actions.call``` line was implicitly passed back to the ```withActions``` function. However, since ```getDurations``` was multiple lines, the final line of the function needed to be explicitly returned in order for ```withActions``` to properly map new functions onto the props object.

**How did you make sure your solution works?**
I clicked the duration button and the asset button a few times on the chart
