### PR TITLE
Fixed balances endpoint address (fixes #1079)

### DIFF
--- a/app/components/Dashboard/AssetBalancesPanel/index.js
+++ b/app/components/Dashboard/AssetBalancesPanel/index.js
@@ -14,6 +14,9 @@ import withLoadingProp from '../../../hocs/withLoadingProp'
 import withProgressPanel from '../../../hocs/withProgressPanel'
 import withSuccessNotification from '../../../hocs/withSuccessNotification'
 import withFailureNotification from '../../../hocs/withFailureNotification'
+import withNetworkData from '../../../hocs/withNetworkData'
+import withAuthData from '../../../hocs/withAuthData'
+import withFilteredTokensData from '../../../hocs/withFilteredTokensData'
 
 const mapBalanceDataToProps = (balances) => ({
   NEO: balances.NEO,
@@ -42,6 +45,9 @@ export default compose(
 
   // Fetch price & balance data based based upon the selected currency.
   // Reload data with the currency changes.
+  withNetworkData(),
+  withAuthData(),
+  withFilteredTokensData(),
   withProgressPanel(batchActions, { title: 'Balances' }),
   withPricesData(mapPricesDataToProps),
   withBalancesData(mapBalanceDataToProps),


### PR DESCRIPTION
Network, auth, and token data were not being imported into assetBalances. Because of this, the GET requests for refreshing asset balances were being treated as absolute paths on the filesystem (such as localhost/undefined/.../undefined/). This was because information necessary for the network path was not being injected into props. By correctly injecting ```net```, ```address```, and ```tokens``` into the component's properties, proper requests to retrieve asset balances can be formed.

**What current issue(s) from Trello/Github does this address?**
Issue #1079 (and possibly #1080)

**What problem does this PR solve?**
The asset balances component crashed the wallet when you clicked refresh. Before refresh was clicked, data was not being populated into the correct component.

**How did you solve this problem?**
Importing ```withNetworkData()```, ```withAuthData()```, and ```withFilteredTokensData()``` into assetBalances.

**How did you make sure your solution works?**
I checked the network logs to verify that the correct address was being accessed.
