### PR TITLE
Fixed spacing on portfolio pie chart to match design notes (fixes #1006)

### DIFF
--- a/app/components/Dashboard/PortfolioPanel/PortfolioBreakdownChart.jsx
+++ b/app/components/Dashboard/PortfolioPanel/PortfolioBreakdownChart.jsx
@@ -29,8 +29,8 @@ export default class PortfolioBreakdownChart extends React.Component<Props> {
     const data = this.getData()
 
     return (
-      <ResponsiveContainer width={220} className={classNames(styles.priceHistoryChart, className)}>
-        <PieChart width={220} height={180}>
+      <ResponsiveContainer width={200} className={classNames(styles.priceHistoryChart, className)}>
+        <PieChart width={200} height={180}>
           <Pie data={data} dataKey="value" nameKey="symbol" innerRadius={40} outerRadius={75}>
             {times(data.length, (index) => (
               <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} stroke={COLORS[index]} />

--- a/app/components/Dashboard/PortfolioPanel/PortfolioPanel.scss
+++ b/app/components/Dashboard/PortfolioPanel/PortfolioPanel.scss
@@ -7,9 +7,11 @@
     flex-direction: row;
     align-items: stretch;
     height: 100%;
+    padding-left: 0;
 
     .chart {
       flex: 0 0 auto;
+      margin-top: -25px;
     }
 
     .table {


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Issue #1006 

**What problem does this PR solve?**
The portfolio pie chart had padding of its own. When combined with the padding of its parent container, there was too much whitespace between the edge of the portfolio panel and the chart.

**How did you solve this problem?**
Cutting down on the whitespace between the edge of the portfolio panel and pie chart to match the design documents as well as other elements on the page.

**How did you make sure your solution works?**
See for yourself!

Before:
![Before](https://user-images.githubusercontent.com/2229212/40997988-6f535822-68d4-11e8-9776-bdc1d6ee29e8.png)

After:
![After](https://user-images.githubusercontent.com/2229212/40998002-78a09e6c-68d4-11e8-90a5-bdd4285193a6.png)


**Are there any special changes in the code that we should be aware of?**
This is probably nothing, but I used a negative margin value (margin-top: -25px), which is kind of hokey, but unfortunately, it was the only elegant solution since the chart's padding is baked into the SVG and I didn't want to touch that. I figured it would be okay since there are other instances of people using negative margin values elsewhere in the codebase.
