### PR TITLE
Changed font to Montserrat (fixes #1007)

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -6,5 +6,6 @@ import store from './store/configureStore'
 import Root from './components/Root'
 import './styles/tippy.compiled.global.css'
 import './styles/main.global.scss'
+import 'typeface-montserrat'
 
 render(<Root store={store} />, document.getElementById('root'))

--- a/app/styles/main.global.scss
+++ b/app/styles/main.global.scss
@@ -9,14 +9,15 @@
 
 html,
 body,
-#root {
+#root,
+input {
   box-sizing: border-box;
   width: 100%;
   height: 100%;
+  font: normal 10px Montserrat, 'Montserrat', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
 }
 
 body {
-  font-family: 'helvetica neue', 'helvetica', sans-serif;
   font-size: 16px;
   padding: 0px;
   margin: 0px;
@@ -32,7 +33,7 @@ input {
   font-size: 1.2em;
   padding: 7px 15px;
   border: none;
-  font-weight: 200;
+  font-weight: 300;
   background-color: $dark-input-color;
   color: $default-text;
   :focus {

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "sifter": "0.5.3",
     "spunky": "^1.3.1",
     "svg-react-loader": "^0.4.5",
+    "typeface-montserrat": "^0.0.54",
     "uuid": "^3.2.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9895,6 +9895,10 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+typeface-montserrat@^0.0.54:
+  version "0.0.54"
+  resolved "https://registry.yarnpkg.com/typeface-montserrat/-/typeface-montserrat-0.0.54.tgz#3fc338db6428d73485b75aa7bd2af8c9a55b9ab3"
+
 ua-parser-js@^0.7.9:
   version "0.7.17"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Issue #1007 

**What problem does this PR solve?**
The font being used before didn't match the design notes 

**How did you solve this problem?**
I imported ```typeface-montserrat``` and set it as the default font-family

**How did you make sure your solution works?**
I verified that all elements used the new font

**Are there any special changes in the code that we should be aware of?**
I added Montserrat to the list of package dependencies
