### PR TITLE
CSS Fixes for portfolio chart spacing and default font size (fixes #1006 again)

### DIFF
--- a/app/components/Dashboard/PortfolioPanel/PortfolioPanel.scss
+++ b/app/components/Dashboard/PortfolioPanel/PortfolioPanel.scss
@@ -11,7 +11,6 @@
 
     .chart {
       flex: 0 0 auto;
-      margin-top: -25px;
     }
 
     .table {

--- a/app/styles/main.global.scss
+++ b/app/styles/main.global.scss
@@ -14,7 +14,7 @@ input {
   box-sizing: border-box;
   width: 100%;
   height: 100%;
-  font: normal 10px Montserrat, 'Montserrat', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+  font-family: 'Montserrat', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
 }
 
 body {


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Issue #1006 

**What problem does this PR solve?**
Some text was rendering as 10px  because I messed up the default font size in my font rule. Also, the portfolio chart wasn't being vertically centered correctly, so I fixed that as well.

**How did you solve this problem?**
Misc. CSS fixes. See code

**How did you make sure your solution works?**
I visually verified various tabs looked correct
