### PR TITLE
Fixed 'Create Wallet' spacking (fixes #1146)

### DIFF
--- a/app/containers/DisplayWalletAccounts/DisplayWalletAccounts.scss
+++ b/app/containers/DisplayWalletAccounts/DisplayWalletAccounts.scss
@@ -25,7 +25,7 @@
 }
 
 .label {
-  width: 120px;
+  width: 140px;
   font-weight: 800;
   font-size: 14px;
 }


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Issue #1146 

**What problem does this PR solve?**
There wasn't enough spacing to the right of created wallet information labels

**How did you solve this problem?**
I increased the label container's width by 20px

**How did you make sure your solution works?**
I verified visually
