### PR TITLE
Show 2 extra letters of currency name (fixes #1005)

### DIFF
--- a/app/components/Dashboard/PortfolioPanel/PortfolioRow.scss
+++ b/app/components/Dashboard/PortfolioPanel/PortfolioRow.scss
@@ -23,6 +23,10 @@
     border-radius: 50%;
   }
 
+  .symbol {
+    flex-grow: 1.67;
+  }
+
   .balance,
   .value {
     flex-grow: 2;


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
#1005 

**What problem does this PR solve?**
Currencies with names greater than four letters were truncated in the portfolio section

**How did you solve this problem?**
I made the currency column's flex-grow attribute 1.67x longer. 1.67*3 = 5, so if the original window fits 3 letters, this new one should fit 5.

**How did you make sure your solution works?**
I verified this issue on windows (since it doesn't seem to occur on my Linux machine)