### PR TITLE
Fixed panel flickering on retry button (fixes #1080)

### DIFF
--- a/app/hocs/withProgressPanel.js
+++ b/app/hocs/withProgressPanel.js
@@ -11,7 +11,6 @@ const mapActionsToProps = (action, props) => ({
 })
 
 export default function withProgressPanel (actions, { title, strategy = recentlyCompletedStrategy, ...options } = {}) {
-  console.log(actions, options, title)
   const Loading = withProps({ title })(LoadingPanel)
   const Failed = withProps((props) => ({ title, onRetry: props.onRetry }))(FailedPanel)
 

--- a/app/hocs/withProgressPanel.js
+++ b/app/hocs/withProgressPanel.js
@@ -1,5 +1,5 @@
 import { compose, withProps } from 'recompose'
-import { withActions, withProgressComponents, alreadyLoadedStrategy, progressValues } from 'spunky'
+import { withActions, withProgressComponents, recentlyCompletedStrategy, progressValues } from 'spunky'
 
 import LoadingPanel from '../components/LoadingPanel'
 import FailedPanel from '../components/FailedPanel'
@@ -10,7 +10,8 @@ const mapActionsToProps = (action, props) => ({
   onRetry: () => action.call(props)
 })
 
-export default function withProgressPanel (actions, { title, strategy = alreadyLoadedStrategy, ...options } = {}) {
+export default function withProgressPanel (actions, { title, strategy = recentlyCompletedStrategy, ...options } = {}) {
+  console.log(actions, options, title)
   const Loading = withProps({ title })(LoadingPanel)
   const Failed = withProps((props) => ({ title, onRetry: props.onRetry }))(FailedPanel)
 


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Issue #1080 

**What problem does this PR solve?**
Currently, when you click the "retry" button, spunky automatically loads up the previous state of the panel and shows it until axios fails to grab necessary information. This causes the previous working state of a panel to sometimes pop up for a fraction of a second when you click the "retry" button.

**How did you solve this problem?**
By switching to the "recentlyCompleted" in the load cycle, spunky now assumes the following: If a panel is currently in the "FAILED" state, it will most likely fail again. This prevents the previous state from flashing onto the screen while still keeping the normal refresh button behavior the same. 

**How did you make sure your solution works?**
I tried the following cases:
- Wallet starts with an internet connection, refresh button is pressed
- Wallet starts with an internet connection, the internet is disconnected, refresh button is pressed.
- Wallet starts without an internet connection, retry button is pressed
- Wallet starts without an internet connection, the internet is connected, retry button is pressed
- Combinations of the 2nd and 4th bullet points without closing the wallet.

**Is there anything else we should know?**
I discovered another bug while testing this one. This bug can cause the wallet to crash when connecting or disconnecting the internet while the wallet is open. The other bug will be fixed in my next PR. For the best results, merge my next pull request before testing this one (or at least cherry-pick the commits into your local workspace). 