### PR TITLE
Fix explorer links

### DIFF
--- a/__tests__/core/explorer.test.js
+++ b/__tests__/core/explorer.test.js
@@ -1,8 +1,24 @@
-import { getExplorerTxLink, openExplorerTx } from '../../app/core/explorer'
+import {
+  buildExplorerLink,
+  getExplorerTxLink,
+  openExplorerTx
+} from '../../app/core/explorer'
+import explorerConfig from '../../app/core/explorerConfig'
 import { MAIN_NETWORK_ID, TEST_NETWORK_ID, EXPLORERS } from '../../app/core/constants'
 import { shell } from 'electron'
 
 describe('explorer tests', () => {
+  describe('Build Explorer Link', () => {
+    test('Build valid link', () => {
+      const networkId = MAIN_NETWORK_ID
+      const explorer = EXPLORERS.NEO_TRACKER
+      const structure = 'addressLinkStructure'
+      const suffix = '1234567890abcdef'
+      const expectedUrl = 'https://neotracker.io/address/1234567890abcdef'
+      expect(buildExplorerLink(networkId, explorer, structure, suffix)).toEqual(expectedUrl)
+    })
+  })
+
   describe('getExplorerTxLink tests', () => {
     test('NeoTracker mainnet explorer test', () => {
       const networkId = MAIN_NETWORK_ID
@@ -40,7 +56,7 @@ describe('explorer tests', () => {
       const networkId = MAIN_NETWORK_ID
       const explorer = EXPLORERS.ANT_CHAIN
       const txId = '1234567890abcdef'
-      const expectedUrl = 'http://antcha.in/tx/hash/1234567890abcdef'
+      const expectedUrl = 'http://antcha.in/tx/hash/0x1234567890abcdef'
       expect(getExplorerTxLink(networkId, explorer, txId)).toEqual(expectedUrl)
     })
 
@@ -48,7 +64,7 @@ describe('explorer tests', () => {
       const networkId = TEST_NETWORK_ID
       const explorer = EXPLORERS.ANT_CHAIN
       const txId = '1234567890abcdef'
-      const expectedUrl = 'http://testnet.antcha.in/tx/hash/1234567890abcdef'
+      const expectedUrl = 'http://testnet.antcha.in/tx/hash/0x1234567890abcdef'
       expect(getExplorerTxLink(networkId, explorer, txId)).toEqual(expectedUrl)
     })
   })

--- a/__tests__/core/explorer.test.js
+++ b/__tests__/core/explorer.test.js
@@ -20,6 +20,17 @@ describe('explorer tests', () => {
   })
 
   describe('getExplorerTxLink tests', () => {
+    test('Invalid explorer', () => {
+      const networkId = MAIN_NETWORK_ID
+      const structure = 'addressLinkStructure'
+      const suffix = '1234567890abcdef'
+      const expectedUrl = 'https://neotracker.io/address/1234567890abcdef'
+
+      expect(() => {
+        buildExplorerLink(networkId, 'broken explorer', structure, suffix)
+      }).toThrow();
+    })
+
     test('NeoTracker mainnet explorer test', () => {
       const networkId = MAIN_NETWORK_ID
       const explorer = EXPLORERS.NEO_TRACKER

--- a/app/core/explorer.js
+++ b/app/core/explorer.js
@@ -1,77 +1,41 @@
 // @flow
 import { openExternal } from './electron'
-import { EXPLORERS } from '../core/constants'
-import { isMainNetwork } from '../core/networks'
+import explorerConfig from './explorerConfig'
+import { isMainNetwork } from './networks'
+
+export const buildExplorerLink = (
+  networkId: string,
+  explorer: ExplorerType,
+  structure: string,
+  suffix: string
+) => {
+  if (Object.prototype.hasOwnProperty.call(explorerConfig, explorer)) {
+    const explorerInfo = explorerConfig[explorer]
+
+    return getExplorerBaseURL(networkId, explorer) + explorerInfo[structure] + suffix
+  }
+
+  return ''
+}
 
 export const getExplorerBaseURL = (networkId: string, explorer: ExplorerType) => {
-  let baseURL
-  if (explorer === EXPLORERS.NEO_TRACKER) {
-    if (isMainNetwork(networkId)) {
-      baseURL = 'https://neotracker.io'
-    } else {
-      baseURL = 'https://testnet.neotracker.io'
-    }
-  } else if (explorer === EXPLORERS.NEO_SCAN) {
-    if (isMainNetwork(networkId)) {
-      baseURL = 'https://neoscan.io'
-    } else {
-      baseURL = 'https://neoscan-testnet.io'
-    }
-  } else {
-    if (isMainNetwork(networkId)) {
-      baseURL = 'http://antcha.in'
-    } else {
-      baseURL = 'http://testnet.antcha.in'
-    }
-  }
-  return baseURL
-}
+  if (Object.prototype.hasOwnProperty.call(explorerConfig, explorer)) {
+    const selectedExplorer = explorerConfig[explorer]
 
-export const getExplorerTxLink = (networkId: string, explorer: ExplorerType, txId: string) => {
-  const baseURL = getExplorerBaseURL(networkId, explorer)
-
-  if (explorer === EXPLORERS.NEO_TRACKER) {
-    return `${baseURL}/tx/${txId}`
-  } else if (explorer === EXPLORERS.NEO_SCAN) {
-    return `${baseURL}/transaction/${txId}`
-  } else {
-    return `${baseURL}/tx/hash/${txId}`
+    return isMainNetwork(networkId)
+      ? selectedExplorer.mainNetwork
+      : selectedExplorer.testNetwork
   }
 }
 
-export const getExplorerAddressLink = (networkId: string, explorer: ExplorerType, address: string) => {
-  const baseURL = getExplorerBaseURL(networkId, explorer)
+export const getExplorerTxLink = (networkId: string, explorer: ExplorerType, txId: string) => buildExplorerLink(networkId, explorer, 'trxLinkStructure', txId)
 
-  if (explorer === EXPLORERS.NEO_TRACKER) {
-    return `${baseURL}/address/${address}`
-  } else if (explorer === EXPLORERS.NEO_SCAN) {
-    return `${baseURL}/address/${address}/1`
-  } else if (explorer === EXPLORERS.NEO_VERSE) {
-    return `${baseURL}/addresses/${address}`
-  } else {
-    return `${baseURL}/address/info/${address}`
-  }
-}
+export const getExplorerAddressLink = (networkId: string, explorer: ExplorerType, address: string) => buildExplorerLink(networkId, explorer, 'addressStructure', address)
 
-export const getExplorerAssetLink = (networkId: string, explorer: ExplorerType, assetId: string) => {
-  const baseURL = getExplorerBaseURL(networkId, explorer)
+export const getExplorerAssetLink = (networkId: string, explorer: ExplorerType, assetId: string) => buildExplorerLink(networkId, explorer, 'assetLinkStructure', assetId)
 
-  if (explorer === EXPLORERS.NEO_TRACKER) {
-    return `${baseURL}/asset/${assetId}`
-  } else if (explorer === EXPLORERS.NEO_SCAN) {
-    return `${baseURL}/asset/${assetId}`
-  } else if (explorer === EXPLORERS.NEO_VERSE) {
-    return `${baseURL}/assets/${assetId}`
-  } else {
-    return `${baseURL}/asset/hash/${assetId}`
-  }
-}
+export const openExplorerTx = (networkId: string, explorer: ExplorerType, txId: string) => openExternal(getExplorerTxLink(networkId, explorer, txId))
 
-export const openExplorerTx = (networkId: string, explorer: ExplorerType, txId: string) =>
-  openExternal(getExplorerTxLink(networkId, explorer, txId))
+export const openExplorerAddress = (networkId: string, explorer: ExplorerType, address: string) => openExternal(getExplorerAddressLink(networkId, explorer, address))
 
-export const openExplorerAddress = (networkId: string, explorer: ExplorerType, address: string) =>
-  openExternal(getExplorerAddressLink(networkId, explorer, address))
-
-export const openExplorerAsset = (networkId: string, explorer: ExplorerType, assetId: string) =>
-  openExternal(getExplorerAssetLink(networkId, explorer, assetId))
+export const openExplorerAsset = (networkId: string, explorer: ExplorerType, assetId: string) => openExternal(getExplorerAssetLink(networkId, explorer, assetId))

--- a/app/core/explorer.js
+++ b/app/core/explorer.js
@@ -15,7 +15,7 @@ export const buildExplorerLink = (
     return getExplorerBaseURL(networkId, explorer) + explorerInfo[structure] + suffix
   }
 
-  return ''
+  throw new Error(`${explorer} is not a valid explorer type. Valid explorer types are: ${Object.keys(explorerConfig).join(', ')}`)
 }
 
 export const getExplorerBaseURL = (networkId: string, explorer: ExplorerType) => {

--- a/app/core/explorer.js
+++ b/app/core/explorer.js
@@ -9,7 +9,7 @@ export const buildExplorerLink = (
   structure: string,
   suffix: string
 ) => {
-  if (Object.prototype.hasOwnProperty.call(explorerConfig, explorer)) {
+  if (explorerConfig.hasOwnProperty(explorer)) {
     const explorerInfo = explorerConfig[explorer]
 
     return getExplorerBaseURL(networkId, explorer) + explorerInfo[structure] + suffix
@@ -19,7 +19,7 @@ export const buildExplorerLink = (
 }
 
 export const getExplorerBaseURL = (networkId: string, explorer: ExplorerType) => {
-  if (Object.prototype.hasOwnProperty.call(explorerConfig, explorer)) {
+  if (explorerConfig.hasOwnProperty(explorer)) {
     const selectedExplorer = explorerConfig[explorer]
 
     return isMainNetwork(networkId)

--- a/app/core/explorerConfig.js
+++ b/app/core/explorerConfig.js
@@ -1,25 +1,27 @@
 import { EXPLORERS } from './constants'
+const { ANT_CHAIN, NEO_SCAN, NEO_TRACKER } = EXPLORERS
 
 export default {
-  [EXPLORERS.NEO_TRACKER]: {
-    addressLinkStructure: 'address/',
-    assetLinkStructure: 'asset/',
-    mainNetwork: 'https://neotracker.io/',
-    testNetwork: 'https://testnet.neotracker.io/',
-    trxLinkStructure: 'tx/'
+  [ANT_CHAIN]: {
+    addressLinkStructure: 'address/info/',
+    assetLinkStructure: 'asset/hash/',
+    mainNetwork: 'http://antcha.in/',
+    testNetwork: 'http://testnet.antcha.in/',
+    trxLinkStructure: 'tx/hash/0x'
   },
-  [EXPLORERS.NEO_SCAN]: {
+  [NEO_SCAN]: {
     addressLinkStructure: 'address/',
     assetLinkStructure: 'asset/',
     mainNetwork: 'https://neoscan.io/',
     testNetwork: 'https://neoscan-testnet.io/',
     trxLinkStructure: 'transaction/'
   },
-  [EXPLORERS.ANT_CHAIN]: {
-    addressLinkStructure: 'address/info/',
-    assetLinkStructure: 'asset/hash/',
-    mainNetwork: 'http://antcha.in/',
-    testNetwork: 'http://testnet.antcha.in/',
-    trxLinkStructure: 'tx/hash/0x'
+  [NEO_TRACKER]: {
+    addressLinkStructure: 'address/',
+    assetLinkStructure: 'asset/',
+    mainNetwork: 'https://neotracker.io/',
+    testNetwork: 'https://testnet.neotracker.io/',
+    trxLinkStructure: 'tx/'
   }
+
 }

--- a/app/core/explorerConfig.js
+++ b/app/core/explorerConfig.js
@@ -1,0 +1,25 @@
+import { EXPLORERS } from './constants'
+
+export default {
+  [EXPLORERS.NEO_TRACKER]: {
+    addressLinkStructure: 'address/',
+    assetLinkStructure: 'asset/',
+    mainNetwork: 'https://neotracker.io/',
+    testNetwork: 'https://testnet.neotracker.io/',
+    trxLinkStructure: 'tx/'
+  },
+  [EXPLORERS.NEO_SCAN]: {
+    addressLinkStructure: 'address/',
+    assetLinkStructure: 'asset/',
+    mainNetwork: 'https://neoscan.io/',
+    testNetwork: 'https://neoscan-testnet.io/',
+    trxLinkStructure: 'transaction/'
+  },
+  [EXPLORERS.ANT_CHAIN]: {
+    addressLinkStructure: 'address/info/',
+    assetLinkStructure: 'asset/hash/',
+    mainNetwork: 'http://antcha.in/',
+    testNetwork: 'http://testnet.antcha.in/',
+    trxLinkStructure: 'tx/hash/0x'
+  }
+}


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
The URL format for antchain explorer has changed, which means links to transactions are broken in the wallet.

**How did you solve this problem?**
Adjusted the URL format, and reworked the code for handling URLs to be more generic. I will get explorer.js to 100% coverage in another PR.

**How did you make sure your solution works?**
Tested that updated links worked now.

**Are there any special changes in the code that we should be aware of?**
There was a general refactor of how the explorer links are generated and how the data is stored.

**Is there anything else we should know?**
N/A

- [x] Unit tests written?
