### PR TITLE
fixes broken build by removing flow annotaion in paths.js

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -1,8 +1,6 @@
-// @flow
 const path = require('path')
 
-const resolveApp = (subPath: string) =>
-  path.resolve(__dirname, '../app/', subPath)
+const resolveApp = subPath => path.resolve(__dirname, '../app/', subPath)
 
 module.exports = {
   alias: {


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
````
yarn dev
yarn run v1.3.2
$ cross-env START_HOT=1 NODE_ENV=development node_modules/.bin/webpack-dev-server --config ./config/webpack.config.dev
/Users/foo/projects/neon-wallet/config/paths.js:4
const resolveApp = (subPath: string) =>
                           ^

SyntaxError: Unexpected token :
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:139:10)
    at Module._compile (module.js:599:28)
    at Object.Module._extensions..js (module.js:646:10)
    at Module.load (module.js:554:32)
    at tryModuleLoad (module.js:497:12)
    at Function.Module._load (module.js:489:3)
    at Module.require (module.js:579:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/Users/foo/projects/neon-wallet/config/webpack.config.dev.js:9:15)
    at Module._compile (module.js:635:30)
    at Object.Module._extensions..js (module.js:646:10)
    at Module.load (module.js:554:32)
    at tryModuleLoad (module.js:497:12)
    at Function.Module._load (module.js:489:3)
    at Module.require (module.js:579:17)
error Command failed with exit code 1.
```
**What problem does this PR solve?**

**How did you solve this problem?**

**How did you make sure your solution works?**

**Are there any special changes in the code that we should be aware of?**

**Is there anything else we should know?**

- [ ] Unit tests written?
