### PR TITLE
switch to statetx branch for neon-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "instascan": "1.0.0",
     "isomorphic-fetch": "2.2.1",
     "lodash": "4.17.4",
-    "neon-js": "git+https://github.com/cityofzion/neon-js.git#3.9.0",
+    "neon-js": "git+https://github.com/cityofzion/neon-js.git#statetx",
     "nock": "^9.2.3",
     "qrcode": "0.9.0",
     "raf": "3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6887,9 +6887,9 @@ neo-async@^2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.5.1.tgz#acb909e327b1e87ec9ef15f41b8a269512ad41ee"
 
-"neon-js@git+https://github.com/cityofzion/neon-js.git#3.9.0":
+"neon-js@git+https://github.com/cityofzion/neon-js.git#statetx":
   version "3.9.0"
-  resolved "git+https://github.com/cityofzion/neon-js.git#fe588b7312cad90f20c4febe0e3f24d93b43ab20"
+  resolved "git+https://github.com/cityofzion/neon-js.git#88578de863653f16fad88fc8a730b42f7521244a"
   dependencies:
     axios "^0.18.0"
     bignumber.js "5.0.0"


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
#1286 

**What problem does this PR solve?**
Switch to `statetx` branch so we can use the voting methods.