### PR TITLE
Fixes token balances section calls wrong path [#1232]

### DIFF
--- a/app/components/Dashboard/TokenBalancesPanel/index.js
+++ b/app/components/Dashboard/TokenBalancesPanel/index.js
@@ -33,14 +33,15 @@ const mapBalancesActionsToProps = (actions, props) => ({
 })
 
 export default compose(
-  withProgressPanel(balancesActions, { title: 'Token Balances' }),
-  withBalancesData(mapBalanceDataToProps),
   withCurrencyData('currencyCode'),
-
-  // expose data & functionality needed for `refresh` action
+  
   withNetworkData(),
   withAuthData(),
   withFilteredTokensData(),
+  withProgressPanel(balancesActions, { title: 'Token Balances' }),
+  withBalancesData(mapBalanceDataToProps),
+
+  // expose data & functionality needed for `refresh` action
   withActions(balancesActions, mapBalancesActionsToProps),
   withLoadingProp(balancesActions)
 )(TokenBalancesPanel)


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
#1232 

**What problem does this PR solve?**
Order matters in recompose's `compose` function. In this case, calling `withProgressPanel` after `withNetworkData` was nuking the props needed in `balancesActions`. I did not go down the rabbit hole of figuring out why this worked when an internet connection was present.

**How did you solve this problem?**
I moved `withNetworkData` before `withProgressPanel`. For consistency's sake I moved a few others to more closely align with the export defined in `AssetBalancesPanel/index.js`.

**How did you make sure your solution works?**
Manually tested. See proper host called in screenshot below.

<img width="1201" alt="screen shot 2018-07-07 at 1 57 41 pm" src="https://user-images.githubusercontent.com/1944428/42414249-8c501f2c-81ee-11e8-8494-3a9b28184f2c.png">

**Are there any special changes in the code that we should be aware of?**
No.

**Is there anything else we should know?**
All tests pass.
