### PR TITLE
Update error message based on import or generate wallet

### DIFF
--- a/app/modules/generateWallet.js
+++ b/app/modules/generateWallet.js
@@ -220,7 +220,7 @@ export const generateNewWalletAccount = (
     } catch (e) {
       console.error(e)
       return dispatchError(
-        'An error occured while trying to generate a new wallet'
+        `An error occured while trying to ${wif ? 'import' : 'generate'} a new wallet`
       )
     }
   }, 500)


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
#1276

**What problem does this PR solve?**
Improves the default error message for the "import" and "generate" wallet screens.

**How did you solve this problem?**
Added a ternary that switches based on the argument passed in for importing new wallets.

**How did you make sure your solution works?**
Manually tested.

<img width="712" alt="screen shot 2018-07-08 at 8 32 32 pm" src="https://user-images.githubusercontent.com/1944428/42428113-59df33f0-82ef-11e8-99a6-28d3705e837b.png">
<img width="719" alt="screen shot 2018-07-08 at 8 32 45 pm" src="https://user-images.githubusercontent.com/1944428/42428115-5b4a4f18-82ef-11e8-8b39-842cfe6ae7a7.png">

