### PR TITLE
Add theme handler

### DIFF
--- a/app/actions/settingsActions.js
+++ b/app/actions/settingsActions.js
@@ -32,7 +32,7 @@ const STORAGE_KEY = 'settings'
 const DEFAULT_SETTINGS: Settings = {
   currency: DEFAULT_CURRENCY_CODE,
   blockExplorer: EXPLORERS.NEO_TRACKER,
-  theme: themes[0],
+  theme: themes.Light,
   tokens: getDefaultTokens()
 }
 

--- a/app/actions/settingsActions.js
+++ b/app/actions/settingsActions.js
@@ -17,7 +17,8 @@ import {
 } from '../core/nep5'
 import {
   EXPLORERS,
-  DEFAULT_CURRENCY_CODE
+  DEFAULT_CURRENCY_CODE,
+  DEFAULT_THEME
 } from '../core/constants'
 import themes from '../themes';
 
@@ -32,7 +33,7 @@ const STORAGE_KEY = 'settings'
 const DEFAULT_SETTINGS: Settings = {
   currency: DEFAULT_CURRENCY_CODE,
   blockExplorer: EXPLORERS.NEO_TRACKER,
-  theme: themes.Light,
+  theme: DEFAULT_THEME,
   tokens: getDefaultTokens()
 }
 

--- a/app/actions/settingsActions.js
+++ b/app/actions/settingsActions.js
@@ -1,15 +1,30 @@
 // @flow
-import { pick, keys, uniqBy } from 'lodash'
-import { createActions } from 'spunky'
+import {
+  pick,
+  keys,
+  uniqBy
+} from 'lodash'
+import {
+  createActions
+} from 'spunky'
 
-import { getStorage, setStorage } from '../core/storage'
-import { getDefaultTokens } from '../core/nep5'
-import { EXPLORERS, DEFAULT_CURRENCY_CODE } from '../core/constants'
+import {
+  getStorage,
+  setStorage
+} from '../core/storage'
+import {
+  getDefaultTokens
+} from '../core/nep5'
+import {
+  EXPLORERS,
+  DEFAULT_CURRENCY_CODE
+} from '../core/constants'
+import themes from '../themes';
 
 type Settings = {
-  currency?: string,
-  blockExplorer?: string,
-  tokens?: Array<TokenItemType>
+  currency ? : string,
+  blockExplorer ? : string,
+  tokens ? : Array < TokenItemType >
 }
 
 const STORAGE_KEY = 'settings'
@@ -17,10 +32,11 @@ const STORAGE_KEY = 'settings'
 const DEFAULT_SETTINGS: Settings = {
   currency: DEFAULT_CURRENCY_CODE,
   blockExplorer: EXPLORERS.NEO_TRACKER,
+  theme: themes[0],
   tokens: getDefaultTokens()
 }
 
-const getSettings = async (): Promise<Settings> => {
+const getSettings = async (): Promise < Settings > => {
   const defaults = DEFAULT_SETTINGS
   const settings = (await getStorage(STORAGE_KEY)) || {}
 
@@ -29,23 +45,28 @@ const getSettings = async (): Promise<Settings> => {
     token => [token.networkId, token.scriptHash].join('-')
   )
 
-  return { ...defaults, ...settings, tokens }
+  return { ...defaults,
+    ...settings,
+    tokens
+  }
 }
 
 export const ID = 'settings'
 
 export const updateSettingsActions = createActions(
   ID,
-  (values: Settings = {}) => async (): Promise<Settings> => {
+  (values: Settings = {}) => async (): Promise < Settings > => {
     const settings = await getSettings()
-    const newSettings = { ...settings, ...values }
+    const newSettings = { ...settings,
+      ...values
+    }
     await setStorage(STORAGE_KEY, newSettings)
 
     return newSettings
   }
 )
 
-export default createActions(ID, () => async (): Promise<Settings> => {
+export default createActions(ID, () => async (): Promise < Settings > => {
   const settings = await getSettings()
   return pick(settings, keys(DEFAULT_SETTINGS))
 })

--- a/app/containers/App/App.jsx
+++ b/app/containers/App/App.jsx
@@ -1,6 +1,5 @@
 // @flow
 import React, { Component } from 'react'
-import { compose } from 'recompose'
 
 import Sidebar from './Sidebar'
 import Footer from './Footer'
@@ -49,4 +48,4 @@ class App extends Component<Props> {
   }
 }
 
-export default compose(withThemeData())(App)
+export default withThemeData()(App)

--- a/app/containers/App/App.jsx
+++ b/app/containers/App/App.jsx
@@ -1,13 +1,16 @@
 // @flow
 import React, { Component } from 'react'
+import { compose } from 'recompose'
 
 import Sidebar from './Sidebar'
 import Footer from './Footer'
 import ModalRenderer from '../ModalRenderer'
 import Notifications from '../Notifications'
+import withThemeData from '../../hocs/withThemeData'
 import { upgradeUserWalletNEP6 } from '../../modules/generateWallet'
 
 import styles from './App.scss'
+import themes from '../../themes';
 
 type Props = {
   children: React$Node,
@@ -30,10 +33,10 @@ class App extends Component<Props> {
   }
 
   render() {
-    const { children, address } = this.props
+    const { children, address, theme } = this.props
 
     return (
-      <div className={styles.container}>
+      <div style={themes[theme]} className={styles.container}>
         {address && <Sidebar className={styles.sidebar} />}
         <div className={styles.wrapper}>
           <div className={styles.content}>{children}</div>
@@ -46,4 +49,6 @@ class App extends Component<Props> {
   }
 }
 
-export default App
+export default compose(
+  withThemeData()
+)(App)

--- a/app/containers/App/App.jsx
+++ b/app/containers/App/App.jsx
@@ -10,7 +10,7 @@ import withThemeData from '../../hocs/withThemeData'
 import { upgradeUserWalletNEP6 } from '../../modules/generateWallet'
 
 import styles from './App.scss'
-import themes from '../../themes';
+import themes from '../../themes'
 
 type Props = {
   children: React$Node,
@@ -49,6 +49,4 @@ class App extends Component<Props> {
   }
 }
 
-export default compose(
-  withThemeData()
-)(App)
+export default compose(withThemeData())(App)

--- a/app/containers/App/App.scss
+++ b/app/containers/App/App.scss
@@ -6,7 +6,7 @@
   position: relative;
   width: 100%;
   height: 100%;
-  background: #e6e6e6;
+  background: var(--main-background);
 
   .sidebar {
     flex: 0 0 auto;

--- a/app/containers/Settings/Settings.jsx
+++ b/app/containers/Settings/Settings.jsx
@@ -189,21 +189,21 @@ export default class Settings extends Component<Props, State> {
             <Button onClick={this.openTokenModal}>Manage Tokens</Button>
           </div>
           <div className="settingsItem">
-            <div className="itemTitle">Block Explorer</div>
-            <select value={explorer} onChange={this.updateExplorerSettings}>
-              {Object.keys(EXPLORERS).map((explorer: ExplorerType) => (
-                <option key={explorer} value={EXPLORERS[explorer]}>
-                  {EXPLORERS[explorer]}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div className="settingsItem">
             <div className="itemTitle">Theme</div>
             <select value={theme} onChange={this.updateThemeSettings}>
               {Object.keys(themes).map((themeName: string) => (
                 <option value={themeName} key={themeName}>
                   {themeName}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="settingsItem">
+            <div className="itemTitle">Block Explorer</div>
+            <select value={explorer} onChange={this.updateExplorerSettings}>
+              {Object.keys(EXPLORERS).map((explorer: ExplorerType) => (
+                <option key={explorer} value={EXPLORERS[explorer]}>
+                  {EXPLORERS[explorer]}
                 </option>
               ))}
             </select>

--- a/app/containers/Settings/Settings.jsx
+++ b/app/containers/Settings/Settings.jsx
@@ -43,7 +43,9 @@ export default class Settings extends Component<Props, State> {
     storage.get('userWallet', (errorReading, data) => {
       if (errorReading) {
         showErrorNotification({
-          message: `An error occurred reading wallet file: ${errorReading.message}`
+          message: `An error occurred reading wallet file: ${
+            errorReading.message
+          }`
         })
         return
       }
@@ -60,7 +62,9 @@ export default class Settings extends Component<Props, State> {
           fs.writeFile(fileName, content, errorWriting => {
             if (errorWriting) {
               showErrorNotification({
-                message: `An error occurred creating the file: ${errorWriting.message}`
+                message: `An error occurred creating the file: ${
+                  errorWriting.message
+                }`
               })
             } else {
               showSuccessNotification({
@@ -74,7 +78,11 @@ export default class Settings extends Component<Props, State> {
   }
 
   loadWalletRecovery = () => {
-    const { showSuccessNotification, showErrorNotification, setAccounts } = this.props
+    const {
+      showSuccessNotification,
+      showErrorNotification,
+      setAccounts
+    } = this.props
 
     dialog.showOpenDialog(fileNames => {
       // fileNames is an array that contains all the selected
@@ -121,7 +129,12 @@ export default class Settings extends Component<Props, State> {
   }
 
   deleteWalletAccount = (label: string, key: string) => {
-    const { showSuccessNotification, showErrorNotification, setAccounts, showModal } = this.props
+    const {
+      showSuccessNotification,
+      showErrorNotification,
+      setAccounts,
+      showModal
+    } = this.props
 
     showModal(MODAL_TYPES.CONFIRM, {
       title: 'Confirm Delete',
@@ -130,7 +143,9 @@ export default class Settings extends Component<Props, State> {
         storage.get('userWallet', (readError, data) => {
           if (readError) {
             showErrorNotification({
-              message: `An error occurred reading previously stored wallet: ${readError.message}`
+              message: `An error occurred reading previously stored wallet: ${
+                readError.message
+              }`
             })
             return
           }
@@ -140,7 +155,9 @@ export default class Settings extends Component<Props, State> {
           storage.set('userWallet', data, saveError => {
             if (saveError) {
               showErrorNotification({
-                message: `An error occurred updating the wallet: ${saveError.message}`
+                message: `An error occurred updating the wallet: ${
+                  saveError.message
+                }`
               })
             } else {
               showSuccessNotification({
@@ -163,7 +180,9 @@ export default class Settings extends Component<Props, State> {
 
     return (
       <div id="settings">
-        <div className="description">Manage your Neon wallet accounts and settings</div>
+        <div className="description">
+          Manage your Neon wallet accounts and settings
+        </div>
         <div className="settingsForm">
           <div className="settingsItem">
             <div className="itemTitle">Tokens</div>
@@ -206,15 +225,24 @@ export default class Settings extends Component<Props, State> {
                 <div className="walletItem">
                   <div className="walletName">{account.key.slice(0, 20)}</div>
                   <div className="walletKey">{account.label}</div>
-                  <div className="deleteWallet" onClick={() => this.deleteWalletAccount(account.label, account.key)}>
+                  <div
+                    className="deleteWallet"
+                    onClick={() =>
+                      this.deleteWalletAccount(account.label, account.key)
+                    }
+                  >
                     <Delete />
                   </div>
                 </div>
               </div>
             ))}
           </div>
-          <Button onClick={() => this.saveWalletRecovery()}>Export wallet recovery file</Button>
-          <Button onClick={this.loadWalletRecovery}>Load wallet recovery file</Button>
+          <Button onClick={() => this.saveWalletRecovery()}>
+            Export wallet recovery file
+          </Button>
+          <Button onClick={this.loadWalletRecovery}>
+            Load wallet recovery file
+          </Button>
         </div>
       </div>
     )

--- a/app/containers/Settings/Settings.jsx
+++ b/app/containers/Settings/Settings.jsx
@@ -9,7 +9,7 @@ import { recoverWallet } from '../../modules/generateWallet'
 
 import Button from '../../components/Button'
 import { EXPLORERS, MODAL_TYPES, CURRENCIES } from '../../core/constants'
-import themes from '../../themes';
+import themes from '../../themes'
 
 const { dialog } = require('electron').remote
 
@@ -43,9 +43,7 @@ export default class Settings extends Component<Props, State> {
     storage.get('userWallet', (errorReading, data) => {
       if (errorReading) {
         showErrorNotification({
-          message: `An error occurred reading wallet file: ${
-            errorReading.message
-          }`
+          message: `An error occurred reading wallet file: ${errorReading.message}`
         })
         return
       }
@@ -62,9 +60,7 @@ export default class Settings extends Component<Props, State> {
           fs.writeFile(fileName, content, errorWriting => {
             if (errorWriting) {
               showErrorNotification({
-                message: `An error occurred creating the file: ${
-                  errorWriting.message
-                }`
+                message: `An error occurred creating the file: ${errorWriting.message}`
               })
             } else {
               showSuccessNotification({
@@ -78,11 +74,7 @@ export default class Settings extends Component<Props, State> {
   }
 
   loadWalletRecovery = () => {
-    const {
-      showSuccessNotification,
-      showErrorNotification,
-      setAccounts
-    } = this.props
+    const { showSuccessNotification, showErrorNotification, setAccounts } = this.props
 
     dialog.showOpenDialog(fileNames => {
       // fileNames is an array that contains all the selected
@@ -124,17 +116,12 @@ export default class Settings extends Component<Props, State> {
   }
 
   updateThemeSettings = (e: Object) => {
-    const { setTheme } = this.props;
-    setTheme(e.target.value);
+    const { setTheme } = this.props
+    setTheme(e.target.value)
   }
 
   deleteWalletAccount = (label: string, key: string) => {
-    const {
-      showSuccessNotification,
-      showErrorNotification,
-      setAccounts,
-      showModal
-    } = this.props
+    const { showSuccessNotification, showErrorNotification, setAccounts, showModal } = this.props
 
     showModal(MODAL_TYPES.CONFIRM, {
       title: 'Confirm Delete',
@@ -143,9 +130,7 @@ export default class Settings extends Component<Props, State> {
         storage.get('userWallet', (readError, data) => {
           if (readError) {
             showErrorNotification({
-              message: `An error occurred reading previously stored wallet: ${
-                readError.message
-              }`
+              message: `An error occurred reading previously stored wallet: ${readError.message}`
             })
             return
           }
@@ -155,9 +140,7 @@ export default class Settings extends Component<Props, State> {
           storage.set('userWallet', data, saveError => {
             if (saveError) {
               showErrorNotification({
-                message: `An error occurred updating the wallet: ${
-                  saveError.message
-                }`
+                message: `An error occurred updating the wallet: ${saveError.message}`
               })
             } else {
               showSuccessNotification({
@@ -180,9 +163,7 @@ export default class Settings extends Component<Props, State> {
 
     return (
       <div id="settings">
-        <div className="description">
-          Manage your Neon wallet accounts and settings
-        </div>
+        <div className="description">Manage your Neon wallet accounts and settings</div>
         <div className="settingsForm">
           <div className="settingsItem">
             <div className="itemTitle">Tokens</div>
@@ -225,24 +206,15 @@ export default class Settings extends Component<Props, State> {
                 <div className="walletItem">
                   <div className="walletName">{account.key.slice(0, 20)}</div>
                   <div className="walletKey">{account.label}</div>
-                  <div
-                    className="deleteWallet"
-                    onClick={() =>
-                      this.deleteWalletAccount(account.label, account.key)
-                    }
-                  >
+                  <div className="deleteWallet" onClick={() => this.deleteWalletAccount(account.label, account.key)}>
                     <Delete />
                   </div>
                 </div>
               </div>
             ))}
           </div>
-          <Button onClick={() => this.saveWalletRecovery()}>
-            Export wallet recovery file
-          </Button>
-          <Button onClick={this.loadWalletRecovery}>
-            Load wallet recovery file
-          </Button>
+          <Button onClick={() => this.saveWalletRecovery()}>Export wallet recovery file</Button>
+          <Button onClick={this.loadWalletRecovery}>Load wallet recovery file</Button>
         </div>
       </div>
     )

--- a/app/containers/Settings/Settings.jsx
+++ b/app/containers/Settings/Settings.jsx
@@ -9,6 +9,7 @@ import { recoverWallet } from '../../modules/generateWallet'
 
 import Button from '../../components/Button'
 import { EXPLORERS, MODAL_TYPES, CURRENCIES } from '../../core/constants'
+import themes from '../../themes';
 
 const { dialog } = require('electron').remote
 
@@ -18,6 +19,8 @@ type Props = {
   explorer: string,
   setCurrency: string => any,
   currency: string,
+  setTheme: string => any,
+  theme: string,
   accounts: any,
   showModal: Function,
   showSuccessNotification: Object => any,
@@ -120,6 +123,11 @@ export default class Settings extends Component<Props, State> {
     setCurrency(e.target.value)
   }
 
+  updateThemeSettings = (e: Object) => {
+    const { setTheme } = this.props;
+    setTheme(e.target.value);
+  }
+
   deleteWalletAccount = (label: string, key: string) => {
     const {
       showSuccessNotification,
@@ -168,7 +176,7 @@ export default class Settings extends Component<Props, State> {
   }
 
   render() {
-    const { accounts, explorer, currency } = this.props
+    const { accounts, explorer, currency, theme } = this.props
 
     return (
       <div id="settings">
@@ -186,6 +194,16 @@ export default class Settings extends Component<Props, State> {
               {Object.keys(EXPLORERS).map((explorer: ExplorerType) => (
                 <option key={explorer} value={EXPLORERS[explorer]}>
                   {EXPLORERS[explorer]}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="settingsItem">
+            <div className="itemTitle">Theme</div>
+            <select value={theme} onChange={this.updateThemeSettings}>
+              {Object.keys(themes).map((themeName: string) => (
+                <option value={themeName} key={themeName}>
+                  {themeName}
                 </option>
               ))}
             </select>

--- a/app/containers/Settings/index.js
+++ b/app/containers/Settings/index.js
@@ -1,22 +1,38 @@
 // @flow
-import { connect } from 'react-redux'
-import { bindActionCreators } from 'redux'
-import { compose } from 'recompose'
-import { withData, withActions } from 'spunky'
+import {
+  connect
+} from 'react-redux'
+import {
+  bindActionCreators
+} from 'redux'
+import {
+  compose
+} from 'recompose'
+import {
+  withData,
+  withActions
+} from 'spunky'
 
 import Settings from './Settings'
 import withExplorerData from '../../hocs/withExplorerData'
 import withCurrencyData from '../../hocs/withCurrencyData'
+import withThemeData from '../../hocs/withThemeData'
 import accountsActions, {
   updateAccountsActions
 } from '../../actions/accountsActions'
-import { updateSettingsActions } from '../../actions/settingsActions'
-import { getNetworks } from '../../core/networks'
+import {
+  updateSettingsActions
+} from '../../actions/settingsActions'
+import {
+  getNetworks
+} from '../../core/networks'
 import {
   showErrorNotification,
   showSuccessNotification
 } from '../../modules/notifications'
-import { showModal } from '../../modules/modal'
+import {
+  showModal
+} from '../../modules/modal'
 
 const mapStateToProps = (state: Object) => ({
   networks: getNetworks()
@@ -31,15 +47,24 @@ const actionCreators = {
 const mapDispatchToProps = dispatch =>
   bindActionCreators(actionCreators, dispatch)
 
-const mapAccountsDataToProps = accounts => ({ accounts })
+const mapAccountsDataToProps = accounts => ({
+  accounts
+})
 
 const mapAccountsActionsToProps = actions => ({
   setAccounts: accounts => actions.call(accounts)
 })
 
 const mapSettingsActionsToProps = actions => ({
-  setCurrency: currency => actions.call({ currency }),
-  setBlockExplorer: blockExplorer => actions.call({ blockExplorer })
+  setCurrency: currency => actions.call({
+    currency
+  }),
+  setBlockExplorer: blockExplorer => actions.call({
+    blockExplorer
+  }),
+  setTheme: theme => actions.call({
+    theme
+  })
 })
 
 export default compose(
@@ -50,6 +75,7 @@ export default compose(
   withData(accountsActions, mapAccountsDataToProps),
   withExplorerData(),
   withCurrencyData(),
+  withThemeData(),
   withActions(updateAccountsActions, mapAccountsActionsToProps),
   withActions(updateSettingsActions, mapSettingsActionsToProps)
 )(Settings)

--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -120,6 +120,8 @@ export const DEFAULT_WALLET = {
 
 export const DEFAULT_CURRENCY_CODE = 'usd'
 
+export const DEFAULT_THEME = 'Light'
+
 export const CURRENCIES = {
   aud: { symbol: '$' },
   brl: { symbol: 'R$' },

--- a/app/hocs/withThemeData.js
+++ b/app/hocs/withThemeData.js
@@ -1,0 +1,13 @@
+// @flow
+import {
+  withData
+} from 'spunky'
+
+import settingsActions from '../actions/settingsActions'
+
+export default function withThemeData(key: string = 'theme') {
+  const mapSettingsDataToProps = settings => ({
+    [key]: settings.theme
+  })
+  return withData(settingsActions, mapSettingsDataToProps)
+}

--- a/app/hocs/withThemeData.js
+++ b/app/hocs/withThemeData.js
@@ -5,9 +5,9 @@ import {
 
 import settingsActions from '../actions/settingsActions'
 
-export default function withThemeData(key: string = 'theme') {
+export default function withThemeData() {
   const mapSettingsDataToProps = settings => ({
-    [key]: settings.theme
+    theme: settings.theme
   })
   return withData(settingsActions, mapSettingsDataToProps)
 }

--- a/app/styles/main.global.scss
+++ b/app/styles/main.global.scss
@@ -21,7 +21,7 @@ body {
   font-size: 16px;
   padding: 0px;
   margin: 0px;
-  background-color: $main-background;
+  background-color: var(--main-background);
   color: $default-text;
   overflow: hidden;
   :focus {

--- a/app/styles/variables.scss
+++ b/app/styles/variables.scss
@@ -1,5 +1,4 @@
 // backgrounds and buttons
-$main-background: #fff;
 $primary-color: #4d933b;
 $default-button: $primary-color;
 $default-button-hover: #5eb248;

--- a/app/themes/Dark.js
+++ b/app/themes/Dark.js
@@ -1,0 +1,4 @@
+export default {
+  '--main-background': '#000',
+  // more dark colors here
+}

--- a/app/themes/Light.js
+++ b/app/themes/Light.js
@@ -1,4 +1,4 @@
 export default {
-  '--main-background': '#FFF',
+  '--main-background': '#e6e6e6',
   // more light colors here
 }

--- a/app/themes/Light.js
+++ b/app/themes/Light.js
@@ -1,0 +1,4 @@
+export default {
+  '--main-background': '#FFF',
+  // more light colors here
+}

--- a/app/themes/index.js
+++ b/app/themes/index.js
@@ -1,5 +1,5 @@
-import Light from './Light';
-import Dark from './Dark';
+import Light from './Light'
+import Dark from './Dark'
 
 export default {
   Light,

--- a/app/themes/index.js
+++ b/app/themes/index.js
@@ -1,0 +1,7 @@
+import Light from './Light';
+import Dark from './Dark';
+
+export default {
+  Light,
+  Dark
+}


### PR DESCRIPTION
Hi all,

I've completed a few bug fixes already in this repo, but this is my first PR for a feature. I tried to closely follow the design patterns already in place, but speak up if not.

This PR specifically addresses the implementation of a system for toggling between themes. It does so by swapping Sass variables for native CSS variables wherever dynamic colors are required. The theme is passed in once at the root level and the variable definitions cascade down through the other components. There are a number of ways this could be done, but I think this route is pretty clean as it didn't require major changes to the way styles are implemented in the app. New themes are also VERY easy to add as they are just a simple object.

Swapping the remaining variables and defining the actual color palettes will be addressed in another PR as this is a separate issue (#1239).

**What current issue(s) from Trello/Github does this address?**
#1249

**What problem does this PR solve?**
Swapping color schemes in the application.

**How did you make sure your solution works?**
Manually tested.

**Other Notes**
You'll see some formatting/spacing changes in a few of the files. I presume this is because when they were initially committed the individual did not have Prettier enabled. Apologies if this makes the actual diff much harder to discern.

**Demo** (Gif is poor quality)
![demo](https://user-images.githubusercontent.com/1944428/42551401-45fabf66-8494-11e8-84e4-c9445eb77aab.gif)



