### PR TITLE
chore(explorer): fixed broken link for addresses

### DIFF
--- a/app/core/explorer.js
+++ b/app/core/explorer.js
@@ -30,7 +30,7 @@ export const getExplorerBaseURL = (networkId: string, explorer: ExplorerType) =>
 
 export const getExplorerTxLink = (networkId: string, explorer: ExplorerType, txId: string) => buildExplorerLink(networkId, explorer, 'trxLinkStructure', txId)
 
-export const getExplorerAddressLink = (networkId: string, explorer: ExplorerType, address: string) => buildExplorerLink(networkId, explorer, 'addressStructure', address)
+export const getExplorerAddressLink = (networkId: string, explorer: ExplorerType, address: string) => buildExplorerLink(networkId, explorer, 'addressLinkStructure', address)
 
 export const getExplorerAssetLink = (networkId: string, explorer: ExplorerType, assetId: string) => buildExplorerLink(networkId, explorer, 'assetLinkStructure', assetId)
 

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "instascan": "1.0.0",
     "isomorphic-fetch": "2.2.1",
     "lodash": "4.17.4",
-    "neon-js": "git+https://github.com/cityofzion/neon-js.git#statetx",
+    "neon-js": "git+https://github.com/cityofzion/neon-js.git#3.9.2",
     "nock": "^9.2.3",
     "qrcode": "0.9.0",
     "raf": "3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6887,9 +6887,9 @@ neo-async@^2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.5.1.tgz#acb909e327b1e87ec9ef15f41b8a269512ad41ee"
 
-"neon-js@git+https://github.com/cityofzion/neon-js.git#statetx":
-  version "3.9.0"
-  resolved "git+https://github.com/cityofzion/neon-js.git#88578de863653f16fad88fc8a730b42f7521244a"
+"neon-js@git+https://github.com/cityofzion/neon-js.git#3.9.2":
+  version "3.9.2"
+  resolved "git+https://github.com/cityofzion/neon-js.git#a1806fa3de3975319e34f5fbf2bcf264d7d56680"
   dependencies:
     axios "^0.18.0"
     bignumber.js "5.0.0"


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
None/ Discussed this with @comountainclimber in discord chat

**What problem does this PR solve?**
Broken URL when clicking on addresses (on receive tab your own address for example)

**How did you solve this problem?**
`addressLinkStructure` was written incorrectly

**How did you make sure your solution works?**
Tested it manually

**Are there any special changes in the code that we should be aware of?**
Nope

**Is there anything else we should know?**
nope

- [ ] Unit tests written? --> not needed, tests already exist
