### PR TITLE
Fix missing checks for null account key in NEP6 wallet file

### DIFF
--- a/app/containers/LoginLocalStorage/LoginLocalStorage.jsx
+++ b/app/containers/LoginLocalStorage/LoginLocalStorage.jsx
@@ -40,9 +40,9 @@ export default class LoginLocalStorage extends Component<Props, State> {
             <option value=''>Select a wallet</option>
             {accounts && accounts.reduce((accum, account, index) => {
               if (account.key) {
-                accum.push(<option value={account.key} key={`wallet${account.label}`}>{account.label}</option>);
+                accum.push(<option value={account.key} key={`wallet${account.label}`}>{account.label}</option>)
               }
-              return accum;
+              return accum
             }, [])}
           </select>
           <div className={loginStyles.loginForm}>

--- a/app/containers/LoginLocalStorage/LoginLocalStorage.jsx
+++ b/app/containers/LoginLocalStorage/LoginLocalStorage.jsx
@@ -1,6 +1,5 @@
 // @flow
 import React, { Component } from 'react'
-import { map } from 'lodash'
 
 import PasswordField from '../../components/PasswordField'
 import HomeButtonLink from '../../components/HomeButtonLink'
@@ -39,11 +38,11 @@ export default class LoginLocalStorage extends Component<Props, State> {
             onChange={(e) => this.setState({ encryptedWIF: e.target.value })}
           >
             <option value=''>Select a wallet</option>
-            {reduce(accounts, (accum, account, index) => {
+            {accounts && accounts.reduce((accum, account, index) => {
               if (account.key) {
                 accum.push(<option value={account.key} key={`wallet${account.label}`}>{account.label}</option>);
               }
-              return acum;
+              return accum;
             }, [])}
           </select>
           <div className={loginStyles.loginForm}>

--- a/app/containers/LoginLocalStorage/LoginLocalStorage.jsx
+++ b/app/containers/LoginLocalStorage/LoginLocalStorage.jsx
@@ -39,9 +39,12 @@ export default class LoginLocalStorage extends Component<Props, State> {
             onChange={(e) => this.setState({ encryptedWIF: e.target.value })}
           >
             <option value=''>Select a wallet</option>
-            {map(accounts, (account, index) => (
-              <option value={account.key} key={`wallet${account.label}`}>{account.label}</option>
-            ))}
+            {reduce(accounts, (accum, account, index) => {
+              if (account.key) {
+                accum.push(<option value={account.key} key={`wallet${account.label}`}>{account.label}</option>);
+              }
+              return acum;
+            }, [])}
           </select>
           <div className={loginStyles.loginForm}>
             <PasswordField

--- a/app/containers/Settings/Settings.jsx
+++ b/app/containers/Settings/Settings.jsx
@@ -241,7 +241,7 @@ export default class Settings extends Component<Props, State> {
               return (
                 <div className='walletList' key={`wallet${account.key}`}>
                   <div className='walletItem'>
-                    <div className='walletName'>{account.key.slice(0, 20)}</div>
+                    <div className='walletName'>{account.key && account.key.slice(0, 20)}</div>
                     <div className='walletKey'>{account.label}</div>
                     <div
                       className='walletCredentials'

--- a/app/modules/generateWallet.js
+++ b/app/modules/generateWallet.js
@@ -126,7 +126,7 @@ export const recoverWallet = (wallet: Object): Promise<*> => {
       }
 
       accounts.some((account) => {
-        if (!walletHasKey(data, account.key)) {
+        if (account.key && !walletHasKey(data, account.key)) {
           data.accounts.push(account)
         }
       })


### PR DESCRIPTION
**What problem does this PR solve?**
There is currently a gap in the handling of addresses without keys in the NEP6 wallet JSON. The proposal mentions that, `This field can be null (for watch-only address or non-standard address).`, however there were not any checks for this use case on file import or read.

**How did you solve this problem?**
Added checks on wallet file import to filter out accounts with no key, since this is not a part of the user flow for neon-wallet.

Also added checks on usages in the login from local storage and setting page. While the import filter should remove these records in the first place, this should not be needed. However the checks were still added just in case, as the result is an app crash if they do occur.


In order to test this, you can import a NEP6 wallet file with one of the key values deleted. In the current app, it will crash when navigating to settings page. In this branch, it does not.
