### PR TITLE
adds styled version num from package.json to Home.jsx

### DIFF
--- a/app/containers/Home/Home.jsx
+++ b/app/containers/Home/Home.jsx
@@ -13,6 +13,7 @@ import AddIcon from '../../assets/icons/add.svg'
 import ImportIcon from '../../assets/icons/import.svg'
 import { ROUTES } from '../../core/constants'
 import HomeLayout from './HomeLayout'
+import pack from '../../../package.json'
 
 type State = {
   tabIndex: number
@@ -90,6 +91,7 @@ export default class Home extends React.Component<Props, State> {
               </Link>
             </div>
           </div>
+          <div className={styles.versionNumber}>{`v${pack.version}`}</div>
         </div>
       </HomeLayout>
     )

--- a/app/containers/Home/Home.scss
+++ b/app/containers/Home/Home.scss
@@ -163,3 +163,11 @@ $navigation-margin: 20px;
   width: 500px;
   align-items: center;
 }
+
+.versionNumber {
+  font-size: 12px;
+  font-weight: 200;
+  margin-bottom: 15px;
+  color: #ced0d4;
+  opacity: 0.7;
+}


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
This solves https://github.com/CityOfZion/neon-wallet/issues/731 its also something that has been brought up multiple times in the past.

**What problem does this PR solve?**
Version number is now extremely easy to see and reference

**How did you solve this problem?**
By pulling in version num from `package.json`

**How did you make sure your solution works?**
Updating version num in pack also updated it in the UI

<img width="713" alt="screen shot 2018-08-27 at 7 36 14 am" src="https://user-images.githubusercontent.com/13072035/44662973-6fdd5980-a9cc-11e8-8d1e-62cfed252701.png">

**Are there any special changes in the code that we should be aware of?**
NOTE: This design change has been confirmed with design team however mocks are not up to date


**Is there anything else we should know?**

- [ ] Unit tests written?
