### PR TITLE
[v2] Feature/filters out invalid hashes

### DIFF
--- a/app/actions/settingsActions.js
+++ b/app/actions/settingsActions.js
@@ -39,9 +39,7 @@ const ensureHex = (token: string): boolean => {
   }
 }
 
-const validateHashLength = (token: string): boolean => {
-  return token.length === 40
-}
+const validateHashLength = (token: string): boolean => token.length === 40
 
 const getSettings = async (): Promise<Settings> => {
   const defaults = await DEFAULT_SETTINGS()
@@ -65,7 +63,6 @@ const getSettings = async (): Promise<Settings> => {
 
   return { ...defaults, ...settings, tokens, version }
 }
-
 
 export const ID = 'settings'
 

--- a/app/actions/settingsActions.js
+++ b/app/actions/settingsActions.js
@@ -40,7 +40,10 @@ const getSettings = async (): Promise<Settings> => {
 
   const { version } = pack
   const tokens = uniqBy(
-    [...(defaults.tokens || []), ...(settings.tokens || [])],
+    [
+      ...(defaults.tokens || []),
+      ...(settings.tokens.filter(token => token.length === 40) || [])
+    ],
     token => [token.networkId, token.scriptHash].join('-')
   )
 

--- a/app/actions/settingsActions.js
+++ b/app/actions/settingsActions.js
@@ -27,6 +27,22 @@ const DEFAULT_SETTINGS: () => Promise<Settings> = async () => ({
   tokens: await getDefaultTokens()
 })
 
+const ensureHex = (token: string): boolean => {
+  const hexRegex = /^([0-9A-Fa-f]{2})*$/
+  try {
+    return hexRegex.test(token)
+  } catch (err) {
+    console.warn('An invalid script hash was manually entered in Settings!', {
+      scriptHash: token
+    })
+    return false
+  }
+}
+
+const validateHashLength = (token: string): boolean => {
+  return token.length === 40
+}
+
 const getSettings = async (): Promise<Settings> => {
   const defaults = await DEFAULT_SETTINGS()
   const settings = (await getStorage(STORAGE_KEY)) || {}
@@ -42,13 +58,14 @@ const getSettings = async (): Promise<Settings> => {
   const tokens = uniqBy(
     [
       ...(defaults.tokens || []),
-      ...(settings.tokens.filter(token => token.length === 40) || [])
+      ...(settings.tokens.filter(ensureHex).filter(validateHashLength) || [])
     ],
     token => [token.networkId, token.scriptHash].join('-')
   )
 
   return { ...defaults, ...settings, tokens, version }
 }
+
 
 export const ID = 'settings'
 


### PR DESCRIPTION
`getTokenBalances()` will throw an error if any of the token hashes entered do not have a length of 40 chars... You can see the dozens of support requests coming in due to this simple mistake (there was no validation of script hashes in manage tokens and many many people just entered garbage here)

This PR addresses that issue by ignoring token hashes that do not have a length of 40