### PR TITLE
settingsActions.js enhancements

### DIFF
--- a/app/hocs/withThemeData.js
+++ b/app/hocs/withThemeData.js
@@ -6,7 +6,7 @@ import settingsActions from '../actions/settingsActions'
 
 export default function withThemeData() {
   const mapSettingsDataToProps = settings => ({
-    theme: DEFAULT_THEME
+    theme: settings.theme
   })
   return withData(settingsActions, mapSettingsDataToProps)
 }


### PR DESCRIPTION
Currently, when blasting away local storage from `Library/Application Support/Neon` (on a fresh install of v2) there are a few issues related to the way we load default settings data. This PR fixes that flow and also simplifies `settingsActions.js` it also resolves the hardcoded fix implemented here so that when we do get around to implementing themes it will be less painful https://github.com/CityOfZion/neon-wallet/pull/1474