### PR TITLE
fix(sidebar): Jumping menu items

### DIFF
--- a/app/containers/App/Sidebar/Sidebar.scss
+++ b/app/containers/App/Sidebar/Sidebar.scss
@@ -50,7 +50,7 @@ $size: 64px;
   box-sizing: border-box;
   width: $size;
   height: $size;
-  border-left: 2px solid transparent;
+  border-left: 4px solid transparent;
   font-size: 24px;
   display: flex;
   flex-direction: column;
@@ -74,7 +74,6 @@ $size: 64px;
   &:hover {
     background: #fff;
     border-color: #5abf6b;
-    border-width: 4px;
 
     &,
     & svg,


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
Fixes the jumping that occurs when hovering the sidebar menu items.

**How did you solve this problem?**
Increases the transparent width border to 4x from 2x

**How did you make sure your solution works?**
Retested the flow and the items do not jump anymore.

**Are there any special changes in the code that we should be aware of?**
No.

**Is there anything else we should know?**
No.

- [ ] Unit tests written?
