### PR TITLE
Implement password hiding

### DIFF
--- a/app/containers/DisplayWalletAccounts/DisplayWalletAccounts.jsx
+++ b/app/containers/DisplayWalletAccounts/DisplayWalletAccounts.jsx
@@ -41,12 +41,16 @@ class DisplayWalletAccounts extends Component<Props> {
       authenticated
     } = this.props
     const fields = [
-      { label: 'Passphrase', value: passphrase },
-      { label: 'Private Key', value: wif },
-      { label: 'Public Address', value: address }
+      {
+        label: 'Passphrase',
+        value: passphrase,
+        type: 'password'
+      },
+      { label: 'Private Key', value: wif, type: 'text' },
+      { label: 'Public Address', value: address, type: 'text' }
     ]
     if (walletName) {
-      fields.unshift({ label: 'Wallet Name', value: walletName })
+      fields.unshift({ label: 'Wallet Name', value: walletName, type: 'text' })
     }
     const conditionalPanelProps = {}
     if (authenticated) {
@@ -91,7 +95,12 @@ class DisplayWalletAccounts extends Component<Props> {
                     [styles.reducedInputFontSize]: item.label === 'Private Key'
                   })}
                 >
-                  <TextInput label={item.label} value={item.value} disabled />
+                  <TextInput
+                    type={item.type}
+                    label={item.label}
+                    value={item.value}
+                    disabled
+                  />
                 </div>
                 <CopyToClipboard
                   className={styles.clipboardCopy}


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
#1453 

**What problem does this PR solve?**

> Thanks for reporting this after careful consideration lets just stick with hiding the password for now in this view adding to the v2 board now...

Per @comountainclimber's comment, this simply passes [type='password'] into the password input. It doesn't do the same for the private key. I wasn't sure if your intention was to have the display feature for this togglable, so I made the simplest assumption based on my interpretation of the comment. If you in fact intended for the hide/show feature to be there as well that can be addressed.

**How did you solve this problem?**

**How did you make sure your solution works?**
Tested locally.

<img width="623" alt="screen shot 2018-10-05 at 9 52 39 pm" src="https://user-images.githubusercontent.com/1944428/46567082-1b8d9980-c8e9-11e8-97b4-037741a8d048.png">

