### PR TITLE
feat(login): Implement a more intuitive login flow with ledger

### DIFF
--- a/app/containers/Home/Home.scss
+++ b/app/containers/Home/Home.scss
@@ -1,4 +1,5 @@
 @import '../../styles/variables';
+@import '../../styles/animations';
 
 $navigation-height: 65px;
 $navigation-margin: 20px;
@@ -32,14 +33,59 @@ $navigation-margin: 20px;
   margin-bottom: 10px;
 }
 
-.ledgerStatusText {
-  font-weight: lighter;
+.ledgerStatusStage {
+  font-family: Gotham-Book;
   margin-top: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  opacity: 0.5;
+  border: 1px solid transparent;
+  width: 380px;
+  margin: 0 auto;
+  padding: 0 30px;
+  font-size: 14px;
+  height: 45px;
+  border-color: #ddd;
+  box-sizing: border-box;
+  &:first-child {
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+    border-bottom-color: transparent;
+  }
+  &:last-child {
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+  }
 }
 
-.ledgerStatusTextError {
-  @extend .ledgerStatusText;
-  color: red;
+.ledgerStatusIcon {
+  path {
+    fill: #66ED87;
+  }
+}
+
+.ledgerStatusActiveStage {
+  opacity: 1.0;  
+  border-left-color: #66eb8e;
+  border-top-color: #66eb8e;
+  border-right-color: #6bdaf6;
+  border-bottom-color: #6bdaf6 !important;
+
+  .ledgerStatusIcon {
+    path {
+      fill: #5C677F;
+    }
+  }
+}
+
+.ledgerStatusCompletedStage {
+  opacity: 1.0;
+}
+
+.ledgerStatusRefreshIcon {
+  @extend .ledgerStatusIcon;
+  animation: spin 2s linear infinite;
 }
 
 .flexContainer {

--- a/app/containers/Home/Home.scss
+++ b/app/containers/Home/Home.scss
@@ -67,10 +67,10 @@ $navigation-margin: 20px;
 
 .ledgerStatusActiveStage {
   opacity: 1.0;  
-  border-left-color: #66eb8e;
-  border-top-color: #66eb8e;
-  border-right-color: #6bdaf6;
-  border-bottom-color: #6bdaf6 !important;
+  border-color: #66eb8e #6bdaf6 #6bdaf6 #66eb8e;
+  &:first-child {
+    border-bottom-color: #6bdaf6;
+  }
 
   .ledgerStatusIcon {
     path {

--- a/app/containers/Home/Home.scss
+++ b/app/containers/Home/Home.scss
@@ -33,7 +33,7 @@ $navigation-margin: 20px;
   margin-bottom: 10px;
 }
 
-.ledgerStatusStage {
+.ledgerStage {
   font-family: Gotham-Book;
   margin-top: 0;
   display: flex;
@@ -59,32 +59,32 @@ $navigation-margin: 20px;
   }
 }
 
-.ledgerStatusIcon {
+.ledgerStageIcon {
   path {
     fill: #66ED87;
   }
 }
 
-.ledgerStatusActiveStage {
+.ledgerStageActive {
   opacity: 1.0;  
   border-color: #66eb8e #6bdaf6 #6bdaf6 #66eb8e;
   &:first-child {
     border-bottom-color: #6bdaf6;
   }
 
-  .ledgerStatusIcon {
+  .ledgerStageIcon {
     path {
       fill: #5C677F;
     }
   }
 }
 
-.ledgerStatusCompletedStage {
+.ledgerStageCompleted {
   opacity: 1.0;
 }
 
-.ledgerStatusRefreshIcon {
-  @extend .ledgerStatusIcon;
+.ledgerStageRefreshIcon {
+  @extend .ledgerStageIcon;
   animation: spin 2s linear infinite;
 }
 

--- a/app/containers/LoginLedgerNanoS/LoginLedgerNanoS.jsx
+++ b/app/containers/LoginLedgerNanoS/LoginLedgerNanoS.jsx
@@ -1,35 +1,80 @@
 // @flow
 import React from 'react'
 import { progressValues } from 'spunky'
+import classNames from 'classnames'
 
 import Button from '../../components/Button'
 import LoginIcon from '../../assets/icons/login.svg'
+import ConfirmIcon from '../../assets/icons/confirm.svg'
+import RefreshIcon from '../../assets/icons/refresh.svg'
 import styles from '../Home/Home.scss'
+
+import { MESSAGES } from '../../ledger/neonLedger'
+
+const LEDGER_CONNECTION_STAGES = {
+  NOT_CONNECTED: 1,
+  OPEN_APP: 2,
+  CONNECTED: 3
+}
 
 const { LOADED, FAILED } = progressValues
 
-type DeviceInfo = {
-  manufacturer: string,
-  product: string
-}
+const { NOT_CONNECTED, OPEN_APP, CONNECTED } = LEDGER_CONNECTION_STAGES
+
+type LedgerConnectionStage = $Values<typeof LEDGER_CONNECTION_STAGES>
 
 type Props = {
   progress: string,
   login: Function,
   connect: Function,
-  deviceInfo: ?DeviceInfo,
   publicKey: ?string,
   error: ?string
 }
 
-const POLL_FREQUENCY = 1000
+type State = {
+  ledgerStage: LedgerConnectionStage,
+  isLoading: boolean
+}
 
-export default class LoginLedgerNanoS extends React.Component<Props> {
+const POLL_FREQUENCY_MS = 1000
+
+export default class LoginLedgerNanoS extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+
+    this.state = this.computeLedgerStageFromProps(props)
+  }
+
   intervalId: ?number
 
   componentDidMount() {
     // $FlowFixMe
-    this.intervalId = setInterval(this.props.connect, POLL_FREQUENCY)
+    this.intervalId = setInterval(this.props.connect, POLL_FREQUENCY_MS)
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    const { progress, error } = this.props
+
+    if (progress !== nextProps.progress || error !== nextProps.error) {
+      this.setState(this.computeLedgerStageFromProps(nextProps))
+    }
+  }
+
+  computeLedgerStageFromProps = (props: Props) => {
+    if (props.progress === LOADED) {
+      return { ledgerStage: CONNECTED, isLoading: false }
+    }
+    if (props.progress === FAILED && props.error) {
+      return {
+        isLoading: true,
+        ledgerStage:
+          props.error === MESSAGES.APP_CLOSED ? OPEN_APP : NOT_CONNECTED
+      }
+    }
+    return {
+      isLoading: true,
+      ledgerStage: NOT_CONNECTED
+    }
   }
 
   componentWillUnmount() {
@@ -61,26 +106,44 @@ export default class LoginLedgerNanoS extends React.Component<Props> {
     )
   }
 
+  getLedgerStageIcon = (stage: LedgerConnectionStage) => {
+    const { ledgerStage, isLoading } = this.state
+    if (ledgerStage === stage && isLoading) {
+      return <RefreshIcon className={styles.ledgerStatusRefreshIcon} />
+    }
+    if (ledgerStage > stage) {
+      return <ConfirmIcon className={styles.ledgerStatusIcon} />
+    }
+    return <i />
+  }
+
   renderStatus = () => {
-    const { progress, deviceInfo, error } = this.props
-
-    if (progress === LOADED && deviceInfo) {
-      return (
-        <p className={styles.ledgerStatusText}>
-          Found USB {deviceInfo.manufacturer} {deviceInfo.product}. NEO app
-          found on hardward device. Click button above to login.
-        </p>
-      )
-    }
-
-    if (progress === FAILED && error) {
-      return <p className={styles.ledgerStatusTextError}>{error}</p>
-    }
-
+    const { ledgerStage } = this.state
     return (
-      <p className={styles.ledgerStatusText}>
-        Looking for USB Devices. Please plugin your device and login.
-      </p>
+      <div>
+        <div
+          className={classNames(styles.ledgerStatusStage, {
+            [styles.ledgerStatusActiveStage]: ledgerStage === NOT_CONNECTED,
+            [styles.ledgerStatusCompletedStage]: ledgerStage > NOT_CONNECTED
+          })}
+        >
+          {this.getLedgerStageIcon(NOT_CONNECTED)}
+          <div>
+            Connect and unlock your <strong>Ledger device</strong>
+          </div>
+        </div>
+        <div
+          className={classNames(styles.ledgerStatusStage, {
+            [styles.ledgerStatusActiveStage]: ledgerStage === OPEN_APP,
+            [styles.ledgerStatusCompletedStage]: ledgerStage > OPEN_APP
+          })}
+        >
+          {this.getLedgerStageIcon(OPEN_APP)}
+          <div>
+            Navigate to the <strong>NEO app</strong> on your device
+          </div>
+        </div>
+      </div>
     )
   }
 

--- a/app/containers/LoginLedgerNanoS/LoginLedgerNanoS.jsx
+++ b/app/containers/LoginLedgerNanoS/LoginLedgerNanoS.jsx
@@ -42,7 +42,7 @@ export default class LoginLedgerNanoS extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props)
 
-    this.state = this.computeLedgerStageFromProps(props)
+    this.state = this.computeStateFromProps(props)
   }
 
   intervalId: ?number
@@ -56,11 +56,11 @@ export default class LoginLedgerNanoS extends React.Component<Props, State> {
     const { progress, error } = this.props
 
     if (progress !== nextProps.progress || error !== nextProps.error) {
-      this.setState(this.computeLedgerStageFromProps(nextProps))
+      this.setState(this.computeStateFromProps(nextProps))
     }
   }
 
-  computeLedgerStageFromProps = (props: Props) => {
+  computeStateFromProps = (props: Props) => {
     if (props.progress === LOADED) {
       return { ledgerStage: CONNECTED, isLoading: false }
     }

--- a/app/containers/LoginLedgerNanoS/LoginLedgerNanoS.jsx
+++ b/app/containers/LoginLedgerNanoS/LoginLedgerNanoS.jsx
@@ -109,10 +109,10 @@ export default class LoginLedgerNanoS extends React.Component<Props, State> {
   getLedgerStageIcon = (stage: LedgerConnectionStage) => {
     const { ledgerStage, isLoading } = this.state
     if (ledgerStage === stage && isLoading) {
-      return <RefreshIcon className={styles.ledgerStatusRefreshIcon} />
+      return <RefreshIcon className={styles.ledgerStageRefreshIcon} />
     }
     if (ledgerStage > stage) {
-      return <ConfirmIcon className={styles.ledgerStatusIcon} />
+      return <ConfirmIcon className={styles.ledgerStageIcon} />
     }
     return <i />
   }
@@ -122,9 +122,9 @@ export default class LoginLedgerNanoS extends React.Component<Props, State> {
     return (
       <div>
         <div
-          className={classNames(styles.ledgerStatusStage, {
-            [styles.ledgerStatusActiveStage]: ledgerStage === NOT_CONNECTED,
-            [styles.ledgerStatusCompletedStage]: ledgerStage > NOT_CONNECTED
+          className={classNames(styles.ledgerStage, {
+            [styles.ledgerStageActive]: ledgerStage === NOT_CONNECTED,
+            [styles.ledgerStageCompleted]: ledgerStage > NOT_CONNECTED
           })}
         >
           {this.getLedgerStageIcon(NOT_CONNECTED)}
@@ -133,9 +133,9 @@ export default class LoginLedgerNanoS extends React.Component<Props, State> {
           </div>
         </div>
         <div
-          className={classNames(styles.ledgerStatusStage, {
-            [styles.ledgerStatusActiveStage]: ledgerStage === OPEN_APP,
-            [styles.ledgerStatusCompletedStage]: ledgerStage > OPEN_APP
+          className={classNames(styles.ledgerStage, {
+            [styles.ledgerStageActive]: ledgerStage === OPEN_APP,
+            [styles.ledgerStageCompleted]: ledgerStage > OPEN_APP
           })}
         >
           {this.getLedgerStageIcon(OPEN_APP)}

--- a/app/containers/LoginLedgerNanoS/LoginLedgerNanoS.jsx
+++ b/app/containers/LoginLedgerNanoS/LoginLedgerNanoS.jsx
@@ -106,12 +106,11 @@ export default class LoginLedgerNanoS extends React.Component<Props, State> {
     )
   }
 
-  getLedgerStageIcon = (stage: LedgerConnectionStage) => {
-    const { ledgerStage, isLoading } = this.state
-    if (ledgerStage === stage && isLoading) {
+  getStatusIcon = (ledgerStage: LedgerConnectionStage) => {
+    if (this.state.isLoading && this.state.ledgerStage === ledgerStage) {
       return <RefreshIcon className={styles.ledgerStageRefreshIcon} />
     }
-    if (ledgerStage > stage) {
+    if (this.state.ledgerStage > ledgerStage) {
       return <ConfirmIcon className={styles.ledgerStageIcon} />
     }
     return <i />
@@ -127,7 +126,7 @@ export default class LoginLedgerNanoS extends React.Component<Props, State> {
             [styles.ledgerStageCompleted]: ledgerStage > NOT_CONNECTED
           })}
         >
-          {this.getLedgerStageIcon(NOT_CONNECTED)}
+          {this.getStatusIcon(NOT_CONNECTED)}
           <div>
             Connect and unlock your <strong>Ledger device</strong>
           </div>
@@ -138,7 +137,7 @@ export default class LoginLedgerNanoS extends React.Component<Props, State> {
             [styles.ledgerStageCompleted]: ledgerStage > OPEN_APP
           })}
         >
-          {this.getLedgerStageIcon(OPEN_APP)}
+          {this.getStatusIcon(OPEN_APP)}
           <div>
             Navigate to the <strong>NEO app</strong> on your device
           </div>

--- a/app/ledger/neonLedger.js
+++ b/app/ledger/neonLedger.js
@@ -13,6 +13,16 @@ const APP_CLOSED = 0x6e00
 const TX_DENIED = 0x6985
 const TX_PARSE_ERR = 0x6d07
 
+export const MESSAGES = {
+  NOT_SUPPORTED: 'Your computer does not support the ledger',
+  NOT_CONNECTED: 'Connect and unlock your Ledger device',
+  APP_CLOSED: 'Navigate to the NEO app on your Ledger device',
+  MSG_TOO_BIG: 'Your transaction is too big for the Ledger to sign',
+  TX_DENIED: 'Your transaction is too big for the Ledger to sign',
+  TX_PARSE_ERR:
+    'Error parsing transaction. Make sure your NEO Ledger app version is up to date'
+}
+
 /**
  * Evaluates Transport Error thrown and rewrite the error message to be more user friendly.
  * @param {Error} err
@@ -22,17 +32,16 @@ const evalTransportError = error => {
   const err = cloneDeep(error)
   switch (err.statusCode) {
     case APP_CLOSED:
-      err.message = 'Your NEO app is closed! Please login.'
+      err.message = MESSAGES.APP_CLOSED
       break
     case MSG_TOO_BIG:
-      err.message = 'Your transaction is too big for the ledger to sign!'
+      err.message = MESSAGES.MSG_TOO_BIG
       break
     case TX_DENIED:
-      err.message = 'You have denied the transaction on your ledger.'
+      err.message = MESSAGES.TX_DENIED
       break
     case TX_PARSE_ERR:
-      err.message =
-        'Error parsing transaction. Make sure your NEO app version is up to date.'
+      err.message = MESSAGES.TX_PARSE_ERR
       break
     default:
   }
@@ -60,10 +69,10 @@ export default class NeonLedger {
   static async init() {
     const supported = await LedgerNode.isSupported()
     if (!supported) {
-      throw new Error('Your computer does not support the ledger!')
+      throw new Error(MESSAGES.NOT_SUPPORTED)
     }
     const paths = await NeonLedger.list()
-    if (paths.length === 0) throw new Error('USB Error: No device found.')
+    if (paths.length === 0) throw new Error(MESSAGES.NOT_CONNECTED)
     const ledger = new NeonLedger(paths[0])
     return ledger.open()
   }


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
#1335 
**What problem does this PR solve?**
Enhances the user experience with a more intuitive login flow with Ledger.

**How did you solve this problem?**
I consolidated the different errors/states into 3 stages - NOT_CONNECTED, OPEN_APP, CONNECTED and created a new UI which shows these stages. (approved by Ben)

**How did you make sure your solution works?**
Tested a lot with the Ledger. It works great, however there are occasions where the Ledger would go to a previous stage when selecting NEO app from Ledger (just for a sec), and then shows all steps are complete.

**Are there any special changes in the code that we should be aware of?**
I have exported `neonLedger.js` error messages so I could handle them in the client side (perhaps his could be refactored into just error codes that the UI will handle instead of the ledger wrapper library)

**Is there anything else we should know?**
I have only tested with Ledger Nano S with latest version (firmware and NEO app) 

- [ ] Unit tests written?

<img width="633" alt="screen shot 2018-10-08 at 10 11 52 pm" src="https://user-images.githubusercontent.com/254095/46609878-ee452380-cb54-11e8-806d-7df32b60e85e.png">
