### PR TITLE
hides BrowserWindow until ready-to-show event

### DIFF
--- a/main.js
+++ b/main.js
@@ -39,11 +39,18 @@ app.on('ready', () => {
       minHeight: 850,
       minWidth: 1200,
       titleBarStyle: 'hidden',
+      show: false,
+      backgroundColor: '#e6e6e6',
       icon: path.join(__dirname, 'icons/png/64x64.png'),
       webPreferences: {
         allowRunningInsecureContent: false,
         webSecurity: true
       }
+    })
+
+    mainWindow.on('ready-to-show', () => {
+      mainWindow.show()
+      mainWindow.focus()
     })
 
     // https://discuss.atom.io/t/prevent-window-navigation-when-dropping-a-link/24365


### PR DESCRIPTION
This PR hides the window from the screen until the application is ready preventing the buggy looking white screen you currently see for about 10 seconds 
when opening the app.

**FIXES:**
<img width="1296" alt="screen shot 2018-10-13 at 12 27 52 pm" src="https://user-images.githubusercontent.com/13072035/46908687-ae2ec980-cee3-11e8-996d-68616662c935.png">