### PR TITLE
Add NNS name lookup to send screen address input

### DIFF
--- a/app/components/Send/SendPanel/SendRecipientList/SendRecipientList.scss
+++ b/app/components/Send/SendPanel/SendRecipientList/SendRecipientList.scss
@@ -50,6 +50,14 @@
   .address {
     width: 60%;
     margin-right: 8px;
+    position: relative;
+  }
+
+  .loader {
+    transform: scale(0.5);
+    left: auto;
+    top: 7%;
+    right: 7%;
   }
 
   .delete {

--- a/app/components/Send/SendPanel/SendRecipientList/SendRecipientListItem/index.jsx
+++ b/app/components/Send/SendPanel/SendRecipientList/SendRecipientListItem/index.jsx
@@ -30,11 +30,12 @@ type Props = {
 
 type State = {
   nnsError: string,
-  isNnsResolving: boolean,
+  isNnsResolving: boolean
 }
 
 class SendRecipientListItem extends Component<Props, State> {
-  state = { addressLabel: '', isNnsResolving: false }
+  state = { nnsError: '', isNnsResolving: false }
+
   nnsFetchTimeout = undefined
 
   handleFieldChange = (e: Object) => {
@@ -58,25 +59,27 @@ class SendRecipientListItem extends Component<Props, State> {
 
     const { name } = e.target
     let { value } = e.target
-    if (value > max) value = max
-    name === 'address' && this.setState({ nnsError: '' })
+    if (name === 'address') this.setState({ nnsError: '' })
     if (name === 'address' && value.endsWith('.neo')) {
       this.setState({ isNnsResolving: true })
-      this.nnsFetchTimeout && clearTimeout(this.nnsFetchTimeout)
+      if (this.nnsFetchTimeout) clearTimeout(this.nnsFetchTimeout)
       this.nnsFetchTimeout = setTimeout(() => {
         resolveNnsDomain(value)
-        .then(address => {
-          clearErrors(index, name)
-          this.setState({ isNnsResolving: false })
-          return updateRowField(index, name, address)
-        })
-        .catch(() => this.setState({
-          nnsError: 'NNS domain not found',
-          isNnsResolving: false
-        }))
+          .then(address => {
+            clearErrors(index, name)
+            this.setState({ isNnsResolving: false })
+            return updateRowField(index, name, address)
+          })
+          .catch(() =>
+            this.setState({
+              nnsError: 'NNS domain not found',
+              isNnsResolving: false
+            })
+          )
       }, 500)
     }
 
+    if (value > max) value = max
     clearErrors(index, name)
     return updateRowField(index, name, value)
   }
@@ -95,7 +98,7 @@ class SendRecipientListItem extends Component<Props, State> {
     const { name } = e.target
     const { clearErrors, index } = this.props
     clearErrors(index, name)
-    name === 'address' && this.setState({ nnsError: '' })
+    if (name === 'address') this.setState({ nnsError: '' })
   }
 
   createAssetList = (): Array<string> => Object.keys(this.props.sendableAssets)
@@ -113,7 +116,7 @@ class SendRecipientListItem extends Component<Props, State> {
       showConfirmSend,
       numberOfRecipients
     } = this.props
-    const { nnsError, isNnsResolving } = this.state;
+    const { nnsError, isNnsResolving } = this.state
 
     const selectInput = showConfirmSend ? (
       <DisplayInput value={asset} />
@@ -156,7 +159,7 @@ class SendRecipientListItem extends Component<Props, State> {
         items={this.createContactList()}
         customChangeEvent
         onFocus={this.clearErrorsOnFocus}
-        error={(errors.address) || nnsError}
+        error={errors.address || nnsError}
       />
     )
 

--- a/app/components/Send/SendPanel/SendRecipientList/SendRecipientListItem/index.jsx
+++ b/app/components/Send/SendPanel/SendRecipientList/SendRecipientListItem/index.jsx
@@ -36,7 +36,7 @@ type State = {
 class SendRecipientListItem extends Component<Props, State> {
   state = { nnsError: '', isNnsResolving: false }
 
-  nnsFetchTimeout = undefined
+  debounceTimer = undefined
 
   handleFieldChange = (e: Object) => {
     const {
@@ -62,8 +62,8 @@ class SendRecipientListItem extends Component<Props, State> {
     if (name === 'address') this.setState({ nnsError: '' })
     if (name === 'address' && value.endsWith('.neo')) {
       this.setState({ isNnsResolving: true })
-      if (this.nnsFetchTimeout) clearTimeout(this.nnsFetchTimeout)
-      this.nnsFetchTimeout = setTimeout(() => {
+      if (this.debounceTimer) clearTimeout(this.debounceTimer)
+      this.debounceTimer = setTimeout(() => {
         resolveNnsDomain(value)
           .then(address => {
             clearErrors(index, name)

--- a/app/components/Send/SendPanel/SendRecipientList/SendRecipientListItem/index.jsx
+++ b/app/components/Send/SendPanel/SendRecipientList/SendRecipientListItem/index.jsx
@@ -1,10 +1,12 @@
 // @flow
 import React, { Component } from 'react'
+import { resolveNnsDomain } from '../../../../../util/nns'
 
 import SelectInput from '../../../../Inputs/SelectInput'
 import NumberInput from '../../../../Inputs/NumberInput'
 import TextInput from '../../../../Inputs/TextInput'
 import DisplayInput from '../../../DisplayInput'
+import Loader from '../../../../Loader'
 
 import TrashCanIcon from '../../../../../assets/icons/delete.svg'
 
@@ -26,7 +28,15 @@ type Props = {
   updateRowField: (index: number, field: string, value: any) => any
 }
 
-class SendRecipientListItem extends Component<Props> {
+type State = {
+  nnsError: string,
+  isNnsResolving: boolean,
+}
+
+class SendRecipientListItem extends Component<Props, State> {
+  state = { addressLabel: '', isNnsResolving: false }
+  nnsFetchTimeout = undefined
+
   handleFieldChange = (e: Object) => {
     const {
       index,
@@ -49,6 +59,24 @@ class SendRecipientListItem extends Component<Props> {
     const { name } = e.target
     let { value } = e.target
     if (value > max) value = max
+    name === 'address' && this.setState({ nnsError: '' })
+    if (name === 'address' && value.endsWith('.neo')) {
+      this.setState({ isNnsResolving: true })
+      this.nnsFetchTimeout && clearTimeout(this.nnsFetchTimeout)
+      this.nnsFetchTimeout = setTimeout(() => {
+        resolveNnsDomain(value)
+        .then(address => {
+          clearErrors(index, name)
+          this.setState({ isNnsResolving: false })
+          return updateRowField(index, name, address)
+        })
+        .catch(() => this.setState({
+          nnsError: 'NNS domain not found',
+          isNnsResolving: false
+        }))
+      }, 500)
+    }
+
     clearErrors(index, name)
     return updateRowField(index, name, value)
   }
@@ -67,6 +95,7 @@ class SendRecipientListItem extends Component<Props> {
     const { name } = e.target
     const { clearErrors, index } = this.props
     clearErrors(index, name)
+    name === 'address' && this.setState({ nnsError: '' })
   }
 
   createAssetList = (): Array<string> => Object.keys(this.props.sendableAssets)
@@ -84,6 +113,7 @@ class SendRecipientListItem extends Component<Props> {
       showConfirmSend,
       numberOfRecipients
     } = this.props
+    const { nnsError, isNnsResolving } = this.state;
 
     const selectInput = showConfirmSend ? (
       <DisplayInput value={asset} />
@@ -126,7 +156,7 @@ class SendRecipientListItem extends Component<Props> {
         items={this.createContactList()}
         customChangeEvent
         onFocus={this.clearErrorsOnFocus}
-        error={errors.address}
+        error={(errors.address) || nnsError}
       />
     )
 
@@ -146,7 +176,10 @@ class SendRecipientListItem extends Component<Props> {
         <div className={styles.rowNumber}>{`${`0${index + 1}`.slice(-2)}`}</div>
         <div className={styles.asset}>{selectInput}</div>
         <div className={styles.amount}>{numberInput}</div>
-        <div className={styles.address}>{addressInput}</div>
+        <div className={styles.address}>
+          {addressInput}
+          {isNnsResolving && <Loader className={styles.loader} />}
+        </div>
         <div className={styles.delete}>
           {numberOfRecipients > 1 && trashCanButton}
         </div>

--- a/app/util/nns.js
+++ b/app/util/nns.js
@@ -1,0 +1,9 @@
+import { rpc } from 'neon-js'
+
+export const resolveNnsDomain = name => {
+  return rpc.queryRPC('https://apiwallet.nel.group/api/mainnet', {
+    method: 'getresolvedaddress',
+    params: [name]
+  })
+  .then(data => data.result[0].data)
+}

--- a/app/util/nns.js
+++ b/app/util/nns.js
@@ -1,9 +1,9 @@
 import { rpc } from 'neon-js'
 
-export const resolveNnsDomain = name => {
-  return rpc.queryRPC('https://apiwallet.nel.group/api/mainnet', {
-    method: 'getresolvedaddress',
-    params: [name]
-  })
-  .then(data => data.result[0].data)
-}
+export const resolveNnsDomain = name =>
+  rpc
+    .queryRPC('https://apiwallet.nel.group/api/mainnet', {
+      method: 'getresolvedaddress',
+      params: [name]
+    })
+    .then(data => data.result[0].data)


### PR DESCRIPTION
This implements a name to address resolutions using NEO Name Service.

When a user inputs a `.neo` domain name into the address field on the send screen, a quick attempt will be made to resolve it to an address. If successful, the field will be populated with the appropriate address. If the name is not found a error message will display on the input field.

![screen recording 2018-10-16 at 03 16 am](https://user-images.githubusercontent.com/6342442/46969726-f58aa500-d0f1-11e8-86b8-e7df7a4ea8b1.gif)
