### PR TITLE
Update NNS domain resolver to direct contract call

### DIFF
--- a/app/components/Send/SendPanel/SendRecipientList/SendRecipientListItem/index.jsx
+++ b/app/components/Send/SendPanel/SendRecipientList/SendRecipientListItem/index.jsx
@@ -1,10 +1,12 @@
 // @flow
 import React, { Component } from 'react'
+import { resolveNnsDomain } from '../../../../../util/nns'
 
 import SelectInput from '../../../../Inputs/SelectInput'
 import NumberInput from '../../../../Inputs/NumberInput'
 import TextInput from '../../../../Inputs/TextInput'
 import DisplayInput from '../../../DisplayInput'
+import Loader from '../../../../Loader'
 
 import TrashCanIcon from '../../../../../assets/icons/delete.svg'
 
@@ -26,7 +28,16 @@ type Props = {
   updateRowField: (index: number, field: string, value: any) => any
 }
 
-class SendRecipientListItem extends Component<Props> {
+type State = {
+  nnsError: string,
+  isNnsResolving: boolean
+}
+
+class SendRecipientListItem extends Component<Props, State> {
+  state = { nnsError: '', isNnsResolving: false }
+
+  debounceTimer = undefined
+
   handleFieldChange = (e: Object) => {
     const {
       index,
@@ -48,6 +59,26 @@ class SendRecipientListItem extends Component<Props> {
 
     const { name } = e.target
     let { value } = e.target
+    if (name === 'address') this.setState({ nnsError: '' })
+    if (name === 'address' && value.endsWith('.neo')) {
+      this.setState({ isNnsResolving: true })
+      if (this.debounceTimer) clearTimeout(this.debounceTimer)
+      this.debounceTimer = setTimeout(() => {
+        resolveNnsDomain(value)
+          .then(address => {
+            clearErrors(index, name)
+            this.setState({ isNnsResolving: false })
+            return updateRowField(index, name, address)
+          })
+          .catch(() =>
+            this.setState({
+              nnsError: 'NNS domain not found',
+              isNnsResolving: false
+            })
+          )
+      }, 500)
+    }
+
     if (value > max) value = max
     clearErrors(index, name)
     return updateRowField(index, name, value)
@@ -67,6 +98,7 @@ class SendRecipientListItem extends Component<Props> {
     const { name } = e.target
     const { clearErrors, index } = this.props
     clearErrors(index, name)
+    if (name === 'address') this.setState({ nnsError: '' })
   }
 
   createAssetList = (): Array<string> => Object.keys(this.props.sendableAssets)
@@ -84,6 +116,7 @@ class SendRecipientListItem extends Component<Props> {
       showConfirmSend,
       numberOfRecipients
     } = this.props
+    const { nnsError, isNnsResolving } = this.state
 
     const selectInput = showConfirmSend ? (
       <DisplayInput value={asset} />
@@ -126,7 +159,7 @@ class SendRecipientListItem extends Component<Props> {
         items={this.createContactList()}
         customChangeEvent
         onFocus={this.clearErrorsOnFocus}
-        error={errors && errors.address}
+        error={errors.address || nnsError}
       />
     )
 
@@ -146,7 +179,10 @@ class SendRecipientListItem extends Component<Props> {
         <div className={styles.rowNumber}>{`${`0${index + 1}`.slice(-2)}`}</div>
         <div className={styles.asset}>{selectInput}</div>
         <div className={styles.amount}>{numberInput}</div>
-        <div className={styles.address}>{addressInput}</div>
+        <div className={styles.address}>
+          {addressInput}
+          {isNnsResolving && <Loader className={styles.loader} />}
+        </div>
         <div className={styles.delete}>
           {numberOfRecipients > 1 && trashCanButton}
         </div>

--- a/app/util/nns.js
+++ b/app/util/nns.js
@@ -1,9 +1,47 @@
-import { rpc } from 'neon-js'
+import Neon, { rpc, api, sc, u } from 'neon-js'
 
-export const resolveNnsDomain = name =>
-  rpc
-    .queryRPC('https://apiwallet.nel.group/api/mainnet', {
-      method: 'getresolvedaddress',
-      params: [name]
+export const resolveNnsDomain = name => {
+  const protocol = {
+    type: 'String',
+    value: 'addr'
+  }
+
+  const empty = {
+    type: 'String',
+    value: ''
+  }
+
+  const subdomain = name.replace(/.neo$/, '')
+  const hashSubdomain = u.sha256(u.str2hexstring(subdomain))
+  const hashDomain = u.sha256(u.str2hexstring('neo'))
+
+  const hashName = u.sha256(hashSubdomain.concat(hashDomain))
+  const parsedName = sc.ContractParam.byteArray(hashName, 'name')
+
+  const scriptHash = '348387116c4a75e420663277d9c02049907128c7'
+  const operation = 'resolve'
+  const args = [protocol, parsedName, empty]
+
+  const props = {
+    scriptHash,
+    operation,
+    args
+  }
+
+  return api
+    .fillUrl({
+      net: 'MainNet',
+      address: ''
     })
-    .then(data => data.result[0].data)
+    .then(config => {
+      const script = Neon.create.script(props)
+      const invokeScript = rpc.Query.invokeScript(script)
+      const execution = invokeScript.execute(config.url)
+      return execution
+    })
+    .then(res => res.result.stack[0].value)
+    .then(value => {
+      if (value === '00') throw new Error('No domain found.')
+      return Neon.u.hexstring2str(value)
+    })
+}


### PR DESCRIPTION
This PP adds back the UI on the send screen for domain name resolution, and updates the calls for resolution to be direct contract calls rather than using the NEL API.

The same logic is in the process of being added to `neon-js` as a plugin, but the `design-v2` branch of `neon-wallet` is only compatible up to version v3.11.0. So upgrading to the next iteration to include the [soon to be](https://github.com/CityOfZion/neon-js/pull/328) `neon-nns` plugin will require more potential updates to `neon-wallet` than are in the scope of just the name service integration.

At such a time where `neon-wallet` us updated to the latest version of `neon-js` with the future plugin, the contract call logic can simply be replaced with the plugin.