### PR TITLE
fix(ledger): Fixes TX denied error message

### DIFF
--- a/app/ledger/neonLedger.js
+++ b/app/ledger/neonLedger.js
@@ -18,7 +18,7 @@ export const MESSAGES = {
   NOT_CONNECTED: 'Connect and unlock your Ledger device',
   APP_CLOSED: 'Navigate to the NEO app on your Ledger device',
   MSG_TOO_BIG: 'Your transaction is too big for the Ledger to sign',
-  TX_DENIED: 'Your transaction is too big for the Ledger to sign',
+  TX_DENIED: 'You have denied the transaction on your ledger',
   TX_PARSE_ERR:
     'Error parsing transaction. Make sure your NEO Ledger app version is up to date'
 }


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
#1519 

**What problem does this PR solve?**
Amends the text when denying on ledger

**How did you solve this problem?**
Amended the tx in `neonLedger.js` for the TX_DENIED message code.

**How did you make sure your solution works?**
<img width="721" alt="screen shot 2018-10-19 at 8 45 59 pm" src="https://user-images.githubusercontent.com/254095/47211085-5d860780-d3e0-11e8-8406-21c19a5481ee.png">


**Are there any special changes in the code that we should be aware of?**
No

**Is there anything else we should know?**
No

- [ ] Unit tests written?
