### PR TITLE
fix(ledger): Fixes ledger confirmation when sending a tx

### DIFF
--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -62,8 +62,7 @@ export const NOTIFICATION_POSITIONS = {
   BOTTOM_LEFT: 'bl'
 }
 
-export const BIP44_PATH =
-  '8000002C' + '80000378' + '80000000' + '00000000' + '00000000' // eslint-disable-line
+export const BIP44_PATH = '8000002C' + '80000378' + '80000000' + '00000000' // eslint-disable-line
 
 export const MODAL_TYPES = {
   SEND: 'SEND',


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
#1516 

**What problem does this PR solve?**
Fixes ledger confirmation when sending assets.

**How did you solve this problem?**
The `BIP44_PATH` constant contained a default account `00000000` (probably from legacy code). The BIP44 function in the ledger code already adds the account... so this resulted in an invalid message being passed to the ledger.

**How did you make sure your solution works?**
Tested on one asset (GAS) with and without a priority free.

<img width="1117" alt="screen shot 2018-10-19 at 11 36 15 pm" src="https://user-images.githubusercontent.com/254095/47218807-b2357c80-d3f8-11e8-9abe-f70d475e4618.png">
<img width="1109" alt="screen shot 2018-10-19 at 11 39 14 pm" src="https://user-images.githubusercontent.com/254095/47218808-b2ce1300-d3f8-11e8-8af3-633e5025859a.png">

**Are there any special changes in the code that we should be aware of?**
No.

**Is there anything else we should know?**
Sending multiple assets seem not to work correctly, but this is not related to the issue.

- [ ] Unit tests written?
