### PR TITLE
fix(settings): Removes search from network/block explorer selection

### DIFF
--- a/app/containers/Settings/Settings.jsx
+++ b/app/containers/Settings/Settings.jsx
@@ -221,6 +221,7 @@ export default class Settings extends Component<Props, State> {
                       this.props.handleNetworkChange(selectedNetwork.id)
                     )
                   }
+                  isSearchable={false}
                 />
               </div>
             </SettingsItem>
@@ -235,6 +236,7 @@ export default class Settings extends Component<Props, State> {
                   options={parsedExplorerOptions}
                   value={this.state.selectedExplorer}
                   onChange={this.updateExplorerSettings}
+                  isSearchable={false}
                 />
               </div>
             </SettingsItem>


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
Removes the search option from network / block explorer selection in settings. I have consulted with @comountainclimber about this and we agreed that a search shouldn't be for network / block explorer as these have very few options.

**How did you solve this problem?**
Added `isSearchable={false}` to the React Select component.

**How did you make sure your solution works?**
Tested it manually

**Are there any special changes in the code that we should be aware of?**
No

**Is there anything else we should know?**
No

- [ ] Unit tests written?
