### PR TITLE
fix(amounts-panel): Removes asset filtering from amounts panel when sending

### DIFF
--- a/app/containers/Send/Send.jsx
+++ b/app/containers/Send/Send.jsx
@@ -115,21 +115,8 @@ export default class Send extends React.Component<Props, State> {
   // TODO: Move this logic to AmountsPanel / Centralized place
   createSendAmountsData = () => {
     const { sendableAssets, prices } = this.props
-    const { showConfirmSend, sendSuccess, sendRowDetails } = this.state
 
-    let assets = Object.keys(sendableAssets)
-
-    if (showConfirmSend || sendSuccess) {
-      assets = (assets.filter((asset: string) =>
-        sendRowDetails
-          .reduce(
-            (accumulator: Array<*>, row: Object) =>
-              accumulator.concat(row.asset),
-            []
-          )
-          .includes(asset)
-      ): Array<*>)
-    }
+    const assets = Object.keys(sendableAssets)
 
     return (assets.map((asset: string) => {
       const { balance } = sendableAssets[asset]


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
The amounts panel was filtered when a send was initiated resulting in a very weird UI experience.

**How did you solve this problem?**
Removed filtering when sending/confirming the assets.

**How did you make sure your solution works?**
Tested manually

**Are there any special changes in the code that we should be aware of?**
No

**Is there anything else we should know?**
No

- [ ] Unit tests written?
