### PR TITLE
feat(amounts-panel): Adds a tooltip and truncation for asset balances

### DIFF
--- a/app/components/AmountsPanel/AmountsInfoBox/AmountsInfoBox.scss
+++ b/app/components/AmountsPanel/AmountsInfoBox/AmountsInfoBox.scss
@@ -30,6 +30,12 @@
   .assetWorth {
     font-family: Gotham-Book;
   }
+
+  .assetName,
+  .assetAmount,
+  .assetWorth {
+    white-space: nowrap;
+  }
 }
 
 .amountsInSingleRow {

--- a/app/components/AmountsPanel/AmountsInfoBox/AmountsInfoBox.scss
+++ b/app/components/AmountsPanel/AmountsInfoBox/AmountsInfoBox.scss
@@ -13,7 +13,7 @@
   justify-content: space-between;
 
   .assetName {
-    padding-right: 15px;
+    padding-right: 10px;
     font-family: Gotham-Light;
     font-size: 14px;
     position: relative;

--- a/app/components/AmountsPanel/AmountsInfoBox/index.jsx
+++ b/app/components/AmountsPanel/AmountsInfoBox/index.jsx
@@ -3,7 +3,8 @@ import React from 'react'
 import { isNumber } from 'lodash-es'
 import classNames from 'classnames'
 import { PRICE_UNAVAILABLE } from '../../../core/constants'
-import { imageMap } from '../../../assets/nep5/png'
+import { truncateNumber } from '../../../core/math'
+import Tooltip from '../../Tooltip'
 
 import styles from './AmountsInfoBox.scss'
 
@@ -15,26 +16,40 @@ type Props = {
   className: string
 }
 
+const DECIMAL_PLACES = 2
+
 const AmountsInfoBox = ({
   assetName,
   totalAmount,
   totalBalanceWorth,
   fiatCurrencySymbol,
   className
-}: Props) => (
-  <div className={classNames(styles.amountsInfoBox, className)}>
-    <span>
-      <span className={styles.assetName}>{assetName}</span>
-      <span className={styles.assetAmount}>
-        <strong>{totalAmount}</strong>
+}: Props) => {
+  const totalAmountNumeric = Number(totalAmount)
+  const totalAmountIsInteger = Number.isInteger(totalAmountNumeric)
+  return (
+    <div className={classNames(styles.amountsInfoBox, className)}>
+      <span>
+        <span className={styles.assetName}>{assetName}</span>
+        <Tooltip title={totalAmount} disabled={totalAmountIsInteger}>
+          <span className={styles.assetAmount}>
+            <strong>
+              {totalAmountIsInteger
+                ? totalAmount
+                : truncateNumber(totalAmountNumeric, DECIMAL_PLACES).toFixed(
+                    DECIMAL_PLACES
+                  )}
+            </strong>
+          </span>
+        </Tooltip>
       </span>
-    </span>
-    <span className={styles.assetWorth}>
-      {isNumber(totalBalanceWorth)
-        ? `${fiatCurrencySymbol} ${totalBalanceWorth.toFixed(2)}`
-        : totalBalanceWorth}
-    </span>
-  </div>
-)
+      <span className={styles.assetWorth}>
+        {isNumber(totalBalanceWorth)
+          ? `${fiatCurrencySymbol} ${totalBalanceWorth.toFixed(DECIMAL_PLACES)}`
+          : totalBalanceWorth}
+      </span>
+    </div>
+  )
+}
 
 export default AmountsInfoBox


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Reported by @Ejhfast 

**What problem does this PR solve?**
Shows a tooltip when hovering on assets that were truncated (set to 2 decimal places)

**How did you solve this problem?**
I used the `truncateNumber` method along with `toFixed` to ensure that the there is no rounding bugs.

**How did you make sure your solution works?**
Tested manually.

<img width="1109" alt="screen shot 2018-10-20 at 11 22 35 pm" src="https://user-images.githubusercontent.com/254095/47255622-fe97bf80-d4bf-11e8-9442-d62484f94657.png">


**Are there any special changes in the code that we should be aware of?**
No.

**Is there anything else we should know?**
No.

- [ ] Unit tests written?
