### PR TITLE
fix(amounts-panel): Use 4 tokens in a row and remove extra spacing

### DIFF
--- a/app/components/AmountsPanel/AmountsInfoBox/AmountsInfoBox.scss
+++ b/app/components/AmountsPanel/AmountsInfoBox/AmountsInfoBox.scss
@@ -3,7 +3,7 @@
 .amountsInfoBox {
   display: flex;
   align-items: center;
-  flex-basis: 20%;
+  flex-basis: 25%;
   padding: 0 12px;
   box-sizing: border-box;
   font-size: 14px;
@@ -13,7 +13,7 @@
   justify-content: space-between;
 
   .assetName {
-    padding-right: 15px;
+    padding-right: 10px;
     font-family: Gotham-Light;
     font-size: 14px;
     position: relative;
@@ -29,6 +29,12 @@
 
   .assetWorth {
     font-family: Gotham-Book;
+  }
+
+  .assetName,
+  .assetAmount,
+  .assetWorth {
+    white-space: nowrap;
   }
 }
 

--- a/app/components/AmountsPanel/AmountsInfoBox/index.jsx
+++ b/app/components/AmountsPanel/AmountsInfoBox/index.jsx
@@ -31,7 +31,7 @@ const AmountsInfoBox = ({
     </span>
     <span className={styles.assetWorth}>
       {isNumber(totalBalanceWorth)
-        ? `${fiatCurrencySymbol} ${totalBalanceWorth.toFixed(2)}`
+        ? `${fiatCurrencySymbol}${totalBalanceWorth.toFixed(2)}`
         : totalBalanceWorth}
     </span>
   </div>

--- a/app/components/AmountsPanel/index.jsx
+++ b/app/components/AmountsPanel/index.jsx
@@ -25,8 +25,8 @@ type Props = {
 
 const ORDER_BY_FIELD = 'totalBalanceWorth'
 const ORDERY_BY_DIRECTION = 'desc'
-const RESULTS_PER_ROW = 5
-const MAX_RESULTS = 10
+const RESULTS_PER_ROW = 4
+const MAX_RESULTS = 8
 
 const validateAmountDataItem = (amountDataItem: AmountDataItem) =>
   has(amountDataItem, 'symbol') &&


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Reported by @Ejhfast

**What problem does this PR solve?**
By showing only 4 tokens and the removal of extra spacing it is now possible to show the full balance amount without collapsing the rows.

**How did you solve this problem?**
Set max tokens per row - 4 (max 8 tokens), removed the extra spacing for the fiat symbol and reduced padding of the token symbol.

**How did you make sure your solution works?**
Tested manually for 4-8 tokens.

**Are there any special changes in the code that we should be aware of?**
No.

**Is there anything else we should know?**
No.

- [ ] Unit tests written?
