### PR TITLE
feature/updates settings logic

### DIFF
--- a/app/actions/balancesActions.js
+++ b/app/actions/balancesActions.js
@@ -25,7 +25,7 @@ async function getBalances({ net, address, tokens }: Props) {
 
   const chunks = tokens
     .filter(token => !token.isUserGenerated)
-    .reduce((accum, currVal, index) => {
+    .reduce((accum, currVal) => {
       if (!accum.length) {
         accum.push([currVal.scriptHash])
         return accum

--- a/app/actions/settingsActions.js
+++ b/app/actions/settingsActions.js
@@ -1,5 +1,5 @@
 // @flow
-import { pick, keys, uniqBy } from 'lodash-es'
+import { pick, keys, uniqBy, cloneDeep } from 'lodash-es'
 import { createActions } from 'spunky'
 
 import { getStorage, setStorage } from '../core/storage'
@@ -62,8 +62,14 @@ export const updateSettingsActions = createActions(
       ...settings,
       ...values
     }
-    await setStorage(STORAGE_KEY, newSettings)
-
+    const parsedForLocalStorage = cloneDeep(newSettings)
+    const tokensForStorage = [
+      ...newSettings.tokens.filter(token => token.isUserGenerated)
+    ]
+    // NOTE: we only save user generated tokens to local storage to avoid
+    // conflicts in managing the "master" nep5 list
+    parsedForLocalStorage.tokens = tokensForStorage
+    await setStorage(STORAGE_KEY, parsedForLocalStorage)
     return newSettings
   }
 )

--- a/app/core/tokenList.json
+++ b/app/core/tokenList.json
@@ -581,21 +581,6 @@
     "image":
       "https://rawgit.com/CityOfZion/neo-tokens/master/assets/png/rht.png"
   },
-  "RPX": {
-    "symbol": "RPX",
-    "companyName": "Red Pulse Token",
-    "type": "NEP5",
-    "networks": {
-      "1": {
-        "name": "Red Pulse Token",
-        "hash": "ecc6b20d3ccac1ee9ef109af5a7cdb85706b1df9",
-        "decimals": 8,
-        "totalSupply": 1358371250
-      }
-    },
-    "image":
-      "https://rawgit.com/CityOfZion/neo-tokens/master/assets/svg/rpx.svg"
-  },
   "SCC": {
     "symbol": "SCC",
     "companyName": "Stem Cell Coin",


### PR DESCRIPTION
- Previously we were saving the entire list of tokens to a users local storage... I noticed the potential for issues for instance if a token is removed from our list it would have always been persisted to storage with no way for a user to remove it _even if our team had removed it_ 
- This PR also removes RPX from our official list of nep5 tokens https://medium.com/switcheo/important-redpulse-rpx-phoenix-phx-token-swap-notice-f589393ee05f
