### PR TITLE
fix(transaction): Network fees font/alignment

### DIFF
--- a/app/components/Blockchain/Transaction/Transaction.jsx
+++ b/app/components/Blockchain/Transaction/Transaction.jsx
@@ -123,7 +123,7 @@ export default class Transaction extends React.Component<Props> {
             <div className={styles.txAmountContainer}>{amount}</div>
             <div className={styles.txToContainer}>
               {isNetworkFee ? (
-                <div className={styles.largerFont}> {to} </div>
+                to
               ) : (
                 <Fragment>
                   {this.findContact(to)}


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
Network fee type was centered and had a larger font than the other types such as mint.. this created an inconsistency in the way the screen is rendered. (please see attached screenshot)

**How did you solve this problem?**
Removed the class that had these styling.

**How did you make sure your solution works?**
Manually tested it

**Are there any special changes in the code that we should be aware of?**
No

**Is there anything else we should know?**
I wasn't sure if this was the intended behavior... but in my view, this should be consistent.

Before: 
<img width="1303" alt="screen shot 2018-10-28 at 10 31 04 pm" src="https://user-images.githubusercontent.com/254095/47615379-34f9be00-db02-11e8-99a5-90daa3e2d104.png">

After:
<img width="1078" alt="screen shot 2018-10-28 at 10 33 56 pm" src="https://user-images.githubusercontent.com/254095/47615412-8609b200-db02-11e8-8e42-83d10013c168.png">
