### PR TITLE
fix(transactions): disables mint tokens address from being added as a contact + cleanups

### DIFF
--- a/app/components/Blockchain/Transaction/Transaction.jsx
+++ b/app/components/Blockchain/Transaction/Transaction.jsx
@@ -79,6 +79,12 @@ export default class Transaction extends React.Component<Props> {
   renderAbstract = (type: string) => {
     const { tx } = this.props
     const { iconType, time, label, amount, isNetworkFee, to, from } = tx
+
+    const formattedTime = moment.unix(time).format('MM/DD/YYYY | HH:MM:ss')
+
+    const contactTo = this.findContact(to)
+    const contactToExists = contactTo !== to
+
     switch (type) {
       case 'CLAIM':
         return (
@@ -88,15 +94,13 @@ export default class Transaction extends React.Component<Props> {
                 <ClaimIcon />
               </div>
             </div>
-            <div className={styles.txDateContainer}>
-              {moment.unix(time).format('MM/DD/YYYY | HH:MM:ss')}
-            </div>
+            <div className={styles.txDateContainer}>{formattedTime}</div>
             <div className={styles.txLabelContainer}>{label}</div>
             <div className={styles.txAmountContainer}>{amount}</div>
             <div className={styles.txToContainer}>
               <Fragment>
-                {this.findContact(to)}
-                {this.findContact(to) === to && (
+                {contactTo}
+                {!contactToExists && (
                   <CopyToClipboard
                     className={styles.copy}
                     text={to}
@@ -116,9 +120,7 @@ export default class Transaction extends React.Component<Props> {
                 <SendIcon />
               </div>
             </div>
-            <div className={styles.txDateContainer}>
-              {moment.unix(time).format('MM/DD/YYYY | HH:MM:ss')}
-            </div>
+            <div className={styles.txDateContainer}>{formattedTime}</div>
             <div className={styles.txLabelContainer}>{label}</div>
             <div className={styles.txAmountContainer}>{amount}</div>
             <div className={styles.txToContainer}>
@@ -126,8 +128,8 @@ export default class Transaction extends React.Component<Props> {
                 <div className={styles.largerFont}> {to} </div>
               ) : (
                 <Fragment>
-                  {this.findContact(to)}
-                  {this.findContact(to) === to && (
+                  {contactTo}
+                  {!contactToExists && (
                     <CopyToClipboard
                       className={styles.copy}
                       text={to}
@@ -144,14 +146,18 @@ export default class Transaction extends React.Component<Props> {
                 className={styles.transactionHistoryButton}
                 renderIcon={ContactsAdd}
                 onClick={this.displayModal}
-                disabled={this.findContact(to) !== to}
+                disabled={contactToExists}
               >
                 Add
               </Button>
             )}
           </div>
         )
-      case 'RECEIVE':
+      case 'RECEIVE': {
+        const contactFrom = this.findContact(from)
+        const contactFromExists = contactFrom !== from
+        const isMintTokens = from === 'MINT TOKENS'
+
         return (
           <div className={styles.abstractContainer}>
             <div className={styles.txTypeIconContainer}>
@@ -159,15 +165,13 @@ export default class Transaction extends React.Component<Props> {
                 <ReceiveIcon />
               </div>
             </div>
-            <div className={styles.txDateContainer}>
-              {moment.unix(time).format('MM/DD/YYYY | HH:MM:ss')}
-            </div>
+            <div className={styles.txDateContainer}>{formattedTime}</div>
             <div className={styles.txLabelContainer}>{label}</div>
             <div className={styles.txAmountContainer}>{amount}</div>
             <div className={styles.txToContainer}>
-              {this.findContact(from)}
-              {this.findContact(from) === from &&
-                from !== 'MINT TOKENS' && (
+              {contactFrom}
+              {!contactFromExists &&
+                !isMintTokens && (
                   <CopyToClipboard
                     className={styles.copy}
                     text={from}
@@ -175,19 +179,21 @@ export default class Transaction extends React.Component<Props> {
                   />
                 )}
             </div>
-            {this.findContact(from) !== from ? (
+            {isMintTokens ? (
               <div className={styles.transactionHistoryButton} />
             ) : (
               <Button
                 className={styles.transactionHistoryButton}
                 renderIcon={ContactsAdd}
                 onClick={this.displayModal}
+                disabled={contactFromExists}
               >
                 Add
               </Button>
             )}
           </div>
         )
+      }
 
       default:
         console.warn('renderTxTypeIcon() invoked with an invalid argument!', {


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
1. Disables mint tokens address from being added as a contact. (the address "MINT TOKENS" is invalid anyway).
2. The "Add" was inconsistent for an existing contact for the send/receive sections... Basically, the receive section would remove the "Add" button while the send would just disable it. I disabled it in both cases.
3. Code cleanups.


**How did you make sure your solution works?**
Manually tested it

**Are there any special changes in the code that we should be aware of?**
No

**Is there anything else we should know?**
No

Before:
<img width="1070" alt="screen shot 2018-10-28 at 10 35 03 pm" src="https://user-images.githubusercontent.com/254095/47617185-dd1a8180-db18-11e8-8642-1c65f6a5cd19.png">

After: 
<img width="1310" alt="screen shot 2018-10-29 at 1 23 26 am" src="https://user-images.githubusercontent.com/254095/47617236-4601f980-db19-11e8-8f54-04d122ab3a60.png">
