### PR TITLE
fix(explorer): fixes broken antchain tx link + cleanups

### DIFF
--- a/__tests__/core/explorer.test.js
+++ b/__tests__/core/explorer.test.js
@@ -1,4 +1,8 @@
-import { getExplorerTxLink, openExplorerTx } from '../../app/core/explorer'
+import {
+  getExplorerAddressLink,
+  getExplorerTxLink,
+  openExplorerTx
+} from '../../app/core/explorer'
 import {
   MAIN_NETWORK_ID,
   TEST_NETWORK_ID,
@@ -7,53 +11,58 @@ import {
 import { shell } from 'electron'
 
 describe('explorer tests', () => {
+  const txId =
+    '33e6dad17f65564222d697923558792feda7847644f1810e6b389106335a7de0'
+  const address = 'AQpLnwMpnhxroPM4fcYGenB2pH5cLhMDao'
+
   describe('getExplorerTxLink tests', () => {
     test('NeoTracker mainnet explorer test', () => {
       const networkId = MAIN_NETWORK_ID
       const explorer = EXPLORERS.NEO_TRACKER
-      const txId = '1234567890abcdef'
-      const expectedUrl = 'https://neotracker.io/tx/1234567890abcdef'
+      const expectedUrl = `https://neotracker.io/tx/${txId}`
+
       expect(getExplorerTxLink(networkId, explorer, txId)).toEqual(expectedUrl)
     })
 
     test('NeoTracker testnet explorer test', () => {
       const networkId = TEST_NETWORK_ID
       const explorer = EXPLORERS.NEO_TRACKER
-      const txId = '1234567890abcdef'
-      const expectedUrl = 'https://testnet.neotracker.io/tx/1234567890abcdef'
+      const expectedUrl = `https://testnet.neotracker.io/tx/${txId}`
+
       expect(getExplorerTxLink(networkId, explorer, txId)).toEqual(expectedUrl)
     })
 
     test('NeoScan mainnet explorer test', () => {
       const networkId = MAIN_NETWORK_ID
       const explorer = EXPLORERS.NEO_SCAN
-      const txId = '1234567890abcdef'
-      const expectedUrl = 'https://neoscan.io/transaction/1234567890abcdef'
+      const expectedUrl = `https://neoscan.io/transaction/${txId}`
+
       expect(getExplorerTxLink(networkId, explorer, txId)).toEqual(expectedUrl)
     })
 
     test('NeoScan testnet explorer test', () => {
       const networkId = TEST_NETWORK_ID
       const explorer = EXPLORERS.NEO_SCAN
-      const txId = '1234567890abcdef'
-      const expectedUrl =
-        'https://neoscan-testnet.io/transaction/1234567890abcdef'
+      const expectedUrl = `https://neoscan-testnet.io/transaction/${txId}`
+
       expect(getExplorerTxLink(networkId, explorer, txId)).toEqual(expectedUrl)
     })
 
     test('AntChain mainnet explorer test', () => {
       const networkId = MAIN_NETWORK_ID
       const explorer = EXPLORERS.ANT_CHAIN
-      const txId = '1234567890abcdef'
-      const expectedUrl = 'http://antcha.in/tx/hash/1234567890abcdef'
+      const expectedUrl =
+        'http://antcha.in/tx/hash/0x33e6dad17f65564222d697923558792feda7847644f1810e6b389106335a7de0'
+
       expect(getExplorerTxLink(networkId, explorer, txId)).toEqual(expectedUrl)
     })
 
     test('AntChain testnet explorer test', () => {
       const networkId = TEST_NETWORK_ID
       const explorer = EXPLORERS.ANT_CHAIN
-      const txId = '1234567890abcdef'
-      const expectedUrl = 'http://testnet.antcha.in/tx/hash/1234567890abcdef'
+      const expectedUrl =
+        'http://testnet.antcha.in/tx/hash/0x33e6dad17f65564222d697923558792feda7847644f1810e6b389106335a7de0'
+
       expect(getExplorerTxLink(networkId, explorer, txId)).toEqual(expectedUrl)
     })
   })
@@ -62,12 +71,74 @@ describe('explorer tests', () => {
     test('open NeoTracker mainnet explorer test', () => {
       const networkId = MAIN_NETWORK_ID
       const explorer = EXPLORERS.NEO_TRACKER
-      const txId = '1234567890abcdef'
-      const expectedUrl = 'https://neotracker.io/tx/1234567890abcdef'
+      const expectedUrl = `https://neotracker.io/tx/${txId}`
       const spy = jest.spyOn(shell, 'openExternal')
 
       openExplorerTx(networkId, explorer, txId)
+
       expect(spy).toHaveBeenCalledWith(expectedUrl)
+    })
+  })
+
+  describe('getExplorerAddressLink tests', () => {
+    test('NeoTracker mainnet explorer test', () => {
+      const networkId = MAIN_NETWORK_ID
+      const explorer = EXPLORERS.NEO_TRACKER
+      const expectedUrl = `https://neotracker.io/address/${address}`
+
+      expect(getExplorerAddressLink(networkId, explorer, address)).toEqual(
+        expectedUrl
+      )
+    })
+
+    test('NeoTracker testnet explorer test', () => {
+      const networkId = TEST_NETWORK_ID
+      const explorer = EXPLORERS.NEO_TRACKER
+      const expectedUrl = `https://testnet.neotracker.io/address/${address}`
+
+      expect(getExplorerAddressLink(networkId, explorer, address)).toEqual(
+        expectedUrl
+      )
+    })
+
+    test('NeoScan mainnet explorer test', () => {
+      const networkId = MAIN_NETWORK_ID
+      const explorer = EXPLORERS.NEO_SCAN
+      const expectedUrl = `https://neoscan.io/address/${address}/1`
+
+      expect(getExplorerAddressLink(networkId, explorer, address)).toEqual(
+        expectedUrl
+      )
+    })
+
+    test('NeoScan testnet explorer test', () => {
+      const networkId = TEST_NETWORK_ID
+      const explorer = EXPLORERS.NEO_SCAN
+      const expectedUrl = `https://neoscan-testnet.io/address/${address}/1`
+
+      expect(getExplorerAddressLink(networkId, explorer, address)).toEqual(
+        expectedUrl
+      )
+    })
+
+    test('AntChain mainnet explorer test', () => {
+      const networkId = MAIN_NETWORK_ID
+      const explorer = EXPLORERS.ANT_CHAIN
+      const expectedUrl = `http://antcha.in/address/info/${address}`
+
+      expect(getExplorerAddressLink(networkId, explorer, address)).toEqual(
+        expectedUrl
+      )
+    })
+
+    test('AntChain testnet explorer test', () => {
+      const networkId = TEST_NETWORK_ID
+      const explorer = EXPLORERS.ANT_CHAIN
+      const expectedUrl = `http://testnet.antcha.in/address/info/${address}`
+
+      expect(getExplorerAddressLink(networkId, explorer, address)).toEqual(
+        expectedUrl
+      )
     })
   })
 })

--- a/app/core/explorer.js
+++ b/app/core/explorer.js
@@ -3,29 +3,28 @@ import { openExternal } from './electron'
 import { EXPLORERS } from './constants'
 import { isMainNetwork } from './networks'
 
+const { NEO_SCAN, NEO_TRACKER, ANT_CHAIN } = EXPLORERS
+
 export const getExplorerBaseURL = (
   networkId: string,
   explorer: ExplorerType
 ) => {
-  let baseURL
-  if (explorer === EXPLORERS.NEO_TRACKER) {
-    if (isMainNetwork(networkId)) {
-      baseURL = 'https://neotracker.io'
-    } else {
-      baseURL = 'https://testnet.neotracker.io'
+  const isMainNet = isMainNetwork(networkId)
+  switch (explorer) {
+    case NEO_TRACKER: {
+      return isMainNet
+        ? 'https://neotracker.io'
+        : 'https://testnet.neotracker.io'
     }
-  } else if (explorer === EXPLORERS.NEO_SCAN) {
-    if (isMainNetwork(networkId)) {
-      baseURL = 'https://neoscan.io'
-    } else {
-      baseURL = 'https://neoscan-testnet.io'
+    case NEO_SCAN: {
+      return isMainNet ? 'https://neoscan.io' : 'https://neoscan-testnet.io'
     }
-  } else if (isMainNetwork(networkId)) {
-    baseURL = 'http://antcha.in'
-  } else {
-    baseURL = 'http://testnet.antcha.in'
+    case ANT_CHAIN: {
+      return isMainNet ? 'http://antcha.in' : 'http://testnet.antcha.in'
+    }
+    default:
+      throw new Error(`Unknown explorer ${explorer}`)
   }
-  return baseURL
 }
 
 export const getExplorerTxLink = (
@@ -35,13 +34,16 @@ export const getExplorerTxLink = (
 ) => {
   const baseURL = getExplorerBaseURL(networkId, explorer)
 
-  if (explorer === EXPLORERS.NEO_TRACKER) {
-    return `${baseURL}/tx/${txId}`
+  switch (explorer) {
+    case NEO_TRACKER:
+      return `${baseURL}/tx/${txId}`
+    case NEO_SCAN:
+      return `${baseURL}/transaction/${txId}`
+    case ANT_CHAIN:
+      return `${baseURL}/tx/hash/0x${txId}`
+    default:
+      throw new Error(`Unknown explorer ${explorer}`)
   }
-  if (explorer === EXPLORERS.NEO_SCAN) {
-    return `${baseURL}/transaction/${txId}`
-  }
-  return `${baseURL}/tx/hash/${txId}`
 }
 
 export const getExplorerAddressLink = (
@@ -51,17 +53,16 @@ export const getExplorerAddressLink = (
 ) => {
   const baseURL = getExplorerBaseURL(networkId, explorer)
 
-  if (explorer === EXPLORERS.NEO_TRACKER) {
-    return `${baseURL}/address/${address}`
+  switch (explorer) {
+    case NEO_TRACKER:
+      return `${baseURL}/address/${address}`
+    case NEO_SCAN:
+      return `${baseURL}/address/${address}/1`
+    case ANT_CHAIN:
+      return `${baseURL}/address/info/${address}`
+    default:
+      throw new Error(`Unknown explorer ${explorer}`)
   }
-  if (explorer === EXPLORERS.NEO_SCAN) {
-    return `${baseURL}/address/${address}/1`
-  }
-  // $FlowFixMe
-  if (explorer === EXPLORERS.NEO_VERSE) {
-    return `${baseURL}/addresses/${address}`
-  }
-  return `${baseURL}/address/info/${address}`
 }
 
 export const getExplorerAssetLink = (
@@ -70,18 +71,15 @@ export const getExplorerAssetLink = (
   assetId: string
 ) => {
   const baseURL = getExplorerBaseURL(networkId, explorer)
-
-  if (explorer === EXPLORERS.NEO_TRACKER) {
-    return `${baseURL}/asset/${assetId}`
+  switch (explorer) {
+    case NEO_TRACKER:
+    case NEO_SCAN:
+      return `${baseURL}/asset/${assetId}`
+    case ANT_CHAIN:
+      return `${baseURL}/assets/hash/${assetId}`
+    default:
+      throw new Error(`Unknown explorer ${explorer}`)
   }
-  if (explorer === EXPLORERS.NEO_SCAN) {
-    return `${baseURL}/asset/${assetId}`
-  }
-  // $FlowFixMe
-  if (explorer === EXPLORERS.NEO_VERSE) {
-    return `${baseURL}/assets/${assetId}`
-  }
-  return `${baseURL}/asset/hash/${assetId}`
 }
 
 export const openExplorerTx = (


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
1. Antchain tx link was broken on both MainNet / TestNet. (missing `0x` prefix)
2. Removed NEOVerse explorer because it was not used.
3. Wrote tests for getExplorerAddressLink
4. Cleanup the code and throw an error when passed with an unknown explorer.

**How did you make sure your solution works?**
Tested manually

**Are there any special changes in the code that we should be aware of?**
No

**Is there anything else we should know?**
No

Before:
http://antcha.in/tx/hash/56ec628ec9dc5383869e053fe685d23457d48dedc7fe63b75a40ef0a746ec6f8 (broken)

After:
http://antcha.in/tx/hash/0x56ec628ec9dc5383869e053fe685d23457d48dedc7fe63b75a40ef0a746ec6f8