### PR TITLE
fix(settings): display the correct label for selected block explorer

### DIFF
--- a/app/actions/settingsActions.js
+++ b/app/actions/settingsActions.js
@@ -7,7 +7,7 @@ import { getDefaultTokens } from '../core/nep5'
 import { ensureHex, validateHashLength } from '../util/tokenHashValidation'
 
 import {
-  EXPLORERS,
+  DEFAULT_EXPLORER,
   DEFAULT_CURRENCY_CODE,
   DEFAULT_THEME
 } from '../core/constants'
@@ -27,7 +27,7 @@ const STORAGE_KEY = 'settings'
 const DEFAULT_SETTINGS: () => Promise<Settings> = async () => ({
   currency: DEFAULT_CURRENCY_CODE,
   theme: DEFAULT_THEME,
-  blockExplorer: EXPLORERS.NEO_SCAN,
+  blockExplorer: DEFAULT_EXPLORER,
   tokens: await getDefaultTokens(),
   version,
   soundEnabled: true

--- a/app/containers/Settings/Settings.jsx
+++ b/app/containers/Settings/Settings.jsx
@@ -16,6 +16,7 @@ import Switch from '../../components/Inputs/Switch'
 
 import {
   EXPLORERS,
+  DEFAULT_EXPLORER,
   CURRENCIES,
   ROUTES,
   MODAL_TYPES,
@@ -69,6 +70,10 @@ type State = {
 }
 
 export default class Settings extends Component<Props, State> {
+  static defaultProps = {
+    explorer: DEFAULT_EXPLORER
+  }
+
   state = {
     selectedCurrency: {
       value: this.props.currency,
@@ -80,7 +85,7 @@ export default class Settings extends Component<Props, State> {
     },
     selectedExplorer: {
       value: this.props.explorer,
-      label: EXPLORERS[this.props.explorer] || EXPLORERS.NEO_SCAN
+      label: this.props.explorer
     },
     soundEnabled: this.props.soundEnabled
   }

--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -27,6 +27,8 @@ export const EXPLORERS = {
   ANT_CHAIN: 'Antchain'
 }
 
+export const DEFAULT_EXPLORER = EXPLORERS.NEO_SCAN
+
 export const ROUTES = {
   HOME: '/',
   DASHBOARD: '/dashboard',


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
The settings dropdown did not show the correct block explorer label and always defaulted to neo scan.

**How did you solve this problem?**
Since the saved value is `this.props.explorer` (the value of `EXPLORERS`), the right label is actually `this.props.explorer`.

**How did you make sure your solution works?**
Tested it manually.

**Are there any special changes in the code that we should be aware of?**
Exported a new `DEFAULT_EXPLORER` for consistency.

**Is there anything else we should know?**
No.
