### PR TITLE
fix(send): disable send button when for zero amounts

### DIFF
--- a/app/components/Send/SendPanel/index.jsx
+++ b/app/components/Send/SendPanel/index.jsx
@@ -15,6 +15,7 @@ import { pluralize } from '../../../util/pluralize'
 import SendIcon from '../../../assets/icons/send.svg'
 
 import styles from './SendPanel.scss'
+import { isZero } from '../../../core/math'
 
 type Props = {
   sendRowDetails: Array<*>,
@@ -44,6 +45,11 @@ type Props = {
   pushQRCodeData: (data: Object) => any
 }
 
+const shouldDisableSendButton = sendRowDetails =>
+  sendRowDetails.some(
+    detail => !detail.address || !detail.amount || isZero(detail.amount)
+  )
+
 const SendPanel = ({
   sendRowDetails,
   sendableAssets,
@@ -71,27 +77,10 @@ const SendPanel = ({
   pushQRCodeData,
   pendingTransaction
 }: Props) => {
-  const shouldDisableSendButton = sendRowDetails => {
-    let disabled = false
-    sendRowDetails.some(detail => {
-      if (!detail.address) {
-        disabled = true
-        return true
-      }
-      if (!detail.amount) {
-        disabled = true
-        return true
-      }
-      return false
-    })
-    return disabled
-  }
-
-  const maxRecipientsMet = () => sendRowDetails.length === maxNumberOfRecipients
-
   if (noSendableAssets) {
     return <ZeroAssets address={address} />
   }
+  const maxRecipientsMet = sendRowDetails.length === maxNumberOfRecipients
 
   let content = (
     <form onSubmit={handleSubmit}>
@@ -178,9 +167,9 @@ const SendPanel = ({
           showSendModal={showSendModal}
           pushQRCodeData={pushQRCodeData}
           disableAddRecipient={
-            shouldDisableSendButton(sendRowDetails) || maxRecipientsMet()
+            shouldDisableSendButton(sendRowDetails) || maxRecipientsMet
           }
-          disableEnterQRCode={maxRecipientsMet()}
+          disableEnterQRCode={maxRecipientsMet}
         />
       )}
       className={styles.sendSuccessPanel}


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
#1642

**What problem does this PR solve?**
Disables the send button when the amount is equal to zero.

**How did you solve this problem?**
1. I have moved the function out of the React component (no need to recreate it on every render).
2. I have simplified the logic and used `isZero` from `math.js`
3. Nonrelated, I have turned `maxRecipientsMet` to a boolean instead of a function (couldn't find a reason why it should be a function)

**How did you make sure your solution works?**
Tested it manually

**Are there any special changes in the code that we should be aware of?**
No

**Is there anything else we should know?**
No
