### PR TITLE
fix(number-input): use raw value instead of formatted

### DIFF
--- a/app/components/Inputs/NumberInput/NumberInput.jsx
+++ b/app/components/Inputs/NumberInput/NumberInput.jsx
@@ -25,7 +25,6 @@ type Props = {
   onBlur?: Function,
   handleMaxClick: Function,
   error?: string,
-  customChangeEvent?: boolean,
   options?: {
     numeralThousandsGroupStyle?: 'thousand' | 'lakh' | 'wan' | 'none',
     numeralIntegerScale?: number,
@@ -44,8 +43,7 @@ export default class NumberInput extends React.Component<Props, State> {
   static defaultProps = {
     max: Infinity,
     onChange: noop,
-    options: {},
-    customChangeEvent: false
+    options: {}
   }
 
   state = {
@@ -59,7 +57,6 @@ export default class NumberInput extends React.Component<Props, State> {
       'options',
       'onChange',
       'className',
-      'customChangeEvent',
       'handleMaxClick'
     )
 
@@ -78,11 +75,7 @@ export default class NumberInput extends React.Component<Props, State> {
           options={this.getOptions()}
           onFocus={this.handleFocus}
           onBlur={this.handleBlur}
-          onChange={
-            this.props.customChangeEvent
-              ? this.props.onChange
-              : this.handleChange
-          }
+          onChange={this.handleChange}
         />
         {error && <ErrorIcon className={styles.errorIcon} />}
         {error && <div className={styles.errorMessage}>{error}</div>}
@@ -127,7 +120,7 @@ export default class NumberInput extends React.Component<Props, State> {
   handleChange = (event: Object) => {
     const { onChange } = this.props
     if (onChange) {
-      return onChange(event.target.rawValue)
+      return onChange(event, event.target.rawValue)
     }
   }
 

--- a/app/components/Receive/QRCodeForm/QrCodeForm.jsx
+++ b/app/components/Receive/QRCodeForm/QrCodeForm.jsx
@@ -80,7 +80,7 @@ export default class QRCodeForm extends React.Component<Props, State> {
                 error={this.state.error}
                 // this is a hack because Cleave will not update
                 // when props change https://github.com/nosir/cleave.js/issues/352
-                onChange={value =>
+                onChange={(e, value) =>
                   this.setState({
                     amount: !this.determineDecimalScale()
                       ? formatNEO(value || 0)
@@ -142,17 +142,13 @@ export default class QRCodeForm extends React.Component<Props, State> {
           error: `You can only request ${asset} up to ${validDecimals} decimals.`
         })
       }
-      if (
-        toBigNumber(amount.toString().replace(/,/g, '')).greaterThan(
-          toBigNumber(1000000000)
-        )
-      ) {
+      if (toBigNumber(amount.toString()).greaterThan(toBigNumber(1000000000))) {
         valid = false
         this.setState({
           error: `You cannot request more than 100,000,000 ${asset}.`
         })
       }
-      if (!toNumber(amount.toString().replace(/,/g, ''))) {
+      if (!toNumber(amount.toString())) {
         valid = false
         this.setState({
           error: `You cannot request 0 ${asset}.`

--- a/app/components/Send/SendPanel/SendRecipientList/SendRecipientListItem/index.jsx
+++ b/app/components/Send/SendPanel/SendRecipientList/SendRecipientListItem/index.jsx
@@ -6,7 +6,7 @@ import NumberInput from '../../../../Inputs/NumberInput'
 import DisplayInput from '../../../DisplayInput'
 
 import { toBigNumber } from '../../../../../core/math'
-import { formatBalanceByDecimalScale } from '../../../../../core/formatters'
+import { formatNumberByDecimalScale } from '../../../../../core/formatters'
 
 import TrashCanIcon from '../../../../../assets/icons/delete.svg'
 
@@ -97,7 +97,7 @@ class SendRecipientListItem extends Component<Props> {
     )
 
     const numberInput = showConfirmSend ? (
-      <DisplayInput value={formatBalanceByDecimalScale(amount)} />
+      <DisplayInput value={formatNumberByDecimalScale(amount)} />
     ) : (
       <NumberInput
         value={amount || 0}

--- a/app/components/Send/SendPanel/index.jsx
+++ b/app/components/Send/SendPanel/index.jsx
@@ -15,6 +15,7 @@ import { pluralize } from '../../../util/pluralize'
 import SendIcon from '../../../assets/icons/send.svg'
 
 import styles from './SendPanel.scss'
+import { isZero } from '../../../core/math'
 
 type Props = {
   sendRowDetails: Array<*>,
@@ -44,6 +45,11 @@ type Props = {
   pushQRCodeData: (data: Object) => any
 }
 
+const shouldDisableSendButton = sendRowDetails =>
+  sendRowDetails.some(
+    detail => !detail.address || !detail.amount || isZero(detail.amount)
+  )
+
 const SendPanel = ({
   sendRowDetails,
   sendableAssets,
@@ -71,27 +77,10 @@ const SendPanel = ({
   pushQRCodeData,
   pendingTransaction
 }: Props) => {
-  const shouldDisableSendButton = sendRowDetails => {
-    let disabled = false
-    sendRowDetails.some(detail => {
-      if (!detail.address) {
-        disabled = true
-        return true
-      }
-      if (!detail.amount) {
-        disabled = true
-        return true
-      }
-      return false
-    })
-    return disabled
-  }
-
-  const maxRecipientsMet = () => sendRowDetails.length === maxNumberOfRecipients
-
   if (noSendableAssets) {
     return <ZeroAssets address={address} />
   }
+  const maxRecipientsMet = sendRowDetails.length === maxNumberOfRecipients
 
   let content = (
     <form onSubmit={handleSubmit}>
@@ -178,9 +167,9 @@ const SendPanel = ({
           showSendModal={showSendModal}
           pushQRCodeData={pushQRCodeData}
           disableAddRecipient={
-            shouldDisableSendButton(sendRowDetails) || maxRecipientsMet()
+            shouldDisableSendButton(sendRowDetails) || maxRecipientsMet
           }
-          disableEnterQRCode={maxRecipientsMet()}
+          disableEnterQRCode={maxRecipientsMet}
         />
       )}
       className={styles.sendSuccessPanel}

--- a/app/containers/Send/Send.jsx
+++ b/app/containers/Send/Send.jsx
@@ -191,10 +191,10 @@ export default class Send extends React.Component<Props, State> {
         const valueAsString = value.toString()
 
         const additionalValue =
-          toNumber(valueAsString.replace(/,/g, '')) >
+          toNumber(valueAsString) >
           toNumber(sendableAssets[objectToModify.asset].balance)
             ? 0
-            : toNumber(valueAsString.replace(/,/g, ''))
+            : toNumber(valueAsString)
 
         const decimals = this.calculateDecimals(objectToModify.asset)
 
@@ -251,11 +251,7 @@ export default class Send extends React.Component<Props, State> {
     if (rows.length > 0) {
       return (rows
         .filter((row: Object) => row.asset === asset)
-        .map((row: Object) =>
-          get(row, 'amount', '0')
-            .toString()
-            .replace(/,/g, '')
-        )
+        .map((row: Object) => get(row, 'amount', '0').toString())
         .reduce(
           (accumulator: Object, currentValue: number | void) =>
             accumulator.plus(currentValue || 0),
@@ -338,7 +334,7 @@ export default class Send extends React.Component<Props, State> {
 
     const entries = sendRowDetails.map((row: Object) => ({
       address: row.address,
-      amount: toNumber(row.amount.toString().replace(/,/g, '')),
+      amount: toNumber(row.amount.toString()),
       symbol: row.asset
     }))
 

--- a/app/containers/TokenSale/TokenSale.jsx
+++ b/app/containers/TokenSale/TokenSale.jsx
@@ -175,7 +175,7 @@ class TokenSale extends Component<Props, State> {
     const { amountToPurchaseFor, assetToPurchaseWith, gasFee } = this.state
     const { assetBalances } = this.props
 
-    const amountWithoutCommas = amountToPurchaseFor.toString().replace(/,/g, '')
+    const amountWithoutCommas = amountToPurchaseFor.toString()
 
     if (!isNumber(Number(amountToPurchaseFor))) {
       this.setState({ inputErrorMessage: 'Amount must be a number.' })

--- a/app/containers/TokenSale/TokenSale.jsx
+++ b/app/containers/TokenSale/TokenSale.jsx
@@ -175,21 +175,19 @@ class TokenSale extends Component<Props, State> {
     const { amountToPurchaseFor, assetToPurchaseWith, gasFee } = this.state
     const { assetBalances } = this.props
 
-    const amountWithoutCommas = amountToPurchaseFor.toString()
-
     if (!isNumber(Number(amountToPurchaseFor))) {
       this.setState({ inputErrorMessage: 'Amount must be a number.' })
       return false
     }
 
-    if (isZero(amountWithoutCommas)) {
+    if (isZero(amountToPurchaseFor)) {
       this.setState({ inputErrorMessage: 'Amount must be greater than 0.' })
       return false
     }
 
     if (
       assetToPurchaseWith === 'NEO' &&
-      !toBigNumber(amountWithoutCommas).isInteger()
+      !toBigNumber(amountToPurchaseFor).isInteger()
     ) {
       this.setState({
         inputErrorMessage: "You can't send fractional amounts of NEO" // eslint-disable-line
@@ -213,7 +211,7 @@ class TokenSale extends Component<Props, State> {
 
     if (assetToPurchaseWith === 'GAS') {
       if (
-        toBigNumber(addNumber(amountWithoutCommas, gasFee)).greaterThan(
+        toBigNumber(addNumber(amountToPurchaseFor, gasFee)).greaterThan(
           gasBalance
         )
       ) {
@@ -225,7 +223,7 @@ class TokenSale extends Component<Props, State> {
       }
     }
 
-    if (toBigNumber(amountWithoutCommas).greaterThan(assetBalance)) {
+    if (toBigNumber(amountToPurchaseFor).greaterThan(assetBalance)) {
       this.setState({
         inputErrorMessage: `You don't have enough ${assetToPurchaseWith}.`
       })

--- a/app/containers/TokenSale/TokenSale.jsx
+++ b/app/containers/TokenSale/TokenSale.jsx
@@ -175,20 +175,19 @@ class TokenSale extends Component<Props, State> {
     const { amountToPurchaseFor, assetToPurchaseWith, gasFee } = this.state
     const { assetBalances } = this.props
 
-    if (!isNumber(Number(amountToPurchaseFor))) {
+    const amount = amountToPurchaseFor.toString()
+
+    if (!isNumber(Number(amount))) {
       this.setState({ inputErrorMessage: 'Amount must be a number.' })
       return false
     }
 
-    if (isZero(amountToPurchaseFor)) {
+    if (isZero(amount)) {
       this.setState({ inputErrorMessage: 'Amount must be greater than 0.' })
       return false
     }
 
-    if (
-      assetToPurchaseWith === 'NEO' &&
-      !toBigNumber(amountToPurchaseFor).isInteger()
-    ) {
+    if (assetToPurchaseWith === 'NEO' && !toBigNumber(amount).isInteger()) {
       this.setState({
         inputErrorMessage: "You can't send fractional amounts of NEO" // eslint-disable-line
       })
@@ -210,11 +209,7 @@ class TokenSale extends Component<Props, State> {
     }
 
     if (assetToPurchaseWith === 'GAS') {
-      if (
-        toBigNumber(addNumber(amountToPurchaseFor, gasFee)).greaterThan(
-          gasBalance
-        )
-      ) {
+      if (toBigNumber(addNumber(amount, gasFee)).greaterThan(gasBalance)) {
         this.setState({
           inputErrorMessage:
             'You do not have enough GAS to prioritize this transaction' // eslint-disable-line
@@ -223,7 +218,7 @@ class TokenSale extends Component<Props, State> {
       }
     }
 
-    if (toBigNumber(amountToPurchaseFor).greaterThan(assetBalance)) {
+    if (toBigNumber(amount).greaterThan(assetBalance)) {
       this.setState({
         inputErrorMessage: `You don't have enough ${assetToPurchaseWith}.`
       })

--- a/app/core/formatters.js
+++ b/app/core/formatters.js
@@ -30,7 +30,7 @@ export const formatThousands = (value: ValueType): string =>
 export const formatNEO = (value: ValueType): string =>
   toBigNumber(value).toFormat(0)
 
-export const formatBalanceByDecimalScale = (value: ValueType): string =>
+export const formatNumberByDecimalScale = (value: ValueType): string =>
   toBigNumber(value).toFormat()
 
 export const formatBalance = (

--- a/app/core/formatters.js
+++ b/app/core/formatters.js
@@ -30,6 +30,9 @@ export const formatThousands = (value: ValueType): string =>
 export const formatNEO = (value: ValueType): string =>
   toBigNumber(value).toFormat(0)
 
+export const formatBalanceByDecimalScale = (value: ValueType): string =>
+  toBigNumber(value).toFormat()
+
 export const formatBalance = (
   symbol: SymbolType,
   balance: ValueType,


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
Currently, the wallet crashes when you try to send a large amount > `999`. This PR solves this problem by only storing the raw value and not the formatted one produced by `Cleave.js`.

**How did you solve this problem?**
I have removed the `customChangeEvent` which was sort of a workaround around the fact that the `onChange` event did not return the `event` object. A better approach for the handler is to use `onChange => (event, value)`. By returning the raw value from the NumberInput it is now possible to remove all the instances of the comma removal.

I have also cleaned `handleFieldChange` method a bit.

**How did you make sure your solution works?**
Tested a lot manually!

**Are there any special changes in the code that we should be aware of?**
Token sale also uses the number input and I haven't tested it well enough.

**Is there anything else we should know?**
Next thing to do is to remove `customChangeEvent` from the `SelectInput`

Before:
<img width="1917" alt="screen shot 2018-11-06 at 4 50 04 pm" src="https://user-images.githubusercontent.com/254095/48045333-0bb4ee00-e1e4-11e8-8e3e-24045bd38756.png">

After:
<img width="1104" alt="screen shot 2018-11-06 at 4 45 25 pm" src="https://user-images.githubusercontent.com/254095/48045363-2d15da00-e1e4-11e8-9306-a27c680b4848.png">
