### PR TITLE
fixes automatic node select bug in sale.js and transactions.js

### DIFF
--- a/app/modules/sale.js
+++ b/app/modules/sale.js
@@ -1,6 +1,6 @@
 // @flow
 import { wallet, api } from 'neon-js'
-import { flatten } from 'lodash-es'
+import { flatten, isEmpty } from 'lodash-es'
 
 import { getNode } from '../actions/nodeStorageActions'
 
@@ -93,8 +93,12 @@ export const participateInSale = (
     gas: 0,
     publicKey: isHardwareLogin ? publicKey : null,
     signingFunction: isHardwareLogin ? signingFunction : null,
-    fees,
-    url
+    fees
+  }
+
+  if (!isEmpty(url)) {
+    // $FlowFixMe
+    config.url = url
   }
 
   try {

--- a/app/modules/transactions.js
+++ b/app/modules/transactions.js
@@ -1,7 +1,7 @@
 // @flow
 /* eslint-disable camelcase */
 import { api, sc, u, wallet } from 'neon-js'
-import { flatMap, keyBy } from 'lodash-es'
+import { flatMap, keyBy, isEmpty } from 'lodash-es'
 
 import {
   showErrorNotification,
@@ -115,8 +115,6 @@ export const sendTransaction = ({
     const isHardwareSend = getIsHardwareLogin(state)
     const url = await getNode(net)
 
-    console.log({ url })
-
     const rejectTransaction = (message: string) =>
       dispatch(showErrorNotification({ message }))
 
@@ -150,8 +148,12 @@ export const sendTransaction = ({
       publicKey,
       privateKey: new wallet.Account(wif).privateKey,
       signingFunction: isHardwareSend ? signingFunction : null,
-      fees,
-      url
+      fees
+    }
+
+    if (!isEmpty(url)) {
+      // $FlowFixMe
+      config.url = url
     }
 
     try {


### PR DESCRIPTION
- Because `getNode`will return an empty object the most recent change to `transactions.js` and `sale.js` allowing for handling of node selection broke if you were running the application for the first time. This PR fixes that problem

NOTE: after manually choosing "Automatic" selection the node gets saved as an empty string in storage. This is the reason I was unable to detect the bug previously in my tests. isEmpty works the same for both empty strings and empty objects