### PR TITLE
Feature/1649

### DIFF
--- a/app/actions/balancesActions.js
+++ b/app/actions/balancesActions.js
@@ -1,6 +1,6 @@
 // @flow
 import { api } from 'neon-js'
-import { extend, isEmpty } from 'lodash-es'
+import { extend, isEmpty, get } from 'lodash-es'
 import { createActions } from 'spunky'
 import { Howl } from 'howler'
 // eslint-disable-next-line $FlowFixMe
@@ -169,9 +169,11 @@ async function getBalances({ net, address }: Props) {
   })
 
   // asset balances
-  const assetBalances = await api.getBalanceFrom({ net, address }, api.neoscan)
+  const assetBalances = await api
+    .getBalanceFrom({ net, address }, api.neoscan)
+    .catch(e => console.error(e))
 
-  const { assets } = assetBalances.balance
+  const assets = get(assetBalances, 'balance.assets', {})
   // The API doesn't always return NEO or GAS keys if, for example, the address only has one asset
   const neoBalance = assets.NEO ? assets.NEO.balance.toString() : '0'
   const gasBalance = assets.GAS


### PR DESCRIPTION
- Fixes https://github.com/CityOfZion/neon-wallet/issues/1649 by manually constructing the Balance class if neoscan is down allowing users to still send, receive and view nep5 tokens independent of neoscan
- Fixes `balancesActions.js` to not fail if request to nodes is successful but req to neoscan fails