### PR TITLE
updates TransactionHistoryPanel/index.js

### DIFF
--- a/app/components/TransactionHistory/TransactionHistoryPanel/index.js
+++ b/app/components/TransactionHistory/TransactionHistoryPanel/index.js
@@ -23,11 +23,11 @@ const mapAccountActionsToProps = (actions, props) => ({
 })
 
 export default compose(
+  withAuthData(),
+  withNetworkData(),
   withProgressPanel(transactionHistoryActions, {
     title: 'Transaction History'
   }),
-  withAuthData(),
-  withNetworkData(),
   withActions(transactionHistoryActions, mapAccountActionsToProps),
   withLoadingProp(transactionHistoryActions),
   withData(transactionHistoryActions, mapTransactionsDataToProps)


### PR DESCRIPTION
- The order of the HOC in `TransactionHistoryPanel/index.js` was incorrect causing our Failed component retry button to not work properly... This PR fixes that

NOTE: to reproduce turn offline mode on in dev tools