### PR TITLE
feature: send updates

### DIFF
--- a/app/components/Send/PriorityFee/PriorityFee.jsx
+++ b/app/components/Send/PriorityFee/PriorityFee.jsx
@@ -16,9 +16,9 @@ type Props = {
 
 const FEE_OPTIONS = [
   {
-    fee: 0.00000001,
+    fee: 0.001,
     description: 'Fast',
-    precision: 8
+    precision: 3
   },
   {
     fee: 0.05,

--- a/app/containers/Send/Send.jsx
+++ b/app/containers/Send/Send.jsx
@@ -19,7 +19,7 @@ import SendPanel from '../../components/Send/SendPanel'
 import HeaderBar from '../../components/HeaderBar'
 import styles from './Send.scss'
 
-const MAX_NUMBER_OF_RECIPIENTS = 10
+const MAX_NUMBER_OF_RECIPIENTS = 25
 
 type Props = {
   sendableAssets: Object,


### PR DESCRIPTION
- Bumps max number of recipients from 10 => 25
- Increases the min fee from a drop of gas to .001 (new  minimum to not be cleaned from the mempool on congestion)