### PR TITLE
[#1626] Implemented chart duration dropdown

### DIFF
--- a/__tests__/components/__snapshots__/NetworkSwitch.test.js.snap
+++ b/__tests__/components/__snapshots__/NetworkSwitch.test.js.snap
@@ -633,7 +633,7 @@ exports[`NetworkSwitch renders without crashing 1`] = `
                     }
                   >
                     <div
-                      className="css-k5geue react-select__value-container react-select__value-container--has-value"
+                      className="css-6zqqc react-select__value-container react-select__value-container--has-value"
                     >
                       <SingleValue
                         clearValue={[Function]}
@@ -783,7 +783,7 @@ exports[`NetworkSwitch renders without crashing 1`] = `
                         }
                       >
                         <div
-                          className="css-8bm2m9 react-select__single-value"
+                          className="css-ljsv20 react-select__single-value"
                         >
                           MainNet
                         </div>

--- a/app/components/Dashboard/PriceHistoryPanel/PriceHistoryPanel.jsx
+++ b/app/components/Dashboard/PriceHistoryPanel/PriceHistoryPanel.jsx
@@ -1,12 +1,12 @@
 // @flow
 import React from 'react'
 import classNames from 'classnames'
-import { keys } from 'lodash-es'
+import { find } from 'lodash-es'
 
 import PriceHistoryChart from './PriceHistoryChart'
 import Panel from '../../Panel'
 import BoundingBox from './BoundingBox'
-import DropdownIcon from '../../../assets/icons/dropdown.svg'
+import StyledReactSelect from '../../Inputs/StyledReactSelect/StyledReactSelect'
 import {
   ASSETS,
   CURRENCIES,
@@ -16,6 +16,11 @@ import styles from './PriceHistoryPanel.scss'
 import { formatFiat, formatThousands } from '../../../core/formatters'
 
 type Duration = '1m' | '1w' | '1d'
+// react-select option format
+type SelectOption = {
+  value: Duration,
+  label: string
+}
 
 type Price = {
   time: number,
@@ -39,11 +44,17 @@ type Props = {
   priceKey: string
 }
 
-const DURATIONS: { [key: Duration]: string } = {
-  '1m': '1 month',
-  '1w': '1 week',
-  '1d': '1 day'
-}
+const DURATIONS: Array<[Duration, string]> = [
+  ['1d', '1 DAY'],
+  ['1w', '1 WEEK'],
+  ['1m', '1 MONTH']
+]
+
+// convert DURATIONS to react-select option format
+const DURATION_OPTIONS: Array<SelectOption> = DURATIONS.map(([k, v]) => ({
+  value: k,
+  label: v
+}))
 
 export default class PriceHistoryPanel extends React.Component<Props> {
   static defaultProps = {
@@ -81,9 +92,17 @@ export default class PriceHistoryPanel extends React.Component<Props> {
         {this.renderLatestPrice()}
         {this.renderPriceChange()}
       </span>
-      <span className={styles.duration} onClick={this.handleChangeDuration}>
-        {this.getDuration()}
-        <DropdownIcon className={styles.icon} />
+      <span className={styles.duration}>
+        <StyledReactSelect
+          defaultValue={this.getDuration()}
+          onChange={this.handleChangeDuration}
+          options={DURATION_OPTIONS}
+          isSearchable={false}
+          fontWeight="normal"
+          transparent
+          hideHighlight
+          textAlign="right"
+        />
       </span>
     </div>
   )
@@ -94,14 +113,12 @@ export default class PriceHistoryPanel extends React.Component<Props> {
     )
   }
 
-  handleChangeDuration = () => {
-    const durations = keys(DURATIONS)
-    const index =
-      (durations.indexOf(this.props.duration) + 1) % durations.length
-    this.props.setDuration(durations[index])
+  handleChangeDuration = (selected: SelectOption) => {
+    this.props.setDuration(selected.value)
   }
 
-  getDuration = () => DURATIONS[this.props.duration]
+  getDuration = (): ?SelectOption =>
+    find(DURATION_OPTIONS, ['value', this.props.duration])
 
   formatDate = (date: Date): string => {
     if (this.props.duration === '1d') {

--- a/app/components/Dashboard/PriceHistoryPanel/PriceHistoryPanel.scss
+++ b/app/components/Dashboard/PriceHistoryPanel/PriceHistoryPanel.scss
@@ -6,8 +6,7 @@
     align-items: center;
     justify-content: space-between;
 
-    .asset,
-    .duration {
+    .asset {
       display: flex;
       align-items: center;
       font-family: Gotham;

--- a/app/components/Inputs/StyledReactSelect/StyledReactSelect.jsx
+++ b/app/components/Inputs/StyledReactSelect/StyledReactSelect.jsx
@@ -52,6 +52,7 @@ const customStyles = {
       ...styles,
       background: props.selectProps.transparent && 'transparent !important',
       fontSize: props.selectProps.fontSize,
+      fontWeight: props.selectProps.fontWeight,
       padding: !props.hideHighlight && '7px 15px !important',
       justifyContent: props.selectProps.settingsSelect && 'flex-end',
       ...conditionalStyles
@@ -69,6 +70,8 @@ const customStyles = {
     return {
       ...styles,
       fontSize: props.selectProps.fontSize,
+      fontWeight: props.selectProps.fontWeight,
+      [props.selectProps.textAlign]: 0,
       ...conditionalStyles
     }
   }


### PR DESCRIPTION
Currently, the dashboard chart duration switcher is a click-to-change implementation.
This commit swaps it for a dropdown as requested in #1626.

![screen recording 2018-11-09 at 18 03 28](https://user-images.githubusercontent.com/486954/48277288-e679e700-e452-11e8-99cd-57d6828be59a.gif)

Implemented using `<StyledReactSelect>` with some custom styling to match the design.
Passes all tests, no new tests added (lmk if this feature requires it).