### PR TITLE
[#1639] Added font-family fallbacks to all non-generic declerations

### DIFF
--- a/app/components/AmountsPanel/AmountsInfoBox/AmountsInfoBox.scss
+++ b/app/components/AmountsPanel/AmountsInfoBox/AmountsInfoBox.scss
@@ -13,7 +13,7 @@
 
   .assetName {
     padding-right: 10px;
-    font-family: Gotham-Light;
+    font-family: var(--font-gotham-light);
     font-size: 14px;
     position: relative;
 
@@ -23,12 +23,12 @@
   }
 
   .assetAmount {
-    font-family: Gotham-Medium;
+    font-family: var(--font-gotham-medium);
     color: var(--amounts-panel-asset-amount-text);
   }
 
   .assetWorth {
-    font-family: Gotham-Book;
+    font-family: var(--font-gotham-book);
     color: var(--amounts-panel-asset-worth-text);
   }
 

--- a/app/components/AmountsPanel/AmountsPanel.scss
+++ b/app/components/AmountsPanel/AmountsPanel.scss
@@ -15,7 +15,7 @@
 
 h1 {
   margin-top: 0;
-  font-family: Gotham-Light;
+  font-family: var(--font-gotham-light);
   font-weight: 100;
   font-size: 30px;
   color: #8d98ae;

--- a/app/components/Blockchain/Transaction/Transaction.scss
+++ b/app/components/Blockchain/Transaction/Transaction.scss
@@ -10,11 +10,11 @@
   width: 200px;
   font-size: 14px;
   text-align: center;
-  font-family: Gotham-Book;
+  font-family: var(--font-gotham-book);
 }
 
 .txLabelContainer {
-  font-family: Gotham-Book;
+  font-family: var(--font-gotham-book);
   font-size: 14px;
   text-align: center;
   width: 75px;

--- a/app/components/Contacts/EditContactPanel/EditContactPanel.scss
+++ b/app/components/Contacts/EditContactPanel/EditContactPanel.scss
@@ -23,7 +23,7 @@
   justify-content: space-between;
 
   span {
-    font-family: Gotham-Medium;
+    font-family: var(--font-gotham-medium);
     font-size: 14px;
     color: #ee6d66;
     display: flex;

--- a/app/components/Dashboard/AssetBalancesPanel/AssetBalancesPanel.scss
+++ b/app/components/Dashboard/AssetBalancesPanel/AssetBalancesPanel.scss
@@ -40,7 +40,7 @@
       .quantity {
         font-weight: 200;
         margin: 16px 0;
-        font-family: Gotham-Light;
+        font-family: var(--font-gotham-light);
         font-size: 40px;
         color: var(--base-text);
       }
@@ -70,7 +70,7 @@
   }
 
   .walletTotal {
-    font-family: Gotham-Medium;
+    font-family: var(--font-gotham-medium);
     font-size: 24px;
     color: var(--base-text);
     text-align: center;
@@ -95,14 +95,14 @@
     font-weight: 100;
     text-transform: uppercase;
     opacity: 0.5;
-    font-family: Gotham-Light;
+    font-family: var(--font-gotham-light);
     font-size: 24px;
     color: var(--base-text);
   }
 
   .assetName {
     opacity: 0.5;
-    font-family: Gotham-Bold;
+    font-family: var(--font-gotham-bold);
     font-size: 13px;
     color: var(--dashboard-asset-panel-asset-name);
     text-align: center;

--- a/app/components/Dashboard/PriceHistoryPanel/PriceHistoryChart.scss
+++ b/app/components/Dashboard/PriceHistoryPanel/PriceHistoryChart.scss
@@ -10,14 +10,14 @@
   padding: 10px;
   background: #394152;
   border-radius: 4px;
-  font-family: Gotham-Book;
+  font-family: var(--font-gotham-book);
   font-size: 12px;
   color: #ffffff;
   text-align: center;
 
   .tooltipTime {
     opacity: 0.5;
-    font-family: Gotham-Book;
+    font-family: var(--font-gotham-book);
     margin-right: 10px;
   }
 }

--- a/app/components/Dashboard/PriceHistoryPanel/PriceHistoryPanel.scss
+++ b/app/components/Dashboard/PriceHistoryPanel/PriceHistoryPanel.scss
@@ -9,7 +9,7 @@
     .asset {
       display: flex;
       align-items: center;
-      font-family: Gotham;
+      font-family: var(--font-gotham);
       color: #969aa0;
       font-size: 12px;
       font-weight: 600;

--- a/app/components/Dashboard/TokenBalancesPanel/TokenBalancesPanel.scss
+++ b/app/components/Dashboard/TokenBalancesPanel/TokenBalancesPanel.scss
@@ -27,7 +27,7 @@ a {
       padding-top: 12px;
       padding-bottom: 6px;
       opacity: 0.5;
-      font-family: Gotham-Bold;
+      font-family: var(--font-gotham-bold);
       font-size: 12px;
       color: var(--base-text);
       text-transform: uppercase;
@@ -111,7 +111,7 @@ a {
 
   h1 {
     margin-top: 0;
-    font-family: Gotham-Light;
+    font-family: var(--font-gotham-light);
     font-weight: 100;
     font-size: 30px;
     color: #8d98ae;

--- a/app/components/HeaderBar/HeaderBar.scss
+++ b/app/components/HeaderBar/HeaderBar.scss
@@ -13,7 +13,7 @@
   border-bottom: solid thin #5c677f;
 
   h3 {
-    font-family: Gotham-Medium;
+    font-family: var(--font-gotham-medium);
     font-size: 16px;
     line-height: 32px;
     margin: 0;

--- a/app/components/Modals/ReceiveModal/style.scss
+++ b/app/components/Modals/ReceiveModal/style.scss
@@ -32,7 +32,7 @@
     font-weight: 100;
     font-size: 30px;
     line-height: 32px;
-    font-family: Gotham-Light;
+    font-family: var(--font-gotham-light);
     color: var(--base-text);
     text-align: center;
   }

--- a/app/components/Modals/SendModal/SendModal.scss
+++ b/app/components/Modals/SendModal/SendModal.scss
@@ -28,7 +28,7 @@
     font-weight: 100;
     font-size: 30px;
     line-height: 32px;
-    font-family: Gotham-Light;
+    font-family: var(--font-gotham-light);
     text-align: center;
   }
 }

--- a/app/components/NodeSelectPanel/NodeSelectPanel.scss
+++ b/app/components/NodeSelectPanel/NodeSelectPanel.scss
@@ -12,7 +12,7 @@ $icon-size: 24px;
   font-size: 14px;
   color: var(--panel-full-height-instructions-text);
   text-align: center;
-  font-family: Gotham-Book;
+  font-family: var(--font-gotham-book);
 }
 
 .nodeSelectContainer {
@@ -48,7 +48,7 @@ $icon-size: 24px;
     .automaticSelect {
       font-size: 14px;
       line-height: 14px;
-      font-family: Gotham-Book;
+      font-family: var(--font-gotham-book);
 
       svg {
         path {
@@ -70,7 +70,7 @@ $icon-size: 24px;
     }
 
     .automaticSelect {
-      font-family: Gotham-Book;
+      font-family: var(--font-gotham-book);
       font-size: 14px;
       color: var(--node-select-automatic-select-button-text);
       svg path {

--- a/app/components/Panel/FullHeightPanel/FullHeightPanel.scss
+++ b/app/components/Panel/FullHeightPanel/FullHeightPanel.scss
@@ -26,7 +26,7 @@
     font-weight: 100;
     font-size: 30px;
     line-height: 32px;
-    font-family: Gotham-Light;
+    font-family: var(--font-gotham-light);
     font-size: 30px;
     color: var(--base-text);
     text-align: center;
@@ -57,7 +57,7 @@
     width: 500px;
     font-size: 14px;
     color: var(--panel-full-height-instructions-text);
-    font-family: Gotham-Book;
+    font-family: var(--font-gotham-book);
   }
 
   .navigation {

--- a/app/components/Panel/Header.scss
+++ b/app/components/Panel/Header.scss
@@ -7,7 +7,7 @@
   justify-content: center;
   height: 50px;
   padding: 0 24px;
-  font-family: Gotham-Book;
+  font-family: var(--font-gotham-book);
   font-size: 14px;
   background: var(--panel-header);
   color: var(--panel-header-text);

--- a/app/components/PanelHeaderButton/PanelHeaderButton.scss
+++ b/app/components/PanelHeaderButton/PanelHeaderButton.scss
@@ -1,7 +1,7 @@
 .panelHeaderButton {
   border: none;
   background: transparent;
-  font-family: Gotham;
+  font-family: var(--font-gotham);
   padding: 8px;
   display: flex;
   margin-right: 10px;

--- a/app/components/Receive/QRCodeForm/styles.scss
+++ b/app/components/Receive/QRCodeForm/styles.scss
@@ -35,7 +35,7 @@
     font-weight: 100;
     font-size: 30px;
     line-height: 32px;
-    font-family: Gotham-Light;
+    font-family: var(--font-gotham-light);
     color: var(--base-text);
     text-align: center;
   }

--- a/app/components/Send/PriorityFee/PriorityFee.scss
+++ b/app/components/Send/PriorityFee/PriorityFee.scss
@@ -3,7 +3,7 @@
   font-size: 14px;
   text-align: left;
   opacity: 0.5;
-  font-family: Gotham-Bold;
+  font-family: var(--font-gotham-bold);
   font-size: 12px;
   margin-bottom: 10px;
 }

--- a/app/components/Send/SendPanel/SendPanel.scss
+++ b/app/components/Send/SendPanel/SendPanel.scss
@@ -24,7 +24,7 @@
     display: flex;
     flex: 0.4;
     justify-content: flex-end;
-    font-family: Gotham;
+    font-family: var(--font-gotham);
   }
 
   .priorityTrasferHeaderTextContainer {
@@ -97,7 +97,7 @@
   display: flex;
   flex-direction: column;
   margin-top: 10px;
-  font-family: Gotham-Book;
+  font-family: var(--font-gotham-book);
   font-size: 12px;
   color: #8d98ae;
   text-align: center;
@@ -140,7 +140,7 @@
   font-size: 14px;
   text-align: left;
   opacity: 0.5;
-  font-family: Gotham-Bold;
+  font-family: var(--font-gotham-bold);
   font-size: 12px;
   margin-bottom: 10px;
 }

--- a/app/components/Settings/SettingsItem/SettingsItem.scss
+++ b/app/components/Settings/SettingsItem/SettingsItem.scss
@@ -7,7 +7,7 @@
 
   .settingsItemLabel {
     flex: 1;
-    font-family: Gotham-Bold;
+    font-family: var(--font-gotham-bold);
     font-size: 12px;
     color: var(--settings-item-label);
   }

--- a/app/components/Settings/SettingsLink/SettingsLink.scss
+++ b/app/components/Settings/SettingsLink/SettingsLink.scss
@@ -9,7 +9,7 @@ $settings-link-color: #66ed87;
   max-height: 45px;
   height: 45px;
   text-decoration: none;
-  font-family: Gotham-Bold;
+  font-family: var(--font-gotham-bold);
   font-size: 12px;
   color: var(--settings-item-label);
 
@@ -50,7 +50,7 @@ label {
 }
 
 .greyLabel {
-  font-family: Gotham-Bold;
+  font-family: var(--font-gotham-bold);
   font-size: 12px;
   color: var(--settings-item-icon);
   min-width: 200px;
@@ -59,7 +59,7 @@ label {
 }
 
 .greenLabel {
-  font-family: Gotham-Bold;
+  font-family: var(--font-gotham-bold);
   font-size: 12px;
   color: var(--settings-link-text);
 }

--- a/app/components/TokenSale/TokenSaleConfirm/TokenSaleConfirm.scss
+++ b/app/components/TokenSale/TokenSaleConfirm/TokenSaleConfirm.scss
@@ -49,7 +49,7 @@
 .confirmationFees {
   display: flex;
   flex-direction: column;
-  font-family: Gotham-Book;
+  font-family: var(--font-gotham-book);
   font-size: 12px;
   color: #8d98ae;
   text-align: center;

--- a/app/containers/App/Sidebar/Logout/Logout.scss
+++ b/app/containers/App/Sidebar/Logout/Logout.scss
@@ -14,7 +14,7 @@
 }
 
 .logoutText {
-  font-family: Gotham-Book;
+  font-family: var(--font-gotham-book);
   font-size: 10px;
   margin-top: 5px;
   color: #9599a2;

--- a/app/containers/App/Sidebar/Sidebar.scss
+++ b/app/containers/App/Sidebar/Sidebar.scss
@@ -52,7 +52,7 @@ $size: 68px;
   text-decoration: none;
 
   div {
-    font-family: Gotham-Book;
+    font-family: var(--font-gotham-book);
     font-size: 10px;
     margin-top: 5px;
   }

--- a/app/containers/Dashboard/Dashboard.scss
+++ b/app/containers/Dashboard/Dashboard.scss
@@ -14,7 +14,7 @@
 
     label {
       margin-right: 5px;
-      font-family: Gotham-Medium;
+      font-family: var(--font-gotham-medium);
     }
 
     .addressLink {

--- a/app/containers/EditWallet/EditWallet.scss
+++ b/app/containers/EditWallet/EditWallet.scss
@@ -4,7 +4,7 @@
   justify-content: space-between;
 
   span {
-    font-family: Gotham-Medium;
+    font-family: var(--font-gotham-medium);
     font-size: 14px;
     color: #ff967e;
     display: flex;

--- a/app/containers/Home/Home.scss
+++ b/app/containers/Home/Home.scss
@@ -74,7 +74,7 @@ $navigation-margin: 20px;
 }
 
 .ledgerStage {
-  font-family: Gotham-Book;
+  font-family: var(--font-gotham-book);
   margin-top: 0;
   display: flex;
   align-items: center;
@@ -211,7 +211,7 @@ $navigation-margin: 20px;
 }
 
 .loginHeader {
-  font-family: Gotham-Light;
+  font-family: var(--font-gotham-light);
   font-weight: 300;
   width: 500px;
   display: flex;
@@ -219,7 +219,7 @@ $navigation-margin: 20px;
   text-align: center;
   justify-content: center;
   line-height: 32px;
-  font-family: Gotham-Light;
+  font-family: var(--font-gotham-light);
   font-size: 30px;
   color: var(--base-text);
 }

--- a/app/containers/Settings/Settings.scss
+++ b/app/containers/Settings/Settings.scss
@@ -62,7 +62,7 @@ $panel-top-margin: 25px;
       justify-content: center;
       display: flex;
       text-decoration: none;
-      font-family: Gotham-Book;
+      font-family: var(--font-gotham-book);
       font-size: 10px;
       color: var(--settings-donation-text);
       letter-spacing: 0.4px;

--- a/app/containers/WalletManager/WalletManager.scss
+++ b/app/containers/WalletManager/WalletManager.scss
@@ -61,7 +61,7 @@
 
     h2 {
       /* Manage Wallets: */
-      font-family: Gotham-Light;
+      font-family: var(--font-gotham-light);
       font-weight: 100;
       font-size: 30px;
       line-height: 32px;
@@ -92,7 +92,7 @@
     }
 
     .address {
-      font-family: Gotham-Book;
+      font-family: var(--font-gotham-book);
       font-size: 12px;
       width: 300px;
       color: #8d98ae;

--- a/app/styles/main.global.scss
+++ b/app/styles/main.global.scss
@@ -34,6 +34,15 @@
   src: url('../assets/fonts/Gotham-Book.woff') format('woff');
 }
 
+:root {
+  --font-fallback: 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+  --font-gotham: 'Gotham', var(--font-fallback);
+  --font-gotham-medium: 'Gotham-Medium', var(--font-fallback);
+  --font-gotham-bold: 'Gotham-Bold', var(--font-fallback);
+  --font-gotham-thin: 'Gotham-Thin', var(--font-fallback);
+  --font-gotham-book: 'Gotham-Book', var(--font-fallback);
+}
+
 @media print {
   #newWallet {
     font-size: 0.8em;
@@ -48,7 +57,7 @@ input {
   box-sizing: border-box;
   width: 100%;
   height: 100%;
-  font-family: 'Gotham', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+  font-family: var(--font-gotham);
 }
 
 body {


### PR DESCRIPTION
Fixes #1639.

### Approach
Make sure all Gotham font-family properties have generic font fallback (i.e. San-Serif).

### Implementation
For simplicity and and minimal files size gains, I implemented css vars.

```css
:root {
  --font-fallback: 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
  --font-gotham: 'Gotham', var(--font-fallback);
  --font-gotham-medium: 'Gotham-Medium', var(--font-fallback);
  --font-gotham-bold: 'Gotham-Bold', var(--font-fallback);
  --font-gotham-thin: 'Gotham-Thin', var(--font-fallback);
  --font-gotham-book: 'Gotham-Book', var(--font-fallback);
}
```

Then replaced it in all relevant scss files.

### Verification
![font](https://user-images.githubusercontent.com/486954/48317114-f41ba200-e5f5-11e8-9494-8fcfeec72b62.gif)

### Next step
Create a style lint rule that enforces this.