### PR TITLE
Changing SPOT contract address

### DIFF
--- a/app/core/tokenList.json
+++ b/app/core/tokenList.json
@@ -696,9 +696,9 @@
     "networks": {
       "1": {
         "name": "Spotcoin",
-        "hash": "0a91cdc3c5ff89983c79e3c72e1ccd9e5beaa5d5",
+        "hash": "2830fc346b1c7a350914fbaea5ef7b3fbe3c994c",
         "decimals": 8,
-        "totalSupply": 694303
+        "totalSupply": 97807005
       }
     }
   },


### PR DESCRIPTION
we had to change our smart contract for SPOT before the distribution so this is the new contract address. also updated the supply as the supply number was incorrect.

**What current issue(s) from Trello/Github does this address?**
There are some issues because we are pointing to the old smart contract and some users are getting confused as the neon-wallet points to the old smart contract instead of the new one.  

**What problem does this PR solve?**
That users will see their correct amount as well as able to transfer tokens correctly.

**How did you solve this problem?**
I updated the script hash and 

**How did you make sure your solution works?**
I verified the script hash with the developers and they believe that is the problem. 

**Are there any special changes in the code that we should be aware of?**
no, just a change in the constant. 

**Is there anything else we should know?**

- [ ] Unit tests written?
