### PR TITLE
[#1640] Added wallet import name duplication validation

### DIFF
--- a/app/modules/generateWallet.js
+++ b/app/modules/generateWallet.js
@@ -1,7 +1,7 @@
 // @flow
 import storage from 'electron-json-storage'
 import { wallet } from 'neon-js'
-import { isEmpty } from 'lodash-es'
+import { isEmpty, intersectionBy } from 'lodash-es'
 
 import {
   showErrorNotification,
@@ -149,6 +149,13 @@ export const recoverWallet = (wallet: Object): Promise<*> =>
 
       if (!accounts.length) {
         reject(Error('No accounts found in recovery file.'))
+      }
+
+      // check if wallet label already exists
+      const duplicateLabels = intersectionBy(data.accounts, accounts, 'label')
+
+      if (duplicateLabels.length > 0) {
+        reject(Error('A wallet with this name already exists locally.'))
       }
 
       // eslint-disable-next-line


### PR DESCRIPTION
Fixes #1640 

Showing error message if account label in imported wallet already exists in a current account.
Intersecting account labels in current wallet and imported wallet as an indication of dupe name.

![import](https://user-images.githubusercontent.com/486954/48470288-ad969500-e7f9-11e8-96c0-0b3d1652c414.gif)
