### PR TITLE
[#1675] Fixed notification text overlapping

### DIFF
--- a/app/containers/Notifications/overrideStyles.js
+++ b/app/containers/Notifications/overrideStyles.js
@@ -25,6 +25,7 @@ const overrideStyles = {
       display: 'flex',
       alignItems: 'center',
       paddingLeft: '60px',
+      paddingRight: '50px',
       borderRadius: '4px',
       color: '#FFF'
     },


### PR DESCRIPTION
Fixes #1675.

Notification text doesn't have any right padding to prevent overlap with close button. Ez fix.

Before:
 
<img width="630" alt="screen shot 2018-11-14 at 12 32 55" src="https://user-images.githubusercontent.com/486954/48477443-459c7a80-e80a-11e8-9931-c6401f2dd495.png">

After:
<img width="630" alt="screen shot 2018-11-14 at 12 33 55" src="https://user-images.githubusercontent.com/486954/48477452-4a612e80-e80a-11e8-8d96-3f97efe3c691.png">
