### PR TITLE
fix for zero decimal token size calculation bug

### DIFF
--- a/app/containers/Send/Send.jsx
+++ b/app/containers/Send/Send.jsx
@@ -383,8 +383,11 @@ export default class Send extends React.Component<Props, State> {
     }
 
     if (asset !== 'NEO' && asset !== 'GAS') {
-      const decpoint =
-        amountNum.toString().length - 1 - amountNum.toString().indexOf('.')
+      let decpoint = 0
+      if (amountNum.toString().indexOf('.') > -1) {
+        decpoint =
+          amountNum.toString().length - 1 - amountNum.toString().indexOf('.')
+      }
 
       const foundToken: TokenItemType | void = tokens.find(
         token => token.symbol === asset && token.networkId === networkId

--- a/app/containers/Send/Send.jsx
+++ b/app/containers/Send/Send.jsx
@@ -383,17 +383,22 @@ export default class Send extends React.Component<Props, State> {
     }
 
     if (asset !== 'NEO' && asset !== 'GAS') {
-      let decpoint = 0
-      if (amountNum.toString().indexOf('.') > -1) {
-        decpoint =
-          amountNum.toString().length - 1 - amountNum.toString().indexOf('.')
+      let decimalPlaces = 0
+      const amountStr = amountNum.toString()
+      const decPointIndex = amountStr.indexOf('.')
+
+      if (decPointIndex !== -1) {
+        decimalPlaces = amountStr.length - 1 - decPointIndex
       }
 
       const foundToken: TokenItemType | void = tokens.find(
         token => token.symbol === asset && token.networkId === networkId
       )
 
-      if (foundToken && decpoint > toNumber(get(foundToken, 'decimals', 8))) {
+      if (
+        foundToken &&
+        decimalPlaces > toNumber(get(foundToken, 'decimals', 8))
+      ) {
         errors.amount = `You can only send ${asset} up to ${get(
           foundToken,
           'decimals',


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?** 
#1700 

**What problem does this PR solve?**
The regression issue with Neon being unable to send tokens with 0 decimals again. This is caused by a comparison relying on the following assignment in Send.jsx:
```const decpoint = amountNum.toString().length - 1 - amountNum.toString().indexOf('.')```

When no decimals are provided, `indexOf('.')` returns a value of `-1`, which causes the expression to evaluate to `1` instead of `0`, so the comparison of ```decpoint > toNumber(get(foundToken, 'decimals', 8))``` below it results in an error for zero-decimal tokens, since `1 > 0`.

**How did you solve this problem?**
Added logic to ensure zero decimals in the input translates to zero decimals in the comparison check in Send.jsx::validateAmount

**How did you make sure your solution works?**
Tested sending RHT on MainNet with the patch applied

**Are there any special changes in the code that we should be aware of?**
No

**Is there anything else we should know?**
No

- [ ] Unit tests written?
