### PR TITLE
[#1640] Added detail to duplicate wallet name error message

### DIFF
--- a/app/modules/generateWallet.js
+++ b/app/modules/generateWallet.js
@@ -12,6 +12,7 @@ import {
 import { validatePassphraseLength } from '../core/wallet'
 import { ROUTES, DEFAULT_WALLET } from '../core/constants'
 import { Account } from '../core/schemas'
+import toSentence from '../util/toSentence'
 
 // Actions
 import { saveAccountActions, getWallet } from '../actions/accountsActions'
@@ -152,10 +153,16 @@ export const recoverWallet = (wallet: Object): Promise<*> =>
       }
 
       // check if wallet label already exists
-      const duplicateLabels = intersectionBy(data.accounts, accounts, 'label')
+      const dupAccounts = intersectionBy(data.accounts, accounts, 'label')
 
-      if (duplicateLabels.length > 0) {
-        reject(Error('A wallet with this name already exists locally.'))
+      if (dupAccounts.length > 0) {
+        const labels = dupAccounts.map(acc => `"${acc.label}"`)
+        const errMsg =
+          labels.length === 1
+            ? `A wallet named ${labels[0]} already exists locally.`
+            : `Wallets named ${toSentence(labels)} already exist locally.`
+
+        reject(Error(errMsg))
       }
 
       // eslint-disable-next-line


### PR DESCRIPTION
@drptbl [suggested](https://github.com/CityOfZion/neon-wallet/issues/1640#issuecomment-440433218) to indicate duplicate wallet names in import error message.

Before, regardless of how many duplicates were found, the error message stated:
`A wallet with this name already exists locally`.

Now specifying wallet name:
<img width="623" alt="screen shot 2018-11-21 at 7 23 05" src="https://user-images.githubusercontent.com/486954/48821422-eab2d800-ed61-11e8-8bab-b1e30e423166.png">

And for multiple duplicates:
<img width="623" alt="screen shot 2018-11-21 at 7 22 41" src="https://user-images.githubusercontent.com/486954/48821425-eedef580-ed61-11e8-8318-d30a7840c57b.png">
