### PR TITLE
[#1715] Fixed wrong chart currency when changing duration

### DIFF
--- a/app/components/Dashboard/PriceHistoryPanel/index.js
+++ b/app/components/Dashboard/PriceHistoryPanel/index.js
@@ -31,11 +31,11 @@ export default compose(
   // Refetch price history if the selected asset or duration changes
   withState('asset', 'setAsset', ASSETS.NEO),
   withState('duration', 'setDuration', '1d'),
+  withCurrencyData('currency'),
   withActions(priceHistoryActions, mapPriceHistoryActionsToProps),
 
   // Fetch prices data based based upon the selected currency.  Reload data with the currency changes.
   withProgressPanel(priceHistoryPanelActions, { title: 'Market Data' }),
-  withCurrencyData('currency'),
   withPricesData(mapPriceDataToProps),
   withData(priceHistoryActions, mapPriceHistoryDataToProps)
 )(PriceHistoryPanel)


### PR DESCRIPTION
Fixes #1715 

The duration change action works with `duration` and `currency`
```
const mapPriceHistoryActionsToProps = (actions, props) => ({
  setDuration: (duration: Duration) => {
    props.setDuration(duration)
    return actions.call({ duration, currency: props.currency })
  }
})
```
But I noticed `withCurrencyData` doesn't update `props` until _after_ the actions are mapped - hence I assume it falls back to default currency which is the bug reported.

Bumped it up and it's works now🤘