### PR TITLE
Added Flow types and constants to <Transaction>

### DIFF
--- a/__tests__/components/TransactionHistoryPanel.test.js
+++ b/__tests__/components/TransactionHistoryPanel.test.js
@@ -53,7 +53,7 @@ const transactions = [
     amount: '0.11988459',
     asset: { symbol: 'GAS' },
     label: 'Gas Claim',
-    iconType: 'CLAIM',
+    type: 'CLAIM',
     id: '_ymelbt8mb'
   },
   {
@@ -66,7 +66,7 @@ const transactions = [
       symbol: 'MCT'
     },
     label: 'MCT',
-    iconType: 'RECEIVE',
+    type: 'RECEIVE',
     id: '_r3mihxg36'
   }
 ]

--- a/app/actions/transactionHistoryActions.js
+++ b/app/actions/transactionHistoryActions.js
@@ -4,6 +4,7 @@ import { api } from 'neon-js'
 import { createActions } from 'spunky'
 
 import { getDefaultTokens } from '../core/nep5'
+import { TX_TYPES, ASSETS } from '../core/constants'
 
 export const NEO_ID =
   'c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b'
@@ -17,14 +18,14 @@ type Props = {
 }
 
 function parseAbstractData(data, currentUserAddress, tokens) {
-  const parsedIconType = abstract => {
+  const parsedTxType = abstract => {
     if (
       abstract.address_to === currentUserAddress &&
       abstract.address_from !== 'claim'
     )
-      return 'RECEIVE'
-    if (abstract.address_from === 'claim') return 'CLAIM'
-    return 'SEND'
+      return TX_TYPES.RECEIVE
+    if (abstract.address_from === 'claim') return TX_TYPES.CLAIM
+    return TX_TYPES.SEND
   }
 
   const parsedAsset = abstract => {
@@ -32,12 +33,12 @@ function parseAbstractData(data, currentUserAddress, tokens) {
     if (token) return token
     if (abstract.asset === NEO_ID) {
       return {
-        symbol: 'NEO'
+        symbol: ASSETS.NEO
       }
     }
     if (abstract.asset === GAS_ID) {
       return {
-        symbol: 'GAS'
+        symbol: ASSETS.GAS
       }
     }
     return {}
@@ -56,8 +57,8 @@ function parseAbstractData(data, currentUserAddress, tokens) {
 
   return data.map(abstract => {
     const asset = parsedAsset(abstract)
-    const iconType = parsedIconType(abstract)
-    const summary = {
+    const type = parsedTxType(abstract)
+    const summary: TxEntryType = {
       to: parsedTo(abstract),
       isNetworkFee: abstract.address_to === 'fees',
       from: parsedFrom(abstract),
@@ -65,8 +66,8 @@ function parseAbstractData(data, currentUserAddress, tokens) {
       time: abstract.time,
       amount: abstract.amount,
       asset,
-      label: iconType === 'CLAIM' ? 'Gas Claim' : asset.symbol,
-      iconType,
+      label: type === TX_TYPES.CLAIM ? 'Gas Claim' : asset.symbol,
+      type,
       id: `_${Math.random()
         .toString(36)
         .substr(2, 9)}`

--- a/app/components/Send/SendPanel/SendSuccess/index.jsx
+++ b/app/components/Send/SendPanel/SendSuccess/index.jsx
@@ -9,6 +9,7 @@ import { pluralize } from '../../../../util/pluralize'
 import { createFormattedDate } from '../../../../util/createFormattedDate'
 
 import styles from './SendSuccess.scss'
+import { TX_TYPES } from '../../../../core/constants'
 
 type Props = {
   sendRowDetails: Array<*>,
@@ -26,7 +27,7 @@ export default class SendSuccess extends React.Component<Props> {
     const { sendRowDetails, txid } = this.props
     // normalize tx data for Transaction
     const transactions = sendRowDetails.map(row => ({
-      iconType: 'SEND',
+      type: TX_TYPES.SEND,
       amount: row.amount,
       label: row.asset,
       to: row.address,

--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -89,6 +89,12 @@ export const MODAL_TYPES = {
   RECEIVE: 'RECEIVE'
 }
 
+export const TX_TYPES = {
+  SEND: 'SEND',
+  RECEIVE: 'RECEIVE',
+  CLAIM: 'CLAIM'
+}
+
 export const MAIN_NETWORK_ID = '1'
 export const TEST_NETWORK_ID = '2'
 

--- a/flow-typed/declarations.js
+++ b/flow-typed/declarations.js
@@ -8,6 +8,8 @@ import {
   NOTIFICATION_LEVELS,
   NOTIFICATION_POSITIONS,
   MODAL_TYPES,
+  TX_TYPES,
+  ASSETS,
   THEME,
 } from '../app/core/constants'
 
@@ -56,6 +58,19 @@ declare type TransactionHistoryType = {
 }
 
 declare type ModalType = $Values<typeof MODAL_TYPES>
+
+declare type TxType = $Values<typeof TX_TYPES>
+
+declare type TxEntryType = {
+  type: TxType,
+  txid: string,
+  to: string,
+  from?: string,
+  amount: number,
+  label: $Values<typeof ASSETS>,
+  time?: number,
+  isNetworkFee?: boolean
+}
 
 declare type SymbolType = string
 


### PR DESCRIPTION
Following [request to add constants](https://github.com/CityOfZion/neon-wallet/pull/1720/files#r235819733) to transaction types

### Constants
Added `TX_TYPES = { SEND, RECEIVE, CLAIM }`
and changed all instances of `'SEND'` to `TX_TYPES.SEND` etc.

### Types
Added type `TxType` to enforce `TX_TYPES`
```
declare type TxType = $Values<typeof TX_TYPES>
```

Added type `TxEntryType` to neatly declare transaction data:
```
declare type TxEntryType = {
  type: TxType,
  txid: string,
  to: string,
  from?: string,
  amount: number,
  label: $Values<typeof ASSETS>,
  time?: number,
  isNetworkFee?: boolean
}
```

### Renamed property
Renamed `iconType` to `type` as it describes the type of the transaction, and an icon is a mere display implementation of it.

No change to app functionality or appearance.