### PR TITLE
feature: implements confirm modal for contact deletion

### DIFF
--- a/app/components/Contacts/EditContactPanel/EditContactPanel.jsx
+++ b/app/components/Contacts/EditContactPanel/EditContactPanel.jsx
@@ -9,7 +9,7 @@ import ArrowIcon from '../../../assets/icons/arrow.svg'
 import Close from '../../../assets/icons/close.svg'
 import AddIcon from '../../../assets/icons/add.svg'
 import BackButton from '../../BackButton'
-import { ROUTES } from '../../../core/constants'
+import { ROUTES, MODAL_TYPES } from '../../../core/constants'
 import styles from './EditContactPanel.scss'
 
 type Props = {
@@ -17,7 +17,9 @@ type Props = {
   name: string,
   address: string,
   onSave: Function,
-  deleteContact: Function
+  deleteContact: Function,
+  showSuccessNotification: Object => any,
+  showModal: (modalType: string, modalProps: Object) => any
 }
 
 export default class EditContactPanel extends React.Component<Props> {
@@ -73,9 +75,17 @@ export default class EditContactPanel extends React.Component<Props> {
   }
 
   handleDelete = () => {
-    const { name } = this.props
-    if (window.confirm(`Are you sure you want to delete contact "${name}"?`)) {
-      this.props.deleteContact(name)
-    }
+    const { name, showModal, showSuccessNotification } = this.props
+
+    showModal(MODAL_TYPES.CONFIRM, {
+      title: 'Confirm Delete',
+      text: `Please confirm removing contact - ${name}`,
+      onClick: () => {
+        this.props.deleteContact(name)
+        showSuccessNotification({
+          message: 'Contact removal was successful.'
+        })
+      }
+    })
   }
 }

--- a/app/components/Contacts/EditContactPanel/EditContactPanel.jsx
+++ b/app/components/Contacts/EditContactPanel/EditContactPanel.jsx
@@ -17,8 +17,8 @@ type Props = {
   name: string,
   address: string,
   onSave: Function,
-  deleteContact: Function,
-  showSuccessNotification: Object => any,
+  deleteContact: string => void,
+  showSuccessNotification: ({ message: string }) => void,
   showModal: (modalType: string, modalProps: Object) => any
 }
 

--- a/app/components/Contacts/EditContactPanel/index.js
+++ b/app/components/Contacts/EditContactPanel/index.js
@@ -10,6 +10,10 @@ import {
   updateContactActions,
   deleteContactActions
 } from '../../../actions/contactsActions'
+import {
+  showErrorNotification,
+  showSuccessNotification
+} from '../../../modules/notifications'
 import withProgressChange from '../../../hocs/withProgressChange'
 import withFailureNotification from '../../../hocs/withFailureNotification'
 import { showModal } from '../../../modules/modal'
@@ -17,7 +21,9 @@ import { showModal } from '../../../modules/modal'
 const { LOADED } = progressValues
 
 const actionCreators = {
-  showModal
+  showModal,
+  showErrorNotification,
+  showSuccessNotification
 }
 
 const mapContactActionsToProps = (actions, props) => ({


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
fixes https://github.com/CityOfZion/neon-wallet/issues/1702

**What problem does this PR solve?**
makes confirmation modals consistent throughout the application

**How did you solve this problem?**
by leveraging our confirm modal type

**How did you make sure your solution works?**
I verified the happy and unhappy paths... when an error is thrown from `contactsActions.js` the error notification will show and prevent the confirmation modal from showing.

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
