### PR TITLE
feature: adds labels to payment request details

### DIFF
--- a/app/components/Modals/BaseModal/BaseModal.scss
+++ b/app/components/Modals/BaseModal/BaseModal.scss
@@ -40,7 +40,7 @@
 
   svg {
     path {
-      fill: var(--panel-full-height-nav-background);
+      fill: var(--panel-full-height-header-icon-color);
     }
   }
 }

--- a/app/components/Modals/ReceiveModal/ReceiveModal.jsx
+++ b/app/components/Modals/ReceiveModal/ReceiveModal.jsx
@@ -95,10 +95,14 @@ export default class ReceiveModal extends React.Component<Props, State> {
             <div className={styles.sectionTitle}>PAYMENT REQUEST DETAILS</div>
             <div className={styles.sectionContent}>
               <div className={styles.assetAmount}>
+                <label>Amount: </label>
                 {(amount ? `${amount} ` : '') + (assetSymbol || 'NEO')}
               </div>
-              <div className={styles.address}>{address}</div>
+              <div className={styles.address}>
+                <label>Address: </label> {address}
+              </div>
               <div className={styles.description}>
+                <label> Reference: </label>
                 {description || '(No Reference)'}
               </div>
             </div>

--- a/app/components/Modals/ReceiveModal/ReceiveModal.jsx
+++ b/app/components/Modals/ReceiveModal/ReceiveModal.jsx
@@ -95,8 +95,12 @@ export default class ReceiveModal extends React.Component<Props, State> {
             <div className={styles.sectionTitle}>PAYMENT REQUEST DETAILS</div>
             <div className={styles.sectionContent}>
               <div className={styles.assetAmount}>
+                <label>Asset: </label>
+                {assetSymbol || 'NEO'}
+              </div>
+              <div className={styles.assetAmount}>
                 <label>Amount: </label>
-                {(amount ? `${amount} ` : '') + (assetSymbol || 'NEO')}
+                {amount}
               </div>
               <div className={styles.address}>
                 <label>Address: </label> {address}

--- a/app/components/Modals/ReceiveModal/ReceiveModal.jsx
+++ b/app/components/Modals/ReceiveModal/ReceiveModal.jsx
@@ -96,7 +96,7 @@ export default class ReceiveModal extends React.Component<Props, State> {
             <div className={styles.sectionContent}>
               <div className={styles.assetAmount}>
                 <label>Asset: </label>
-                {assetSymbol || 'NEO'}
+                {assetSymbol || ASSETS.NEO}
               </div>
               <div className={styles.assetAmount}>
                 <label>Amount: </label>

--- a/app/components/Modals/ReceiveModal/style.scss
+++ b/app/components/Modals/ReceiveModal/style.scss
@@ -11,6 +11,12 @@
   height: 100%;
 }
 
+label {
+  font-family: var(--font-gotham-thin);
+  text-transform: uppercase;
+  font-size: 14px;
+}
+
 .header {
   display: flex;
   align-items: center;

--- a/app/components/Modals/SendModal/ConfirmDetails/ConfirmDetails.jsx
+++ b/app/components/Modals/SendModal/ConfirmDetails/ConfirmDetails.jsx
@@ -29,22 +29,22 @@ export default class ConfirmDetails extends React.Component<Props> {
           <div className={baseStyles.sectionTitle}>PAYMENT DETAILS</div>
           <div className={styles.paymentDetails}>
             <div className={styles.detailGroup}>
-              <div className={styles.detailName}>Asset</div>
+              <div className={styles.detailName}>Asset:</div>
               <div>{this.getRecipientData('asset')}</div>
             </div>
 
             <div className={styles.detailGroup}>
-              <div className={styles.detailName}>Address</div>
+              <div className={styles.detailName}>Address:</div>
               <div>{this.getRecipientData('address')}</div>
             </div>
 
             <div className={styles.detailGroup}>
-              <div className={styles.detailName}>Amount</div>
+              <div className={styles.detailName}>Amount:</div>
               <div>{this.getRecipientData('amount')}</div>
             </div>
 
             <div className={styles.detailGroup}>
-              <div className={styles.detailName}>Reference</div>
+              <div className={styles.detailName}>Reference:</div>
               <div>{this.getRecipientData('reference')}</div>
             </div>
           </div>

--- a/app/components/Modals/SendModal/ConfirmDetails/ConfirmDetails.jsx
+++ b/app/components/Modals/SendModal/ConfirmDetails/ConfirmDetails.jsx
@@ -34,13 +34,13 @@ export default class ConfirmDetails extends React.Component<Props> {
             </div>
 
             <div className={styles.detailGroup}>
-              <div className={styles.detailName}>Address:</div>
-              <div>{this.getRecipientData('address')}</div>
+              <div className={styles.detailName}>Amount:</div>
+              <div>{this.getRecipientData('amount')}</div>
             </div>
 
             <div className={styles.detailGroup}>
-              <div className={styles.detailName}>Amount:</div>
-              <div>{this.getRecipientData('amount')}</div>
+              <div className={styles.detailName}>Address:</div>
+              <div>{this.getRecipientData('address')}</div>
             </div>
 
             <div className={styles.detailGroup}>

--- a/app/components/Modals/SendModal/ConfirmDetails/ConfirmDetails.scss
+++ b/app/components/Modals/SendModal/ConfirmDetails/ConfirmDetails.scss
@@ -8,7 +8,9 @@
 
   .detailGroup {
     .detailName {
-      font-weight: bold;
+      font-family: var(--font-gotham-thin);
+      text-transform: uppercase;
+      font-size: 14px;
     }
 
     &:not(:first-child) {


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
https://github.com/CityOfZion/neon-wallet/issues/1580

**What problem does this PR solve?**
This PR labels the details of a nep9 payment request for UI clarity... It also updates the labels in Receive for consistent verbage and style

**How did you solve this problem?**

**How did you make sure your solution works?**
Manually reviewing the UI.

<img width="843" alt="screen shot 2018-11-24 at 10 41 15 am" src="https://user-images.githubusercontent.com/13072035/48971355-91eb7580-efd5-11e8-8fcc-a2258ad3582b.png">

<img width="766" alt="screen shot 2018-11-24 at 10 38 40 am" src="https://user-images.githubusercontent.com/13072035/48971325-36b98300-efd5-11e8-845b-b4be09bfdfae.png">

**Are there any special changes in the code that we should be aware of?**

**Is there anything else we should know?**
This PR also updates the style of the back button in modals as it was using the wrong color previously.

- [ ] Unit tests written?
