### PR TITLE
[#1718] Version check revision

### DIFF
--- a/app/modules/metadata.js
+++ b/app/modules/metadata.js
@@ -1,5 +1,6 @@
 // @flow
 import axios from 'axios'
+import retry from 'axios-retry'
 import compareVersions from 'compare-versions'
 
 import { showWarningNotification } from './notifications'
@@ -12,6 +13,11 @@ import { version } from '../../package.json'
 const DOWNLOAD_LINK = `<a href='${NEON_WALLET_RELEASE_LINK}' target='_blank' class="notification-link">${NEON_WALLET_RELEASE_LINK}</a>`
 const CURRENT_RELEASE_URL =
   'https://api.github.com/repos/CityOfZion/neon-wallet/releases/latest'
+export const RETRY_CONFIG = {
+  retries: 3,
+  retryDelay: () => 1000,
+  timeout: 1000
+}
 
 // Actions
 export const checkVersion = () => async (dispatch: DispatchType) => {
@@ -25,6 +31,19 @@ export const checkVersion = () => async (dispatch: DispatchType) => {
       })
     )
 
+  // wait for network connection
+  await new Promise(resolve => {
+    if (navigator.onLine) {
+      resolve()
+    } else {
+      window.addEventListener('online', resolve)
+    }
+  })
+
+  // register retry interceptor
+  retry(axios, RETRY_CONFIG)
+
+  // get latest release data
   try {
     const response = await axios.get(CURRENT_RELEASE_URL)
     const shouldUpdate =
@@ -37,9 +56,5 @@ export const checkVersion = () => async (dispatch: DispatchType) => {
         `Your wallet is out of date! Please download the latest version from ${DOWNLOAD_LINK}`
       )
     }
-  } catch (err) {
-    showError(
-      `Error checking wallet version! Please make sure you have downloaded the latest version: ${DOWNLOAD_LINK}`
-    )
-  }
+  } catch (_) {} // eslint-disable-line no-empty
 }

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   "dependencies": {
     "@ledgerhq/hw-transport-node-hid": "4.7.6",
     "axios": "0.17.0",
+    "axios-retry": "3.1.1",
     "bignumber.js": "5.0.0",
     "buffer": "5.0.8",
     "chai": "^4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1061,6 +1061,13 @@ aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
 
+axios-retry@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/axios-retry/-/axios-retry-3.1.1.tgz#88d2971f671a9023b21d887c5dcac6c54f332cde"
+  integrity sha512-BeNOxa/CBQQLa9gVuMta1oWIhbL6UETKBfAmFjOXwiBxgcmrDBVVwz/gKZTpzKJlVjmi5DeYC+lP5Ng7ssc1pg==
+  dependencies:
+    is-retry-allowed "^1.1.0"
+
 axios@0.17.0:
   version "0.17.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.17.0.tgz#7da747916db803f761651d6091d708789b953c6a"
@@ -6608,7 +6615,7 @@ is-resolvable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
 
-is-retry-allowed@^1.0.0:
+is-retry-allowed@^1.0.0, is-retry-allowed@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
 


### PR DESCRIPTION
Fixes #1718 

**What problem does this PR solve?**
It's reported that although app is up-to-date, an error message suggesting upgrade appears frequently on app start.

**How did you solve this problem?**
1. Stalling version check till network connection is on.
2. Applied retry mechanism upon API request fail.
3. Suppressed error message (till implementing remote logging 😉)

**How did you make sure your solution works?**
1. Mocked app version and got upgrade notification.
2. Turned off internet connection, started app, logged in, turned internet connection back on and verified the API request went out thereafter.
3. Changed API url to http://httpstat.us/500 and verified 4 consecutive network requests.

- [x] Unit tests written? YES
