### PR TITLE
[#1640] Fixed import wallet non-terminating execution bug

### DIFF
--- a/app/modules/generateWallet.js
+++ b/app/modules/generateWallet.js
@@ -163,6 +163,7 @@ export const recoverWallet = (wallet: Object): Promise<*> =>
             : `Wallets named ${toSentence(labels)} already exist locally.`
 
         reject(Error(errMsg))
+        return
       }
 
       // eslint-disable-next-line


### PR DESCRIPTION
@drptbl reported dup wallet importing shows error but persists the import. It's a bug I introduced in #1716. SHAME 😓

#### Solution
TIL `reject` doesn't terminate `Promise` execution.. Added the missing `return` after rejection.
