### PR TITLE
[#1318] PrepWork 2+3/3: Added cancellable ability to util/poll.js

### DIFF
--- a/__tests__/util/poll.test.js
+++ b/__tests__/util/poll.test.js
@@ -1,0 +1,33 @@
+import poll, { TimeoutError } from '../../app/util/poll'
+
+describe('poll functionality', () => {
+  test('should stop when condition fulfilled', async () => {
+    // 10 rounds of 10ms
+    const pollCfg = { attempts: 10, frequency: 10 }
+
+    // pulfill the poll condition after 5th attempt
+    let num = 5
+    const condition = jest.fn(() => {
+      return --num === 0 ? Promise.resolve(num) : Promise.reject()
+    })
+
+    // run poll, expect no exit by error
+    const result = await poll(condition, pollCfg)
+    // expect to have run 5/10 attempts
+    expect(condition).toHaveBeenCalledTimes(5)
+  })
+
+  test('should stop when max attempts reached', async () => {
+    // 10 rounds of 10ms
+    const pollCfg = { attempts: 10, frequency: 10 }
+    // always reject means poll is continuous
+    const condition = jest.fn(() => Promise.reject())
+
+    try {
+      await poll(condition, pollCfg) // run poll
+    } catch (e) {
+      expect(e.name).toBe(TimeoutError.name) // expect it to reach max attempts
+      expect(condition).toHaveBeenCalledTimes(11) // expect to have run 10 (+1) attempts
+    }
+  })
+})

--- a/app/util/poll.js
+++ b/app/util/poll.js
@@ -3,17 +3,24 @@ import delay from './delay'
 const DEFAULT_ATTEMPTS = Infinity
 const DEFAULT_FREQUENCY = 1000
 
+export class TimeoutError extends Error {
+  constructor() {
+    super('Poll reached maximum attempts')
+    this.name = 'TimeoutError'
+  }
+}
+
 export default function poll(
   request,
   { attempts = DEFAULT_ATTEMPTS, frequency = DEFAULT_FREQUENCY } = {}
 ) {
-  return request().catch(function retry(err) {
+  return request().catch(function retry() {
     // eslint-disable-next-line
     if (attempts-- > 0) {
       return delay(frequency)
         .then(request)
         .catch(retry)
     }
-    throw err
+    throw new TimeoutError()
   })
 }


### PR DESCRIPTION
Preparation work for solving #1318.

**tl;dr** Added cancellablePoll

NOTICE: This PR is dependent on #1730. Please defer review until merged.

#### The #1318 Pull Request stack
1. (#1730) PrepWork 1/3: Added util/poll.js unit tests
2. (#1731) PrepWork 2/3: Made util/poll.js cancellable with cancellablePoll
3. (#1731) PrepWork 3/3: Added cancellablePoll unit tests ☜☜☜ _**YOU ARE HERE**_
4. (#1732) Actual 1/2: Enable “Scan QR” button only if camera available
5. (#1733) Actual 2/2: Added camera availability unit tests

#### What's this commit about?
This is prepare work for the actual feature - Enabling/disabling “Scan QR” button depending on camera availability.
The main feature (next commit) polls continuously for camera availability. It's important to cancel the polling if the user clicks away from the login tab.

**Tests:**
Previous poll tests keep passing.
Added new "should be cancellable" test

- [ ] Unit tests written?
