### PR TITLE
[#1318] Actual 1/2: Enable “Scan QR” button only if camera available

### DIFF
--- a/__tests__/components/__snapshots__/Login.test.js.snap
+++ b/__tests__/components/__snapshots__/Login.test.js.snap
@@ -22,6 +22,7 @@ exports[`Login renders without crashing 1`] = `
       className="privateKeyLoginButtonRow"
     >
       <Button
+        disabled={true}
         id="scan-private-key-qr-button"
         onClick={[Function]}
         primary={true}

--- a/__tests__/util/poll.test.js
+++ b/__tests__/util/poll.test.js
@@ -1,0 +1,33 @@
+import poll, { TimeoutError } from '../../app/util/poll'
+
+describe('poll functionality', () => {
+  test('should stop when condition fulfilled', async () => {
+    // 10 rounds of 10ms
+    const pollCfg = { attempts: 10, frequency: 10 }
+
+    // pulfill the poll condition after 5th attempt
+    let num = 5
+    const condition = jest.fn(() => {
+      return --num === 0 ? Promise.resolve(num) : Promise.reject()
+    })
+
+    // run poll, expect no exit by error
+    const result = await poll(condition, pollCfg)
+    // expect to have run 5/10 attempts
+    expect(condition).toHaveBeenCalledTimes(5)
+  })
+
+  test('should stop when max attempts reached', async () => {
+    // 10 rounds of 10ms
+    const pollCfg = { attempts: 10, frequency: 10 }
+    // always reject means poll is continuous
+    const condition = jest.fn(() => Promise.reject())
+
+    try {
+      await poll(condition, pollCfg) // run poll
+    } catch (e) {
+      expect(e.name).toBe(TimeoutError.name) // expect it to reach max attempts
+      expect(condition).toHaveBeenCalledTimes(11) // expect to have run 10 (+1) attempts
+    }
+  })
+})

--- a/app/containers/LoginPrivateKey/LoginPrivateKey.jsx
+++ b/app/containers/LoginPrivateKey/LoginPrivateKey.jsx
@@ -10,7 +10,8 @@ import Close from '../../assets/icons/close.svg'
 import styles from '../Home/Home.scss'
 
 type Props = {
-  loginWithPrivateKey: Function
+  loginWithPrivateKey: Function,
+  cameraAvailable: boolean
 }
 
 type State = {
@@ -35,7 +36,7 @@ export default class LoginPrivateKey extends React.Component<Props, State> {
   }
 
   render = () => {
-    const { loginWithPrivateKey } = this.props
+    const { loginWithPrivateKey, cameraAvailable } = this.props
     const { wif, scannerActive } = this.state
 
     return (
@@ -84,6 +85,7 @@ export default class LoginPrivateKey extends React.Component<Props, State> {
                   primary
                   renderIcon={GridIcon}
                   onClick={this.toggleScanner}
+                  disabled={!cameraAvailable}
                 >
                   Scan QR
                 </Button>

--- a/app/containers/LoginPrivateKey/index.js
+++ b/app/containers/LoginPrivateKey/index.js
@@ -4,6 +4,7 @@ import { withActions } from 'spunky'
 
 import LoginPrivateKey from './LoginPrivateKey'
 import withFailureNotification from '../../hocs/withFailureNotification'
+import withCameraAvailability from '../../hocs/withCameraAvailability'
 import { wifLoginActions } from '../../actions/authActions'
 
 const mapActionsToProps = actions => ({
@@ -12,5 +13,6 @@ const mapActionsToProps = actions => ({
 
 export default compose(
   withActions(wifLoginActions, mapActionsToProps),
-  withFailureNotification(wifLoginActions)
+  withFailureNotification(wifLoginActions),
+  withCameraAvailability
 )(LoginPrivateKey)

--- a/app/hocs/withCameraAvailability.js
+++ b/app/hocs/withCameraAvailability.js
@@ -1,0 +1,99 @@
+// @flow
+import React from 'react'
+import { filter } from 'lodash-es'
+import { cancellablePoll as poll } from '../util/poll'
+import type { CancellableType } from '../util/poll'
+
+const POLL_FREQUENCY = 1000
+
+type State = {
+  avail: boolean
+}
+
+type Props = {}
+
+// $FlowFixMe
+export default function withCameraAvailability(Component) {
+  class CameraAvailability extends React.Component<Props, State> {
+    config = { frequency: POLL_FREQUENCY }
+
+    cancellable: CancellableType
+
+    state = {
+      avail: false
+    }
+
+    componentDidMount() {
+      // start wait for available camera
+      this.awaitAvailable()
+    }
+
+    componentDidUpdate(_: Props, prevState: State) {
+      // cleanup
+      this.cancellable.cancel()
+
+      // if camera found, wait until no longer available
+      // if no camera found, wait until available
+      if (prevState.avail) {
+        this.awaitNotAvailable()
+      } else {
+        this.awaitAvailable()
+      }
+    }
+
+    componentWillUnmount() {
+      // cancel current poll
+      this.cancellable.cancel()
+    }
+
+    // wait till camera is available
+    awaitAvailable = async (): Promise<*> => {
+      // register poll to allow cancellation
+      this.cancellable = poll(this.isCameraAvailable, this.config)
+
+      // once resolved, update the avail state
+      return this.cancellable.promise.then(() => {
+        this.setState({ avail: true })
+      })
+    }
+
+    // wait till camera is no longer available
+    awaitNotAvailable = async (): Promise<*> => {
+      // register poll to allow cancellation
+      this.cancellable = poll(this.noCameraAvailable, this.config)
+
+      // once resolved, update the avail state
+      return this.cancellable.promise.then(() => {
+        this.setState({ avail: false })
+      })
+    }
+
+    // check if any camera devices are available
+    isCameraAvailable = async (): Promise<*> => {
+      // get available cameras
+      const cameras = await this.getCameras()
+      // resolve if found camera, reject if not
+      return cameras.length > 0 ? Promise.resolve() : Promise.reject()
+    }
+
+    // check if no camera devices are available
+    noCameraAvailable = async (): Promise<*> => {
+      // get available cameras
+      const cameras = await this.getCameras()
+      // reject if found camera, resolve if not
+      return cameras.length === 0 ? Promise.resolve() : Promise.reject()
+    }
+
+    // get available cameras
+    getCameras = async (): Promise<Array<MediaDeviceInfoType>> => {
+      const devices = await navigator.mediaDevices.enumerateDevices()
+      return filter(devices, { kind: 'videoinput' })
+    }
+
+    render() {
+      return <Component cameraAvailable={this.state.avail} {...this.props} />
+    }
+  }
+
+  return CameraAvailability
+}

--- a/app/util/poll.js
+++ b/app/util/poll.js
@@ -3,17 +3,24 @@ import delay from './delay'
 const DEFAULT_ATTEMPTS = Infinity
 const DEFAULT_FREQUENCY = 1000
 
+export class TimeoutError extends Error {
+  constructor() {
+    super('Poll reached maximum attempts')
+    this.name = 'TimeoutError'
+  }
+}
+
 export default function poll(
   request,
   { attempts = DEFAULT_ATTEMPTS, frequency = DEFAULT_FREQUENCY } = {}
 ) {
-  return request().catch(function retry(err) {
+  return request().catch(function retry() {
     // eslint-disable-next-line
     if (attempts-- > 0) {
       return delay(frequency)
         .then(request)
         .catch(retry)
     }
-    throw err
+    throw new TimeoutError()
   })
 }

--- a/flow-typed/declarations.js
+++ b/flow-typed/declarations.js
@@ -122,5 +122,23 @@ declare type SendEntryType = {
   symbol: SymbolType
 }
 
- 
- declare type ThemeType = THEME.LIGHT | THEME.DARK
+declare type ThemeType = THEME.LIGHT | THEME.DARK
+
+// polyfill flow's bom since Node does implement navigator.mediaDevices
+declare interface Navigator extends Navigator {
+  mediaDevices: MediaDevicesType;
+}
+
+// https://mdn.io/MediaDevices
+// https://mdn.io/MediaDevices/enumerateDevices
+declare type MediaDevicesType = {
+  enumerateDevices(): Promise<Array<MediaDeviceInfoType>>
+}
+
+// https://mdn.io/MediaDeviceInfo
+declare type MediaDeviceInfoType = {
+  deviceId: string,
+  groupId: string,
+  kind: 'videoinput' | 'audioinput' | 'audiooutput',
+  label: string
+}


### PR DESCRIPTION
Fixes #1318.

**tl;dr** The actual feature work

NOTICE: This PR depends on #1730 and #1731 to be merged so defer review till then plz.

#### The #1318 Pull Request stack
1. (#1730) PrepWork 1/3: Added util/poll.js unit tests
2. (#1731) PrepWork 2/3: Made util/poll.js cancellable with cancellablePoll
3. (#1731) PrepWork 3/3: Added cancellablePoll unit tests
4. (#1732) Actual 1/2: Enable “Scan QR” button only if camera available  ☜☜☜ _**YOU ARE HERE**_
5. (#1733) Actual 2/2: Added camera availability unit tests

#### What's this commit about?
The main feature finally. Basically, once the Private Key Login tab is clicked, the "Scan QR" button isn't enabled until a camera source is found (not "active" but rather "available" in the OS).

This enhancement to `LoginPrivateKey` is implemented with an HOC `withCameraAvailability` which adds a prop `cameraAvailable` to the wrapped component and automatically toggles the boolean value according to actual camera availability.

The availability is determined depending on [`navigator.mediaDevices.enumerateDevices()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/enumerateDevices). This required updating Flow's BOM declarations (this browser feature isn't yet supported in IE 😪...)

The listener is implemented with the `util/poll.js` polling mechanism. When the state of availability changes (for instance, a usb camera was connected), the polling ends, and another is set listening to the opposite value (when the camera is disconnected). Eventually, polling is stopped when component is unmounted.

LETS SEE IT IN ACTION
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/486954/49176340-504f2780-f353-11e8-8fd1-32c0101d7876.gif)

