### PR TITLE
Quick Poll perf optimization

### DIFF
--- a/app/util/poll.js
+++ b/app/util/poll.js
@@ -22,7 +22,7 @@ export function cancellablePoll(
   { attempts = DEFAULT_ATTEMPTS, frequency = DEFAULT_FREQUENCY } = {}
 ) {
   let hasCancelled = false
-  const promise = request().catch(function retry() {
+  const retry = () => {
     if (hasCancelled) {
       throw new CancellationError()
     }
@@ -34,7 +34,8 @@ export function cancellablePoll(
         .catch(retry)
     }
     throw new TimeoutError()
-  })
+  }
+  const promise = request().catch(retry)
 
   return {
     promise,


### PR DESCRIPTION
@comountainclimber [said rightfully](https://github.com/CityOfZion/neon-wallet/pull/1731/files/57ddc3db408b090dfb14ce469c8c9c0e59b476fe#r237591080) that `retry` in `poll` is needlessly repeatedly being redefined, so this commit pulls it out. All tests pass and checked manually that camera availability feature still operating.