### PR TITLE
feature: updates version check notification

### DIFF
--- a/app/containers/Notifications/overrideStyles.js
+++ b/app/containers/Notifications/overrideStyles.js
@@ -63,6 +63,10 @@ const overrideStyles = {
       fontWeight: 200,
       backgroundColor: 'none',
       opacity: '0.8'
+    },
+    warning: {
+      color: '#000000',
+      opacity: 0.4
     }
   }
 }

--- a/app/modules/metadata.js
+++ b/app/modules/metadata.js
@@ -3,7 +3,7 @@ import React from 'react'
 import axios from 'axios'
 import retry from 'axios-retry'
 import compareVersions from 'compare-versions'
-import { shell } from 'electron'
+import { ConditionalLink } from '../util/ConditionalLink'
 
 import { showWarningNotification } from './notifications'
 import {
@@ -56,12 +56,9 @@ export const checkVersion = () => async (dispatch: DispatchType) => {
       showError(
         <div>
           Your wallet is out of date! Please download the latest version from{' '}
-          <div
-            className="notification-download-link"
-            onClick={() => shell.openExternal(NEON_WALLET_RELEASE_LINK)}
-          >
+          <ConditionalLink href={NEON_WALLET_RELEASE_LINK}>
             {NEON_WALLET_RELEASE_LINK}
-          </div>
+          </ConditionalLink>
         </div>
       )
     }

--- a/app/modules/metadata.js
+++ b/app/modules/metadata.js
@@ -1,7 +1,9 @@
 // @flow
+import React from 'react'
 import axios from 'axios'
 import retry from 'axios-retry'
 import compareVersions from 'compare-versions'
+import { shell } from 'electron'
 
 import { showWarningNotification } from './notifications'
 import {
@@ -10,7 +12,6 @@ import {
 } from '../core/constants'
 import { version } from '../../package.json'
 
-const DOWNLOAD_LINK = `<a href='${NEON_WALLET_RELEASE_LINK}' target='_blank' class="notification-link">${NEON_WALLET_RELEASE_LINK}</a>`
 const CURRENT_RELEASE_URL =
   'https://api.github.com/repos/CityOfZion/neon-wallet/releases/latest'
 export const RETRY_CONFIG = {
@@ -21,13 +22,13 @@ export const RETRY_CONFIG = {
 
 // Actions
 export const checkVersion = () => async (dispatch: DispatchType) => {
-  const showError = message =>
+  const showError = children =>
     dispatch(
       showWarningNotification({
-        message,
         autoDismiss: 0,
         stack: true,
-        position: NOTIFICATION_POSITIONS.BOTTOM_CENTER
+        position: NOTIFICATION_POSITIONS.BOTTOM_CENTER,
+        children
       })
     )
 
@@ -53,7 +54,15 @@ export const checkVersion = () => async (dispatch: DispatchType) => {
 
     if (shouldUpdate) {
       showError(
-        `Your wallet is out of date! Please download the latest version from ${DOWNLOAD_LINK}`
+        <div>
+          Your wallet is out of date! Please download the latest version from{' '}
+          <div
+            className="notification-download-link"
+            onClick={() => shell.openExternal(NEON_WALLET_RELEASE_LINK)}
+          >
+            {NEON_WALLET_RELEASE_LINK}
+          </div>
+        </div>
       )
     }
   } catch (_) {} // eslint-disable-line no-empty

--- a/app/modules/notifications.js
+++ b/app/modules/notifications.js
@@ -4,14 +4,15 @@ import { reject, uniqueId } from 'lodash-es'
 import { NOTIFICATION_LEVELS, NOTIFICATION_POSITIONS } from '../core/constants'
 
 type NotificationArgsType = {
-  message: string,
+  message?: string,
   id?: string,
   title?: string,
   position?: $Values<typeof NOTIFICATION_POSITIONS>,
   dismissible?: boolean,
   autoDismiss?: number,
   autoDismiss?: number,
-  stack?: boolean
+  stack?: boolean,
+  children?: React$Node
 }
 
 type NotificationFactoryArgsType = {

--- a/app/styles/main.global.scss
+++ b/app/styles/main.global.scss
@@ -210,6 +210,12 @@ input::placeholder {
   }
 }
 
+.notifications-wrapper {
+  .notification-download-link {
+    color: #0000ff;
+  }
+}
+
 .neon-tabs {
   width: 100%;
 

--- a/main.js
+++ b/main.js
@@ -139,6 +139,14 @@ app.on('ready', () => {
       inputMenu.popup(mainWindow)
     })
 
+    mainWindow.webContents.on('will-navigate', (e, url) => {
+      console.log('will-nav', url, mainWindow.webContents.getURL())
+      if (url.substr(0, 21) !== 'http://localhost:3000') {
+        e.preventDefault()
+        shell.openExternal(url)
+      }
+    })
+
     if (process.env.START_HOT) {
       mainWindow.loadURL(`http://localhost:${port}/dist`)
     } else {

--- a/main.js
+++ b/main.js
@@ -139,14 +139,6 @@ app.on('ready', () => {
       inputMenu.popup(mainWindow)
     })
 
-    mainWindow.webContents.on('will-navigate', (e, url) => {
-      console.log('will-nav', url, mainWindow.webContents.getURL())
-      if (url.substr(0, 21) !== 'http://localhost:3000') {
-        e.preventDefault()
-        shell.openExternal(url)
-      }
-    })
-
     if (process.env.START_HOT) {
       mainWindow.loadURL(`http://localhost:${port}/dist`)
     } else {


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
https://github.com/CityOfZion/neon-wallet/issues/743

**What problem does this PR solve?**
- The link in the version check notification will now behave like the other links found throughout the application
- Fixes a few issues related to styles (low contrast problems)

BEFORE:
<img width="1229" alt="screen shot 2018-12-02 at 8 49 52 pm" src="https://user-images.githubusercontent.com/13072035/49352146-d7faa600-f673-11e8-8e37-de7cba1f5f24.png">


AFTER:
<img width="1221" alt="screen shot 2018-12-02 at 8 48 46 pm" src="https://user-images.githubusercontent.com/13072035/49352108-b699ba00-f673-11e8-98cb-08dfb4bec597.png">



**How did you solve this problem?**
By using electron's `shell.openExternal` https://github.com/electron/electron/blob/master/docs/api/shell.md#shellopenexternalurl-options-callback

**How did you make sure your solution works?**
Manual testing...

**Are there any special changes in the code that we should be aware of?**
`NotificationArgsType` has been updated to include children - see the React Notificaiton System documentation https://github.com/igorprado/react-notification-system#children

**Is there anything else we should know?**

- [ ] Unit tests written?
