### PR TITLE
[#1576] 2/3: QR Scan loading indicator

### DIFF
--- a/app/components/QrCodeScanner/index.js
+++ b/app/components/QrCodeScanner/index.js
@@ -1,1 +1,6 @@
-export { default } from './QrCodeScanner'
+import { compose } from 'recompose'
+
+import withThemeData from '../../hocs/withThemeData'
+import QrCodeScanner from './QrCodeScanner'
+
+export default compose(withThemeData())(QrCodeScanner)

--- a/app/containers/App/Loading.js
+++ b/app/containers/App/Loading.js
@@ -1,13 +1,24 @@
 // @flow
 import React from 'react'
 
+import classNames from 'classnames'
 import themes from '../../themes'
 import Loader from '../../components/Loader'
 import styles from './Loading.scss'
 
-export default function Loading({ theme }: { theme: ThemeType }) {
+export const ANIMATION_DURATION = 900 // one animation round in ms
+
+type Props = {
+  theme: ThemeType,
+  nobackground?: boolean
+}
+
+export default function Loading(props: Props) {
+  const { theme, nobackground: nobg } = props
+  const className = classNames(styles.loading, { [styles.nobackground]: nobg })
+
   return (
-    <div style={themes[theme]} className={styles.loading}>
+    <div style={themes[theme]} className={className}>
       <Loader />
     </div>
   )

--- a/app/containers/App/Loading.scss
+++ b/app/containers/App/Loading.scss
@@ -5,3 +5,7 @@
   width: 100%;
   background: var(--base-main-background);
 }
+
+.nobackground {
+  background: transparent;
+}

--- a/app/containers/Home/Home.scss
+++ b/app/containers/Home/Home.scss
@@ -66,6 +66,7 @@ $navigation-margin: 20px;
   display: flex;
   justify-content: center;
   min-height: 150px;
+  position: relative;
   video {
     min-width: 350px;
     margin-top: -40px;


### PR DESCRIPTION
Fixes #1576 

DEPENDS ON #1744. Plz do not merge before #1744 or the commit history could get messy.

**What problem does this PR solve?**
It was reported that the webcam preview might take up to 5 secs to initialize and a loading indicator is needed.

**How did you solve this problem?**
Added a loading indicator to `QRCodeScanner` which affects both Private Key Login and Send modules thanks to #1744 😋.

![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/486954/49511074-c7744680-f892-11e8-99b4-77f401b0bded.gif)
![ezgif com-video-to-gif 2](https://user-images.githubusercontent.com/486954/49511079-c8a57380-f892-11e8-820c-972f7bb56968.gif)

**How did you make sure your solution works?**
Manually tested that:
a) Other loading indicators remain unaffected.
b) Loading indicator shows up and runs smoothly in both cases.

**Are there any special changes in the code that we should be aware of?**
Plz notice that commits from #1744 are included so only review commit cd1b19e
I've added specific comments in the GitHub commit code.

**Is there anything else we should know?**
The cake is a lie.

- [ ] Unit tests written?
