### PR TITLE
[#1582] 3/3: Added QR scan error handling

### DIFF
--- a/app/components/Modals/SendModal/ReadCode/ReadCode.jsx
+++ b/app/components/Modals/SendModal/ReadCode/ReadCode.jsx
@@ -11,7 +11,7 @@ import baseStyles from '../SendModal.scss'
 import styles from './ReadCode.scss'
 
 type Props = {
-  gotoNextStep: Function,
+  gotoNextStep: (content: string, stopScanner: Function) => void,
   cameraAvailable: boolean
 }
 

--- a/app/components/Modals/SendModal/SendModal.jsx
+++ b/app/components/Modals/SendModal/SendModal.jsx
@@ -45,7 +45,7 @@ export default class SendModal extends React.Component<Props, State> {
     })
   }
 
-  gotoNextStep = (recipientData: Object, stopScanner: Function) => {
+  gotoNextStep = (recipientData: string, stopScanner: Function) => {
     const { error } = this.state
     const { hideNotification } = this.props
 

--- a/app/components/QrCodeScanner/QrCodeScanner.scss
+++ b/app/components/QrCodeScanner/QrCodeScanner.scss
@@ -1,0 +1,16 @@
+.error {
+  color: var(--input-label);
+  text-align: center;
+  .heading svg {
+    vertical-align: middle;
+    position: relative;
+    top: -2px;
+    path {
+      fill: var(--input-error)
+    }
+  }
+  .desc {
+    font-size: 14px;
+    padding: 10px 50px 0;
+  }
+}

--- a/app/components/QrCodeScanner/index.js
+++ b/app/components/QrCodeScanner/index.js
@@ -1,1 +1,6 @@
-export { default } from './QrCodeScanner'
+import { compose } from 'recompose'
+
+import withThemeData from '../../hocs/withThemeData'
+import QrCodeScanner from './QrCodeScanner'
+
+export default compose(withThemeData())(QrCodeScanner)

--- a/app/containers/App/Loading.js
+++ b/app/containers/App/Loading.js
@@ -1,13 +1,24 @@
 // @flow
 import React from 'react'
 
+import classNames from 'classnames'
 import themes from '../../themes'
 import Loader from '../../components/Loader'
 import styles from './Loading.scss'
 
-export default function Loading({ theme }: { theme: ThemeType }) {
+export const ANIMATION_DURATION = 900 // one animation round in ms
+
+type Props = {
+  theme: ThemeType,
+  nobackground?: boolean
+}
+
+export default function Loading(props: Props) {
+  const { theme, nobackground: nobg } = props
+  const className = classNames(styles.loading, { [styles.nobackground]: nobg })
+
   return (
-    <div style={themes[theme]} className={styles.loading}>
+    <div style={themes[theme]} className={className}>
       <Loader />
     </div>
   )

--- a/app/containers/App/Loading.scss
+++ b/app/containers/App/Loading.scss
@@ -5,3 +5,7 @@
   width: 100%;
   background: var(--base-main-background);
 }
+
+.nobackground {
+  background: transparent;
+}

--- a/app/containers/Home/Home.scss
+++ b/app/containers/Home/Home.scss
@@ -66,6 +66,7 @@ $navigation-margin: 20px;
   display: flex;
   justify-content: center;
   min-height: 150px;
+  position: relative;
   video {
     min-width: 350px;
     margin-top: -40px;

--- a/app/containers/LoginPrivateKey/LoginPrivateKey.jsx
+++ b/app/containers/LoginPrivateKey/LoginPrivateKey.jsx
@@ -10,7 +10,7 @@ import Close from '../../assets/icons/close.svg'
 import styles from '../Home/Home.scss'
 
 type Props = {
-  loginWithPrivateKey: Function,
+  loginWithPrivateKey: (content: string) => void,
   cameraAvailable: boolean
 }
 

--- a/app/util/ConditionalLink.jsx
+++ b/app/util/ConditionalLink.jsx
@@ -1,0 +1,29 @@
+// @flow
+import React, { Fragment } from 'react'
+import { shell } from 'electron'
+import Tooltip from '../components/Tooltip'
+
+type Props = {
+  href: ?string,
+  tooltip?: string,
+  children: React$Node
+}
+
+export function ConditionalLink(props: Props): React$Element<*> {
+  const { href, tooltip } = props
+  let { children } = props
+
+  if (href) {
+    if (tooltip) {
+      children = <Tooltip title={tooltip}>{children}</Tooltip>
+    }
+
+    const linkProps = {
+      onClick: () => shell.openExternal(href), // open in default browser
+      href: 'return false' // prevent default
+    }
+
+    return <a {...linkProps}>{children}</a>
+  }
+  return <Fragment>{children}</Fragment>
+}


### PR DESCRIPTION
Fixes #1582 

DEPENDS ON #1745. Plz do not merge before #1745 or the commit history could get messy.

**What problem does this PR solve?**
Firing up the webcam for QR scanning could fail for the following reasons:
a) Camera already in use by other program (I read it [here](https://stackoverflow.com/questions/43919639/what-is-a-trackstarterror))
b) App denied access to camera (easily reproducible)
c) Some unknown reason

Our UI doesn't reflect that to the user:

<img width="320" alt="screen shot 2018-12-05 at 14 34 56" src="https://user-images.githubusercontent.com/486954/49513971-48374080-f89b-11e8-98de-5712424fd2b8.png">

**How did you solve this problem?**
I now catch all errors and show a "Could not connect to camera" error where the webcam preview is expected.

Specifically for `TrackStartError` which adheres to reasons (a) and (b) I add a short note for the user to check that no other program is using the camera and refer to grant appropriate permissions by operating system.

This change applies to both `Send` modal and `LoginPrivateKey` which implement `QrCodeScanner`.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/486954/49563078-e15f6900-f926-11e8-8c79-65d54d97a89e.gif)


And looks fine in `Send` modal:
<img width="320" alt="screen shot 2018-12-06 at 7 14 58" src="https://user-images.githubusercontent.com/486954/49563087-e9b7a400-f926-11e8-9a16-715dfb23409a.png">


**How did you make sure your solution works?**
I tested manually and only on my Mac.
@drptbl would appreciate your help in testing on Windows and Ubuntu as well 🙏🏻

**Are there any special changes in the code that we should be aware of?**
Since I gathered links to the relevant docs for Mac, Win and Lin, so other OS shouldn't render a link but rather plain text. So I created a util `ConditionalLink` which renders an `a` only if the `href` prop has a value. So renders like this:

<img width="320" alt="screen shot 2018-12-06 at 7 16 00" src="https://user-images.githubusercontent.com/486954/49563095-f50acf80-f926-11e8-9cb0-56a6b668f807.png">

**Is there anything else we should know?**
Plz notice that commits from #1745 are included so only review commit 4139dba

- [ ] Unit tests written?
