### PR TITLE
[#1688] Added client side import validation for account key

### DIFF
--- a/app/modules/generateWallet.js
+++ b/app/modules/generateWallet.js
@@ -227,6 +227,13 @@ export const generateNewWalletAccount = (
         return dispatchError('A wallet with this name already exists locally')
       }
 
+      if (walletHasKey(storedWallet, encryptedWIF)) {
+        onFailure()
+        return dispatchError(
+          'A wallet with this address already exists locally'
+        )
+      }
+
       dispatch(
         saveAccountActions.call({
           isImport,


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Addresses #1688 

**What problem does this PR solve?**
Importing PK+passphrase that already exist locally yields an error notification along with a "wallet imported" success message.

**How did you solve this problem?**
My solution is actually superficial - takes care of this specific case before continuing to server.
But I don't think it solves the REAL issue.

AFAIK the real issue is that as a `NEW_WALLET_ACCOUNT` is dispatched
https://github.com/CityOfZion/neon-wallet/blob/545bf77ca68f2da0b4c02483727ba2e794fedfff/app/modules/generateWallet.js#L240-L251
an unconditional redirect occurs to `DisplayWalletAccounts`
https://github.com/CityOfZion/neon-wallet/blob/545bf77ca68f2da0b4c02483727ba2e794fedfff/app/modules/generateWallet.js#L252-L256
which triggers a `saveAccountActions` action that fails
https://github.com/CityOfZion/neon-wallet/blob/545bf77ca68f2da0b4c02483727ba2e794fedfff/app/containers/DisplayWalletAccounts/index.js#L44-L47
resulting in a mix of error notification and success page title.

So to truly fix this, I guess we need to move the save action to `generateWallet` and listen to a success event before redirecting.

So why didn't I implement that?
a) I don't yet feel confident with this kind of sensitive and complex handling. Spunky is confusing to me...
b) This PR is a simple and effective solution for this specific issue. (Not sure there are other probable cases)

Reviewer - feel free to reject this PR if convinced otherwise.
<img src="https://user-images.githubusercontent.com/486954/49665485-b1ff4800-fa5d-11e8-85d2-c3b1df7f42f0.jpg" width=320 />


**How did you make sure your solution works?**
Manually tested.

- [ ] Unit tests written?
