### PR TITLE
feature: fix font size in private key input

### DIFF
--- a/__tests__/components/__snapshots__/Login.test.js.snap
+++ b/__tests__/components/__snapshots__/Login.test.js.snap
@@ -15,6 +15,7 @@ exports[`Login renders without crashing 1`] = `
         autoFocus={true}
         onChange={[Function]}
         placeholder="Enter your private key here"
+        textInputClassName="privateKeyInput"
         value=""
       />
     </div>

--- a/app/components/Inputs/TextInput/TextInput.js
+++ b/app/components/Inputs/TextInput/TextInput.js
@@ -62,7 +62,7 @@ export default class TextInput extends React.Component<Props, State> {
           {this.renderBefore()}
           <input
             {...passDownProps}
-            className={`${styles.input} ${textInputClassName || ''}`}
+            className={classNames(styles.input, textInputClassName)}
             onFocus={this.handleFocus}
             onBlur={this.handleBlur}
           />

--- a/app/containers/Home/Home.scss
+++ b/app/containers/Home/Home.scss
@@ -62,6 +62,13 @@ $navigation-margin: 20px;
   }
 }
 
+.privateKeyInput {
+  font-size: 12px;
+  &::placeholder {
+    font-size: 14px;
+  }
+}
+
 .scannerContainer {
   display: flex;
   justify-content: center;

--- a/app/containers/LoginPrivateKey/LoginPrivateKey.jsx
+++ b/app/containers/LoginPrivateKey/LoginPrivateKey.jsx
@@ -60,6 +60,7 @@ export default class LoginPrivateKey extends React.Component<Props, State> {
             <React.Fragment>
               <div className={styles.centeredInput}>
                 <PasswordInput
+                  textInputClassName={styles.privateKeyInput}
                   placeholder="Enter your private key here"
                   value={wif}
                   onChange={(e: Object) =>


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
This PR fixes https://github.com/CityOfZion/neon-wallet/issues/1737

**What problem does this PR solve?**
Users are unable to see the full string of the WIF when pasted into the home screen private key login input.

**How did you solve this problem?**
I solve this by fixing broken concatanation of classNames in TextInput.js and passing down a CSS class that keeps the placeholder at 14px but reduces the font to 12px. 

**How did you make sure your solution works?**
Tested with numerous private key combinations
![fixed-font-size](https://user-images.githubusercontent.com/13072035/49951344-e9834f80-feb6-11e8-8cd9-ca5713a262e9.gif)


**Are there any special changes in the code that we should be aware of?**

**Is there anything else we should know?**

- [ ] Unit tests written?
