### PR TITLE
feature: fixes config.yml to properly use caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,19 +27,18 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: neon-wallet-{{ checksum "yarn.lock" }}
+          key: neon-wallet-cache-{{ checksum "yarn.lock" }}
       - run: apt-get -y update
       - run: apt-get -y install libusb-1.0-0-dev icnsutils graphicsmagick libudev-dev
       - run: yarn config delete proxy
-      - run: yarn install --network-timeout 1000000 --network-concurrency 1
+      - run: yarn install --frozen-lockfile --network-timeout 1000000 --network-concurrency 1
       - run: yarn lint
       - run: yarn flow
       - run: yarn dist
       - save_cache:
-          key: neon-wallet-{{ checksum "yarn.lock" }}
+          key: neon-wallet-cache-{{ checksum "yarn.lock" }}
           paths:
-            - ~/.yarn-cache
-            - ./node_modules
+            - /usr/local/share/.cache/yarn/v2
       - persist_to_workspace:
           root: *workspace_root
           paths:
@@ -50,12 +49,12 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: neon-wallet-{{ checksum "yarn.lock" }}
+          key: neon-wallet-cache-{{ checksum "yarn.lock" }}
       - run: apt-get -y update
       - run: apt-get -y install libusb-1.0-0-dev graphicsmagick libudev-dev
       - run: apt-get -y install libxtst6 libxss1 libgtk2.0-0 libnss3 libasound2 libgconf-2-4
-      - run: yarn install --network-timeout 1000000 --network-concurrency 1
-      - run: yarn test
+      - run: yarn test-ci
+      # TODO: add these steps back when e2e test suite is functional
       # - run:
       #     name: Running Xvfb for e2e test
       #     command: Xvfb -ac :99 -screen 0 1280x1024x16
@@ -76,7 +75,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: neon-wallet-{{ checksum "yarn.lock" }}
+          key: neon-wallet-cache-{{ checksum "yarn.lock" }}
       - run: apt-get -y update
       - run: apt-get -y install libusb-1.0-0-dev icnsutils graphicsmagick libudev-dev
       - run: apt-get install --no-install-recommends -y gcc-multilib g++-multilib
@@ -92,7 +91,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: neon-wallet-{{ checksum "yarn.lock" }}
+          key: neon-wallet-cache-{{ checksum "yarn.lock" }}
       - run: apt-get -y update
       - run: apt-get -y install libusb-1.0-0-dev icnsutils graphicsmagick libudev-dev
       - run: yarn install --network-timeout 1000000 --network-concurrency 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: neon-wallet-cache-{{ checksum "yarn.lock" }}
+          key: neon-wallet-dependencies-cache-{{ checksum "yarn.lock" }}
       - run: apt-get -y update
       - run: apt-get -y install libusb-1.0-0-dev icnsutils graphicsmagick libudev-dev
       - run: yarn config delete proxy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,10 @@ jobs:
       - run: yarn flow
       - run: yarn dist
       - save_cache:
-          key: neon-wallet-cache-{{ checksum "yarn.lock" }}
+          key: neon-wallet-dependencies-cache-{{ checksum "yarn.lock" }}
           paths:
             - /usr/local/share/.cache/yarn/v2
+            - ./node_modules
       - persist_to_workspace:
           root: *workspace_root
           paths:
@@ -49,7 +50,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: neon-wallet-cache-{{ checksum "yarn.lock" }}
+          key: neon-wallet-dependencies-cache-{{ checksum "yarn.lock" }}
       - run: apt-get -y update
       - run: apt-get -y install libusb-1.0-0-dev graphicsmagick libudev-dev
       - run: apt-get -y install libxtst6 libxss1 libgtk2.0-0 libnss3 libasound2 libgconf-2-4
@@ -75,11 +76,10 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: neon-wallet-cache-{{ checksum "yarn.lock" }}
+          key: neon-wallet-dependencies-cache-{{ checksum "yarn.lock" }}
       - run: apt-get -y update
       - run: apt-get -y install libusb-1.0-0-dev icnsutils graphicsmagick libudev-dev
       - run: apt-get install --no-install-recommends -y gcc-multilib g++-multilib
-      - run: yarn install --network-timeout 1000000 --network-concurrency 1
       - run: yarn assets
       - run: yarn build -w --x64
       - store_artifacts:
@@ -91,10 +91,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: neon-wallet-cache-{{ checksum "yarn.lock" }}
+          key: neon-wallet-dependencies-cache-{{ checksum "yarn.lock" }}
       - run: apt-get -y update
       - run: apt-get -y install libusb-1.0-0-dev icnsutils graphicsmagick libudev-dev
-      - run: yarn install --network-timeout 1000000 --network-concurrency 1
       - run: yarn dist
       - store_artifacts:
           path: dist

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "cross-env START_HOT=1 NODE_ENV=development node_modules/.bin/webpack-dev-server --config ./config/webpack.config.dev",
     "start-dev": "cross-env NODE_ENV=development electron . --enable-logging --remote-debugging-port=9222",
     "assets-dev": "cross-env NODE_ENV=development webpack --config ./config/webpack.config.dev",
-    "test": "npm rebuild node-hid && jest --coverage",
+    "test": "npm rebuild node-hid && ./node_modules/.bin/jest --coverage",
     "test-ci": "yarn test && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "test:e2e": "ava __e2e__/*.e2e.js --timeout=120s -s",
     "test-watch": "jest --watch",


### PR DESCRIPTION
After doing some review of our circleCI set up, and a few hours of messing around I noticed a few issues...

- The path to our yarn cache was incorrect.
- Without the use of `--frozen-lockfile` flag in our yarn install command we were somehow generating a new lock file (within circleCI) that never matched the one we were committing - this was causing our "restore cache" step to always think that there was no cache based on the checksum.
- Without changing the name of the "save cache" key, circleCI was unable to properly update the existing cache (because yarn.lock was not being updates)

This update will dramatically reduce build times (50%+ reduction) as build, test, and deploy phases no longer have to run `yarn` when checksums match 🎉 