### PR TITLE
Fixed missing frame lines in ReadCode

### DIFF
--- a/app/components/Modals/SendModal/ReadCode/ReadCode.jsx
+++ b/app/components/Modals/SendModal/ReadCode/ReadCode.jsx
@@ -65,10 +65,10 @@ export default class ReadCode extends React.Component<Props, State> {
             )}
           >
             <div className={styles.qrCodeScannerPlaceholder}>
-              <div className="frameLineTopLeft" />
-              <div className="frameLineTopRight" />
-              <div className="frameLineBottomLeft" />
-              <div className="frameLineBottomRight" />
+              <div className={styles.frameLineTopRight} />
+              <div className={styles.frameLineTopLeft} />
+              <div className={styles.frameLineBottomRight} />
+              <div className={styles.frameLineBottomLeft} />
               {this.getScanner()}
             </div>
           </div>

--- a/app/components/Modals/SendModal/ReadCode/ReadCode.scss
+++ b/app/components/Modals/SendModal/ReadCode/ReadCode.scss
@@ -14,13 +14,6 @@
   }
 }
 
-.frameLine {
-  position: absolute;
-  width: 20px;
-  height: 20px;
-  border-style: solid;
-}
-
 .scanButtonContainer {
   margin-top: auto;
   margin-bottom: 50px;
@@ -29,43 +22,75 @@
 .qrCodeScannerPlaceholder {
   position: relative;
   display: flex;
-  align-items: center;
   justify-content: center;
   width: 100%;
   height: 220px;
   border-radius: 5px;
   background-color: var(--panel-header);
   padding: 30px 0px;
+}
 
-  .frameLineTopLeft {
-    @extend .frameLine;
+// frameLine placeholder selectors
+%frameLine {
+  content: '';
+  position: absolute;
+  width: 24px;
+  height: 24px;
+  border: {
+    style: solid;
+    width: 3px;
+    radius: 5px;
+  }
+  opacity: 0.5;
+
+  &Top {
     top: 15px;
-    left: 15px;
-    border-width: 2px 0 0 2px;
-    border-top-left-radius: 5px;
+    border-bottom: {
+      color: transparent;
+      left-radius: 0;
+      right-radius: 0;
+    }
   }
 
-  .frameLineTopRight {
-    @extend .frameLine;
-    top: 15px;
-    right: 15px;
-    border-width: 2px 2px 0 0;
-    border-top-right-radius: 5px;
-  }
-
-  .frameLineBottomLeft {
-    @extend .frameLine;
+  &Bottom {
     bottom: 15px;
-    left: 15px;
-    border-width: 0 0 2px 2px;
-    border-bottom-left-radius: 5px;
+    border-top: {
+      color: transparent;
+      left-radius: 0;
+      right-radius: 0;
+    }
   }
 
-  .frameLineBottomRight {
-    @extend .frameLine;
-    bottom: 15px;
+  &Right {
     right: 15px;
-    border-width: 0 2px 2px 0;
-    border-bottom-right-radius: 5px;
+    border: {
+      left-color: transparent;
+      top-left-radius: 0;
+      bottom-left-radius: 0;
+    }
+  }
+
+  &Left {
+    left: 15px;
+    border: {
+      right-color: transparent;
+      top-right-radius: 0;
+      bottom-right-radius: 0;
+    }
+  }
+}
+
+.frameLine {
+  &TopLeft {
+    @extend %frameLine, %frameLineTop, %frameLineLeft;
+  }
+  &TopRight {
+    @extend %frameLine, %frameLineTop, %frameLineRight;
+  }
+  &BottomLeft {
+    @extend %frameLine, %frameLineBottom, %frameLineLeft;
+  }
+  &BottomRight {
+    @extend %frameLine, %frameLineBottom, %frameLineRight;
   }
 }


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Noticed that in the sketch design file there should be markers in the send modal QR scan rubric AND that there are related DOM elements in the code, but the markers do not appear.

Before | After
------------ | -------------
<img width="300" alt="screen shot 2018-12-19 at 15 12 18" src="https://user-images.githubusercontent.com/486954/50222316-93277c80-03a0-11e9-998e-017a99ab25aa.png">|<img width="300" alt="screen shot 2018-12-19 at 15 11 25" src="https://user-images.githubusercontent.com/486954/50222321-96bb0380-03a0-11e9-89be-4658928118fc.png">

**What problem does this PR solve?**
1) The existing DOM element classnames were in plain text instead of CSS module properties.
2) The design implementation wasn't totally accurate - the marker edges should be pointy.
<img width="150" alt="screen shot 2018-12-19 at 14 59 56" src="https://user-images.githubusercontent.com/486954/50221815-09c37a80-039f-11e9-9720-5a43e0d6e670.png">

**How did you solve this problem?**
1) Fixed classnames.
2) Implemented pointy edged with the css border transparent trick.

**How did you make sure your solution works?**
Manually gazed at it like a madman.

**Are there any special changes in the code that we should be aware of?**
Since Sass `@extend` is already used for this, I kicked it up a notch making it into placeholder classes (`.frameLine` -> `%frameLine`) which is better for perf in this case.

It all comes down to this. Ain't it nice? 😬
```css
.frameLine {
  &TopLeft {
    @extend %frameLine, %frameLineTop, %frameLineLeft;
  }
  &TopRight {
    @extend %frameLine, %frameLineTop, %frameLineRight;
  }
  &BottomLeft {
    @extend %frameLine, %frameLineBottom, %frameLineLeft;
  }
  &BottomRight {
    @extend %frameLine, %frameLineBottom, %frameLineRight;
  }
}
```