### PR TITLE
QR Scan - Resume on progress event instead of preset time

### DIFF
--- a/app/components/Modals/SendModal/ReadCode/ReadCode.jsx
+++ b/app/components/Modals/SendModal/ReadCode/ReadCode.jsx
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react'
 import classNames from 'classnames'
+import { type ProgressState } from 'spunky'
 
 import GridIcon from 'assets/icons/grid.svg'
 import CozDonationQrCode from 'assets/images/coz-donation-qr-code.png'
@@ -11,7 +12,8 @@ import baseStyles from '../SendModal.scss'
 import styles from './ReadCode.scss'
 
 type Props = {
-  gotoNextStep: string => any,
+  callback: string => any,
+  callbackProgress: ProgressState,
   cameraAvailable: boolean,
 }
 
@@ -30,9 +32,11 @@ export default class ReadCode extends React.Component<Props, State> {
 
   getScanner = () => {
     if (this.state.scannerActive) {
+      const { callback, callbackProgress } = this.props
       return (
         <QrCodeScanner
-          callback={this.props.gotoNextStep}
+          callback={callback}
+          callbackProgress={callbackProgress}
           width="352"
           height="220"
         />

--- a/app/components/Modals/SendModal/SendModal.jsx
+++ b/app/components/Modals/SendModal/SendModal.jsx
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react'
+import { type ProgressState } from 'spunky'
 
 import BaseModal from '../BaseModal'
 import ReadCode from './ReadCode'
@@ -12,6 +13,7 @@ type Props = {
   getRecipientData: string => any,
   clearRecipientData: () => null,
   recipientData: ?RecipientData,
+  progress: ProgressState,
 }
 
 export default class SendModal extends React.Component<Props> {
@@ -23,7 +25,7 @@ export default class SendModal extends React.Component<Props> {
   }
 
   get stepComponent(): React$Element<ConfirmDetails | ReadCode> {
-    const { recipientData, getRecipientData } = this.props
+    const { recipientData, getRecipientData, progress } = this.props
 
     return recipientData ? (
       <ConfirmDetails
@@ -31,7 +33,7 @@ export default class SendModal extends React.Component<Props> {
         confirmAndClose={() => this.confirmAndClose(recipientData)}
       />
     ) : (
-      <ReadCode gotoNextStep={getRecipientData} />
+      <ReadCode callback={getRecipientData} callbackProgress={progress} />
     )
   }
 

--- a/app/components/Modals/SendModal/index.js
+++ b/app/components/Modals/SendModal/index.js
@@ -1,5 +1,5 @@
 import { compose } from 'recompose'
-import { withActions, withData } from 'spunky'
+import { withActions, withData, withProgress } from 'spunky'
 
 import SendModal from './SendModal'
 import {
@@ -26,6 +26,7 @@ export default compose(
     message =>
       `An error occurred while scanning this QR code: ${message}. Please try again.`,
   ),
+  withProgress(getRecipientData),
 
   withActions(clearRecipientData, mapClearDataToProps),
   withData(clearRecipientData, mapRecipientDataToProps),

--- a/app/containers/LoginPrivateKey/LoginPrivateKey.jsx
+++ b/app/containers/LoginPrivateKey/LoginPrivateKey.jsx
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react'
+import { type ProgressState } from 'spunky'
 
 import QrCodeScanner from '../../components/QrCodeScanner'
 import Button from '../../components/Button'
@@ -12,6 +13,7 @@ import styles from '../Home/Home.scss'
 type Props = {
   loginWithPrivateKey: (content: string) => void,
   cameraAvailable: boolean,
+  progress: ProgressState,
 }
 
 type State = {
@@ -30,7 +32,7 @@ export default class LoginPrivateKey extends React.Component<Props, State> {
   }
 
   render = () => {
-    const { loginWithPrivateKey, cameraAvailable } = this.props
+    const { loginWithPrivateKey, cameraAvailable, progress } = this.props
     const { wif, scannerActive } = this.state
 
     return (
@@ -46,6 +48,7 @@ export default class LoginPrivateKey extends React.Component<Props, State> {
               <div className={styles.scannerContainer}>
                 <QrCodeScanner
                   callback={loginWithPrivateKey}
+                  callbackProgress={progress}
                   width="316"
                   height="178"
                 />

--- a/app/containers/LoginPrivateKey/index.js
+++ b/app/containers/LoginPrivateKey/index.js
@@ -1,6 +1,6 @@
 // @flow
 import { compose } from 'recompose'
-import { withActions } from 'spunky'
+import { withActions, withProgress } from 'spunky'
 
 import LoginPrivateKey from './LoginPrivateKey'
 import withFailureNotification from '../../hocs/withFailureNotification'
@@ -14,5 +14,6 @@ const mapActionsToProps = actions => ({
 export default compose(
   withActions(wifLoginActions, mapActionsToProps),
   withFailureNotification(wifLoginActions),
+  withProgress(wifLoginActions),
   withCameraAvailability,
 )(LoginPrivateKey)


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
This is the last part of the QR Scan fix and refactor commits.

**What problem does this PR solve?**
Since introducing scan pause state in #1760, the scanner has no way of knowing if and when to resume, so a constant 4 second wait is invoked after pause. That's suboptimal since callback response duration cannot be predetermined.

**How did you solve this problem?**
A safer method is to regard a callback error as an indication that scanning should be resumed. 
So I added `withProgress()` to the relevant components (thence #1761) and the scanner now acts upon progress changed from `LOADING` to `FAILED`.

Note: Listening to callback success events is irrelevant since the scanner component is abandoned thereafter.

**How did you make sure your solution works?**
Manually tested.

**Are there any special changes in the code that we should be aware of?**
Put in a 1.5 second resume delay just for better user experience, so it doesn't resume before the callback error notification prompts.

**Is there anything else we should know?**

- [ ] Unit tests written?
