### PR TITLE
Feature: send UX enhancements (ready for review)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -70,7 +70,8 @@
     "react/destructuring-assignment": 0,
     "react/sort-comp": 0,
     "react/button-has-type": 0,
-    "flowtype/generic-spacing": 0
+    "flowtype/generic-spacing": 0,
+    "no-param-reassign": ["warn"]
   },
   "settings": {
     "import/resolver": {

--- a/__tests__/actions/blockHeightActions.test.js
+++ b/__tests__/actions/blockHeightActions.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { api } from 'neon-js'
+import { api } from '@cityofzion/neon-js'
 
 import blockHeightActions from '../../app/actions/blockHeightActions'
 import { TEST_NETWORK_ID } from '../../app/core/constants'

--- a/__tests__/actions/claimsActions.test.js
+++ b/__tests__/actions/claimsActions.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { api, u } from 'neon-js'
+import { api, u } from '@cityofzion/neon-js'
 
 import claimsActions from '../../app/actions/claimsActions'
 import { mockPromiseResolved } from '../testHelpers'

--- a/__tests__/actions/nodeStorageActions.test.js
+++ b/__tests__/actions/nodeStorageActions.test.js
@@ -1,4 +1,4 @@
-import { api } from 'neon-js'
+import { api } from '@cityofzion/neon-js'
 import nock from 'nock'
 
 import nodeStorageActions, {

--- a/__tests__/components/__snapshots__/TransactionHistoryPanel.test.js.snap
+++ b/__tests__/components/__snapshots__/TransactionHistoryPanel.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TransactionHistoryPanel renders without crashing 1`] = `
-<withData(Connect(withData(withProps(Connect(withActions(Connect(withProgress(withProgressComponents(Connect(withActions(Connect(withProgress(withProps(Connect(withData(TransactionHistory))))))))))))))))
+<withData(Connect(withData(withProps(Connect(withActions(Connect(withProgress(withProgressComponents(Connect(withActions(Connect(withCall(Connect(withData(Connect(withProgress(withProps(Connect(withData(TransactionHistory))))))))))))))))))))
   address="AWy7RNBVr9vDadRMK9p7i7Z1tL7GrLAxoh"
   dispatch={[Function]}
   store={

--- a/__tests__/components/__snapshots__/TransactionHistoryPanel.test.js.snap
+++ b/__tests__/components/__snapshots__/TransactionHistoryPanel.test.js.snap
@@ -1,9 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TransactionHistoryPanel renders without crashing 1`] = `
-<withData(Connect(withData(withProps(Connect(withActions(Connect(withProgress(withProgressComponents(Connect(withActions(Connect(withCall(Connect(withData(Connect(withProgress(withProps(Connect(withData(TransactionHistory))))))))))))))))))))
-  address="AWy7RNBVr9vDadRMK9p7i7Z1tL7GrLAxoh"
-  dispatch={[Function]}
+<Connect(withData(Connect(withData(withProps(Connect(withActions(Connect(withProgress(withProgressComponents(Connect(withActions(Connect(withCall(Connect(withData(Connect(withProgress(withProps(Connect(withData(TransactionHistory)))))))))))))))))))))
+  getPendingTransactionInfo={[Function]}
   store={
     Object {
       "clearActions": [Function],
@@ -14,27 +13,5 @@ exports[`TransactionHistoryPanel renders without crashing 1`] = `
       "subscribe": [Function],
     }
   }
-  storeSubscription={
-    t {
-      "listeners": Object {
-        "clear": [Function],
-        "get": [Function],
-        "notify": [Function],
-        "subscribe": [Function],
-      },
-      "onStateChange": [Function],
-      "parentSub": undefined,
-      "store": Object {
-        "clearActions": [Function],
-        "dispatch": [Function],
-        "getActions": [Function],
-        "getState": [Function],
-        "replaceReducer": [Function],
-        "subscribe": [Function],
-      },
-      "unsubscribe": [Function],
-    }
-  }
-  wif="L4SLRcPgqNMAMwM3nFSxnh36f1v5omjPg3Ewy1tg2PnEon8AcHou"
 />
 `;

--- a/__tests__/components/__snapshots__/TransactionHistoryPanel.test.js.snap
+++ b/__tests__/components/__snapshots__/TransactionHistoryPanel.test.js.snap
@@ -1,8 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TransactionHistoryPanel renders without crashing 1`] = `
-<Connect(withData(Connect(withData(withProps(Connect(withActions(Connect(withProgress(withProgressComponents(Connect(withActions(Connect(withCall(Connect(withData(Connect(withProgress(withProps(Connect(withData(TransactionHistory)))))))))))))))))))))
-  getPendingTransactionInfo={[Function]}
+<withData(Connect(withData(withProps(Connect(withActions(Connect(withProgress(withProgressComponents(Connect(withActions(Connect(withCall(Connect(withData(Connect(withProgress(withProps(Connect(withData(TransactionHistory))))))))))))))))))))
+  address="AWy7RNBVr9vDadRMK9p7i7Z1tL7GrLAxoh"
+  dispatch={[Function]}
   store={
     Object {
       "clearActions": [Function],
@@ -13,5 +14,27 @@ exports[`TransactionHistoryPanel renders without crashing 1`] = `
       "subscribe": [Function],
     }
   }
+  storeSubscription={
+    t {
+      "listeners": Object {
+        "clear": [Function],
+        "get": [Function],
+        "notify": [Function],
+        "subscribe": [Function],
+      },
+      "onStateChange": [Function],
+      "parentSub": undefined,
+      "store": Object {
+        "clearActions": [Function],
+        "dispatch": [Function],
+        "getActions": [Function],
+        "getState": [Function],
+        "replaceReducer": [Function],
+        "subscribe": [Function],
+      },
+      "unsubscribe": [Function],
+    }
+  }
+  wif="L4SLRcPgqNMAMwM3nFSxnh36f1v5omjPg3Ewy1tg2PnEon8AcHou"
 />
 `;

--- a/__tests__/setupTests.js
+++ b/__tests__/setupTests.js
@@ -3,7 +3,7 @@ import 'raf/polyfill'
 import { configure } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 import nock from 'nock'
-import { api } from 'neon-js'
+import { api } from '@cityofzion/neon-js'
 
 configure({ adapter: new Adapter() })
 

--- a/app/actions/accountActions.js
+++ b/app/actions/accountActions.js
@@ -5,6 +5,7 @@ import balancesActions from './balancesActions'
 import claimsActions from './claimsActions'
 import pricesActions from './pricesActions'
 import transactionHistoryActions from './transactionHistoryActions'
+import { getPendingTransactionInfo } from './pendingTransactionActions'
 
 export const ID = 'account'
 
@@ -12,5 +13,6 @@ export default createBatchActions(ID, {
   balances: balancesActions,
   claims: claimsActions,
   transactions: transactionHistoryActions,
+  pendingTransactionsInfo: getPendingTransactionInfo,
   prices: pricesActions,
 })

--- a/app/actions/authActions.js
+++ b/app/actions/authActions.js
@@ -1,5 +1,5 @@
 // @flow
-import { wallet } from 'neon-js'
+import { wallet } from '@cityofzion/neon-js'
 import { noop } from 'lodash-es'
 import { createActions } from 'spunky'
 

--- a/app/actions/balancesActions.js
+++ b/app/actions/balancesActions.js
@@ -1,5 +1,5 @@
 // @flow
-import { api } from 'neon-js'
+import { api } from '@cityofzion/neon-js'
 import { extend, isEmpty, get } from 'lodash-es'
 import { createActions } from 'spunky'
 import { Howl } from 'howler'

--- a/app/actions/blockHeightActions.js
+++ b/app/actions/blockHeightActions.js
@@ -1,5 +1,5 @@
 // @flow
-import { api } from 'neon-js'
+import { api } from '@cityofzion/neon-js'
 import { createActions } from 'spunky'
 
 import { getNetworkById } from '../core/deprecated'

--- a/app/actions/claimsActions.js
+++ b/app/actions/claimsActions.js
@@ -1,5 +1,5 @@
 // @flow
-import { api } from 'neon-js'
+import { api } from '@cityofzion/neon-js'
 import { createActions } from 'spunky'
 
 type Props = {

--- a/app/actions/contactsActions.js
+++ b/app/actions/contactsActions.js
@@ -1,6 +1,6 @@
 // @flow
 import { createActions } from 'spunky'
-import { wallet } from 'neon-js'
+import { wallet } from '@cityofzion/neon-js'
 import { has, isEmpty, keys, values, indexOf, zipObject, omit } from 'lodash-es'
 
 import { getStorage, setStorage } from '../core/storage'

--- a/app/actions/icoTokensActions.js
+++ b/app/actions/icoTokensActions.js
@@ -1,5 +1,5 @@
 // @flow
-import { api } from 'neon-js'
+import { api } from '@cityofzion/neon-js'
 import { isEmpty } from 'lodash-es'
 import { createActions } from 'spunky'
 

--- a/app/actions/nodeNetworkActions.js
+++ b/app/actions/nodeNetworkActions.js
@@ -1,5 +1,5 @@
 // @flow
-import { rpc } from 'neon-js'
+import { rpc } from '@cityofzion/neon-js'
 import { createActions } from 'spunky'
 import {
   NODES_MAIN_NET,

--- a/app/actions/nodeStorageActions.js
+++ b/app/actions/nodeStorageActions.js
@@ -1,7 +1,7 @@
 // @flow
 import { createActions } from 'spunky'
 import { isEmpty, random, get, compact } from 'lodash-es'
-import { rpc, api } from 'neon-js'
+import { rpc, api } from '@cityofzion/neon-js'
 
 import { getStorage, setStorage } from '../core/storage'
 import {

--- a/app/actions/pendingTransactionActions.js
+++ b/app/actions/pendingTransactionActions.js
@@ -191,7 +191,7 @@ export const getPendingTransactionInfo = createActions(
             })
 
           if (result) {
-            if (result.confirmations > MINIMUM_CONFIRMATIONS) {
+            if (result.confirmations >= MINIMUM_CONFIRMATIONS) {
               // eslint-disable-next-line
               await pruneConfirmedOrStaleTransaction(address, transaction.hash)
             } else {

--- a/app/actions/pendingTransactionActions.js
+++ b/app/actions/pendingTransactionActions.js
@@ -23,7 +23,7 @@ type PendingTransaction = {
   vout: Array<{ asset: string, address: string, value: string }>,
   sendEntries: Array<SendEntryType>,
   confirmations: number,
-  txid: number,
+  txid: string,
   net_fee: string,
   blocktime: number,
   type: string,
@@ -31,7 +31,7 @@ type PendingTransaction = {
 
 type ParsedPendingTransaction = {
   confirmations: number,
-  txid: number,
+  txid: string,
   net_fee: string,
   blocktime: number,
   to: string,
@@ -54,7 +54,7 @@ export const parseContractTransaction = async (
   for (const send of transaction.vout) {
     parsedData.push({
       confirmations,
-      txid,
+      txid: txid.substring(2),
       net_fee,
       blocktime,
       amount: toBigNumber(send.value).toString(),
@@ -83,7 +83,7 @@ export const parseInvocationTransaction = (
   // use the original send entries array.
   return sendEntries.map(send => ({
     confirmations,
-    txid,
+    txid: txid.substring(2),
     net_fee,
     blocktime,
     amount: toBigNumber(send.amount).toString(),
@@ -135,7 +135,8 @@ export const pruneConfirmedOrStaleTransaction = async (
   const storage = await getPendingTransactions()
   if (Array.isArray(storage[address])) {
     storage[address] = storage[address].filter(
-      transaction => transaction.hash !== txId,
+      // use includes here to be indifferent to 0x prefix
+      transaction => !transaction.hash.includes(txId),
     )
   }
   await setPendingTransactions(storage)

--- a/app/actions/pendingTransactionActions.js
+++ b/app/actions/pendingTransactionActions.js
@@ -1,0 +1,150 @@
+// @flow
+import { createActions } from 'spunky'
+import Neon from '@cityofzion/neon-js'
+import { isEmpty } from 'lodash-es'
+
+import { getStorage, setStorage } from '../core/storage'
+import { getNode, getRPCEndpoint } from './nodeStorageActions'
+import { findAndReturnTokenInfo } from '../util/findAndReturnTokenInfo'
+
+export const ID = 'pendingTransactions'
+const STORAGE_KEY = 'pendingTransactions'
+const MINIMUM_CONFIRMATIONS = 40
+
+type PendingTransactions = {
+  [address: string]: Array<string>,
+}
+
+type PendingTransaction = {
+  vout: Array<{ asset: string, address: string, value: string }>,
+  confirmations: number,
+  txid: number,
+  net_fee: string,
+  blocktime: number,
+}
+
+type ParsedPendingTransaction = {
+  confirmations: number,
+  txid: number,
+  net_fee: string,
+  blocktime: number,
+  to: string,
+  amount: string,
+  asset: string,
+}
+
+export const parsePendingTxInfo = async (
+  pendingTransactionsInfo: Array<PendingTransaction>,
+  net: string,
+) => {
+  const parsedData: Array<ParsedPendingTransaction> = []
+  // eslint-disable-next-line
+  for (const transaction of pendingTransactionsInfo) {
+    if (transaction) {
+      // eslint-disable-next-line
+      const { confirmations, txid, net_fee, blocktime = 0 } = transaction
+      transaction.vout.pop()
+      // eslint-disable-next-line
+      for (const send of transaction.vout) {
+        parsedData.push({
+          confirmations,
+          txid,
+          net_fee,
+          blocktime,
+          amount: send.value,
+          to: send.address,
+          // eslint-disable-next-line no-await-in-loop
+          asset: await findAndReturnTokenInfo(send.asset, net),
+        })
+      }
+    }
+  }
+  const sortedByBlockTime = (
+    a: ParsedPendingTransaction,
+    b: ParsedPendingTransaction,
+  ) => b.blocktime - a.blocktime
+  const sorted: Array<ParsedPendingTransaction> = parsedData.sort(
+    sortedByBlockTime,
+  )
+  return sorted
+}
+
+const getPendingTransactions = async (): Promise<PendingTransactions> =>
+  getStorage(STORAGE_KEY)
+
+const setPendingTransactions = async (
+  pendingTransactions: PendingTransactions,
+): Promise<any> => setStorage(STORAGE_KEY, pendingTransactions)
+
+export const pruneConfirmedOrStaleTransaction = async (
+  address: string,
+  txId: string,
+) => {
+  const storage = await getPendingTransactions()
+  if (Array.isArray(storage[address])) {
+    storage[address] = storage[address].filter(
+      transaction => transaction !== txId,
+    )
+  }
+  await setPendingTransactions(storage)
+}
+
+export const addPendingTransaction = createActions(
+  ID,
+  ({ address, txId }) => async (): Promise<void> => {
+    const transactions = await getPendingTransactions()
+
+    if (Array.isArray(transactions[address])) {
+      transactions[address].push(txId)
+    } else {
+      transactions[address] = []
+    }
+    await setPendingTransactions(transactions)
+  },
+)
+
+export const getPendingTransactionInfo = createActions(
+  ID,
+  ({ address, net }) => async (): Promise<Array<Object>> => {
+    const transactions = await getPendingTransactions()
+    if (Array.isArray(transactions[address]) && transactions[address].length) {
+      let url = await getNode(net)
+      if (isEmpty(url)) {
+        url = await getRPCEndpoint(net)
+      }
+      const client = Neon.create.rpcClient(url)
+
+      const pendingTransactionInfo = []
+
+      // eslint-disable-next-line
+      for (const transaction of transactions[address]) {
+        if (transaction) {
+          // eslint-disable-next-line
+          const result = await client
+            .getRawTransaction(transaction, 1)
+            .catch(async e => {
+              console.error(
+                e,
+                'An transaction was added to storage that the blockchain does not recognize - purging from storage',
+              )
+              await pruneConfirmedOrStaleTransaction(address, transaction)
+            })
+
+          if (result.confirmations > MINIMUM_CONFIRMATIONS) {
+            // eslint-disable-next-line
+            await pruneConfirmedOrStaleTransaction(address, transaction)
+          }
+          pendingTransactionInfo.push(result)
+        }
+      }
+
+      return parsePendingTxInfo(pendingTransactionInfo, net)
+    }
+    return []
+  },
+)
+
+export default createActions(ID, () => async () => {
+  const pendingTransactions = await getPendingTransactions()
+  return pendingTransactions
+})

--- a/app/actions/voteActions.js
+++ b/app/actions/voteActions.js
@@ -1,5 +1,5 @@
 // @flow
-import { api, rpc } from 'neon-js'
+import { api, rpc } from '@cityofzion/neon-js'
 import { createActions } from 'spunky'
 
 import { getNetworkById } from '../core/deprecated'

--- a/app/components/Blockchain/Transaction/ClaimAbstract.jsx
+++ b/app/components/Blockchain/Transaction/ClaimAbstract.jsx
@@ -1,0 +1,61 @@
+// @flow
+import React, { Fragment } from 'react'
+
+import classNames from 'classnames'
+import styles from './Transaction.scss'
+import ClaimIcon from '../../../assets/icons/claim.svg'
+import CopyToClipboard from '../../CopyToClipboard'
+
+type Props = {
+  txDate: React$Node,
+  logo: React$Node,
+  label: string,
+  amount: string | number,
+  contactTo: React$Node | string,
+  to: string,
+  contactToExists: boolean,
+}
+
+export default class ClaimAbstract extends React.Component<Props> {
+  render = () => {
+    const {
+      txDate,
+      logo,
+      label,
+      amount,
+      contactTo,
+      to,
+      contactToExists,
+    } = this.props
+    return (
+      <div className={classNames(styles.transactionContainer)}>
+        <div className={styles.abstractContainer}>
+          <div className={styles.txTypeIconContainer}>
+            <div className={styles.claimIconContainer}>
+              <ClaimIcon />
+            </div>
+          </div>
+          {txDate}
+          <div className={styles.txLabelContainer}>
+            {logo}
+            {label}
+          </div>
+          <div className={styles.txAmountContainer}>{amount}</div>
+          <div className={styles.txToContainer}>
+            <Fragment>
+              <span>{contactTo}</span>
+              {!contactToExists && (
+                <CopyToClipboard
+                  className={styles.copy}
+                  text={to}
+                  tooltip="Copy Public Address"
+                />
+              )}
+            </Fragment>
+          </div>
+          <div className={styles.historyButtonPlaceholder} />
+        </div>
+      </div>
+    )
+  }
+}

--- a/app/components/Blockchain/Transaction/PendingAbstract.jsx
+++ b/app/components/Blockchain/Transaction/PendingAbstract.jsx
@@ -9,20 +9,20 @@ import CopyToClipboard from '../../CopyToClipboard'
 import { pluralize } from '../../../util/pluralize'
 
 type Props = {
-  renderTxDate: (time: ?number) => React$Node | null,
+  txDate: React$Node | null,
   findContact: (address: string) => React$Node | null,
   asset: {
     symbol: string,
     image?: string,
   },
   blocktime: number,
-  amount: string,
+  amount: string | number,
   to: string,
   confirmations: number,
   showAddContactModal: (address: string) => void,
 }
 
-export default class Transaction extends React.Component<Props> {
+export default class PendingAbstract extends React.Component<Props> {
   render = () => {
     const {
       asset,
@@ -32,6 +32,7 @@ export default class Transaction extends React.Component<Props> {
       findContact,
       showAddContactModal,
       confirmations,
+      txDate,
     } = this.props
     const contactTo = findContact(to)
     const contactToExists = contactTo !== to
@@ -47,7 +48,14 @@ export default class Transaction extends React.Component<Props> {
               <SendIcon />
             </div>
           </div>
-          {!!blocktime && this.props.renderTxDate(blocktime)}
+          {!blocktime ? (
+            <div className={styles.pendingTxDate}>
+              awaiting confirmations...
+            </div>
+          ) : (
+            txDate
+          )}
+
           <div className={styles.txLabelContainer}>
             {logo}
             {asset.symbol}

--- a/app/components/Blockchain/Transaction/PendingAbstract.jsx
+++ b/app/components/Blockchain/Transaction/PendingAbstract.jsx
@@ -9,7 +9,6 @@ import CopyToClipboard from '../../CopyToClipboard'
 import { pluralize } from '../../../util/pluralize'
 
 type Props = {
-  txDate: React$Node | null,
   findContact: (address: string) => React$Node | null,
   asset: {
     symbol: string,
@@ -20,6 +19,7 @@ type Props = {
   to: string,
   confirmations: number,
   showAddContactModal: (address: string) => void,
+  renderTxDate: (time: number) => React$Node | null,
 }
 
 export default class PendingAbstract extends React.Component<Props> {
@@ -32,7 +32,7 @@ export default class PendingAbstract extends React.Component<Props> {
       findContact,
       showAddContactModal,
       confirmations,
-      txDate,
+      renderTxDate,
     } = this.props
     const contactTo = findContact(to)
     const contactToExists = contactTo !== to
@@ -53,7 +53,7 @@ export default class PendingAbstract extends React.Component<Props> {
               awaiting confirmations...
             </div>
           ) : (
-            txDate
+            renderTxDate(blocktime)
           )}
 
           <div className={styles.txLabelContainer}>

--- a/app/components/Blockchain/Transaction/PendingTransaction.jsx
+++ b/app/components/Blockchain/Transaction/PendingTransaction.jsx
@@ -1,0 +1,84 @@
+// @flow
+import React, { Fragment } from 'react'
+
+import Button from '../../Button'
+import styles from './Transaction.scss'
+import SendIcon from '../../../assets/icons/send-tx.svg'
+import ContactsAdd from '../../../assets/icons/contacts-add.svg'
+import CopyToClipboard from '../../CopyToClipboard'
+import { pluralize } from '../../../util/pluralize'
+
+type Props = {
+  renderTxDate: (time: ?number) => React$Node | null,
+  findContact: (address: string) => React$Node | null,
+  asset: {
+    symbol: string,
+    image?: string,
+  },
+  blocktime: number,
+  amount: string,
+  to: string,
+  confirmations: number,
+  showAddContactModal: (address: string) => void,
+}
+
+export default class Transaction extends React.Component<Props> {
+  render = () => {
+    const {
+      asset,
+      amount,
+      to,
+      blocktime,
+      findContact,
+      showAddContactModal,
+      confirmations,
+    } = this.props
+    const contactTo = findContact(to)
+    const contactToExists = contactTo !== to
+    const logo = asset.image && (
+      <img src={asset.image} alt={`${asset.symbol} logo`} />
+    )
+
+    return (
+      <Fragment>
+        <div className={styles.abstractContainer}>
+          <div className={styles.txTypeIconContainer}>
+            <div className={styles.sendIconContainer}>
+              <SendIcon />
+            </div>
+          </div>
+          {!!blocktime && this.props.renderTxDate(blocktime)}
+          <div className={styles.txLabelContainer}>
+            {logo}
+            {asset.symbol}
+          </div>
+          <div className={styles.txAmountContainer}>{amount}</div>
+          <div className={styles.txToContainer}>
+            <Fragment>
+              <span>{contactTo}</span>
+              {!contactToExists && (
+                <CopyToClipboard
+                  className={styles.copy}
+                  text={to}
+                  tooltip="Copy Public Address"
+                />
+              )}
+            </Fragment>
+          </div>
+          <Button
+            className={styles.transactionHistoryButton}
+            renderIcon={ContactsAdd}
+            onClick={() => showAddContactModal(to)}
+            disabled={contactToExists}
+          >
+            Add
+          </Button>
+        </div>
+        <div className={styles.confirmationsContainer}>
+          <b>{confirmations || 0}</b>{' '}
+          {pluralize('Confirmation', confirmations || 0)}
+        </div>
+      </Fragment>
+    )
+  }
+}

--- a/app/components/Blockchain/Transaction/ReceiveAbstract.jsx
+++ b/app/components/Blockchain/Transaction/ReceiveAbstract.jsx
@@ -1,0 +1,80 @@
+// @flow
+import React from 'react'
+import classNames from 'classnames'
+
+import Button from '../../Button'
+import styles from './Transaction.scss'
+import ReceiveIcon from '../../../assets/icons/receive-tx.svg'
+import ContactsAdd from '../../../assets/icons/contacts-add.svg'
+import CopyToClipboard from '../../CopyToClipboard'
+
+type Props = {
+  txDate: React$Node,
+  logo: React$Node,
+  label: string,
+  amount: string | number,
+  showAddContactModal: (from: string) => void,
+  contactFromExists: boolean,
+  from: string,
+  address: string,
+  contactFrom: React$Node | string,
+  contactFromExists: boolean,
+}
+
+export default class ReceiveAbstract extends React.Component<Props> {
+  render = () => {
+    const {
+      txDate,
+      logo,
+      label,
+      amount,
+      contactFrom,
+      showAddContactModal,
+      contactFromExists,
+      from,
+      address,
+    } = this.props
+    const isMintTokens = from === 'MINT TOKENS'
+    const isGasClaim = address === from && !Number(amount)
+    return (
+      <div className={classNames(styles.transactionContainer)}>
+        <div className={styles.abstractContainer}>
+          <div className={styles.txTypeIconContainer}>
+            <div className={styles.receiveIconContainer}>
+              <ReceiveIcon />
+            </div>
+          </div>
+          {txDate}
+          <div className={styles.txLabelContainer}>
+            {logo}
+            {label}
+          </div>
+          <div className={styles.txAmountContainer}>{amount}</div>
+          <div className={styles.txToContainer}>
+            <span>{contactFrom}</span>
+            {!contactFromExists &&
+              !isMintTokens && (
+                <CopyToClipboard
+                  className={styles.copy}
+                  text={from}
+                  tooltip="Copy Public Address"
+                />
+              )}
+          </div>
+          {isMintTokens || isGasClaim ? (
+            <div className={styles.transactionHistoryButton} />
+          ) : (
+            <Button
+              className={styles.transactionHistoryButton}
+              renderIcon={ContactsAdd}
+              onClick={() => showAddContactModal(from)}
+              disabled={contactFromExists}
+            >
+              Add
+            </Button>
+          )}
+        </div>
+      </div>
+    )
+  }
+}

--- a/app/components/Blockchain/Transaction/SendAbstract.jsx
+++ b/app/components/Blockchain/Transaction/SendAbstract.jsx
@@ -15,7 +15,6 @@ type Props = {
   amount: string | number,
   contactTo: React$Node | string,
   to: string,
-
   contactToExists: boolean,
   showAddContactModal: (to: string) => void,
   isNetworkFee: boolean,

--- a/app/components/Blockchain/Transaction/SendAbstract.jsx
+++ b/app/components/Blockchain/Transaction/SendAbstract.jsx
@@ -1,0 +1,83 @@
+// @flow
+import React, { Fragment } from 'react'
+import classNames from 'classnames'
+
+import Button from '../../Button'
+import styles from './Transaction.scss'
+import SendIcon from '../../../assets/icons/send-tx.svg'
+import ContactsAdd from '../../../assets/icons/contacts-add.svg'
+import CopyToClipboard from '../../CopyToClipboard'
+
+type Props = {
+  txDate: React$Node,
+  logo: React$Node,
+  label: string,
+  amount: string | number,
+  contactTo: React$Node | string,
+  to: string,
+
+  contactToExists: boolean,
+  showAddContactModal: (to: string) => void,
+  isNetworkFee: boolean,
+}
+
+export default class SendAbstract extends React.Component<Props> {
+  render = () => {
+    const {
+      txDate,
+      logo,
+      label,
+      amount,
+      contactTo,
+      to,
+      contactToExists,
+      showAddContactModal,
+      isNetworkFee,
+    } = this.props
+    return (
+      <div className={classNames(styles.transactionContainer)}>
+        <div className={styles.abstractContainer}>
+          <div className={styles.txTypeIconContainer}>
+            <div className={styles.sendIconContainer}>
+              <SendIcon />
+            </div>
+          </div>
+          {txDate}
+          <div className={styles.txLabelContainer}>
+            {logo}
+            {label}
+          </div>
+          <div className={styles.txAmountContainer}>{amount}</div>
+          <div className={styles.txToContainer}>
+            {isNetworkFee ? (
+              to
+            ) : (
+              <Fragment>
+                <span>{contactTo}</span>
+                {!contactToExists && (
+                  <CopyToClipboard
+                    className={styles.copy}
+                    text={to}
+                    tooltip="Copy Public Address"
+                  />
+                )}
+              </Fragment>
+            )}
+          </div>
+          {isNetworkFee ? (
+            <div className={styles.historyButtonPlaceholder} />
+          ) : (
+            <Button
+              className={styles.transactionHistoryButton}
+              renderIcon={ContactsAdd}
+              onClick={() => showAddContactModal(to)}
+              disabled={contactToExists}
+            >
+              Add
+            </Button>
+          )}
+        </div>
+      </div>
+    )
+  }
+}

--- a/app/components/Blockchain/Transaction/Transaction.jsx
+++ b/app/components/Blockchain/Transaction/Transaction.jsx
@@ -8,6 +8,7 @@ import classNames from 'classnames'
 import { TX_TYPES } from '../../../core/constants'
 
 import Button from '../../Button'
+import PendingTransaction from './PendingTransaction'
 import { openExplorerTx } from '../../../core/explorer'
 import styles from './Transaction.scss'
 import ClaimIcon from '../../../assets/icons/claim.svg'
@@ -20,30 +21,57 @@ import Tooltip from '../../Tooltip'
 
 type Props = {
   tx: TxEntryType,
+  pendingTx: {
+    asset: {
+      symbol: string,
+      image?: string,
+    },
+    blocktime: number,
+    amount: string,
+    to: string,
+    confirmations: number,
+  },
   networkId: string,
   explorer: ExplorerType,
   contacts: Object,
   showAddContactModal: ({ address: string }) => null,
   address: string,
   className?: string,
+  isPending?: boolean,
 }
 
 export default class Transaction extends React.Component<Props> {
+  static defaultProps = {
+    tx: {},
+  }
+
   render = () => {
     const {
       tx: { type },
       className,
+      isPending,
     } = this.props
     return (
       <div className={classNames(styles.transactionContainer, className)}>
-        {this.renderAbstract(type)}
-        <Button
-          className={styles.transactionHistoryButton}
-          renderIcon={InfoIcon}
-          onClick={this.handleClick}
-        >
-          View
-        </Button>
+        {isPending ? (
+          <PendingTransaction
+            renderTxDate={this.renderTxDate}
+            findContact={this.findContact}
+            showAddContactModal={this.displayModal}
+            {...this.props.pendingTx}
+          />
+        ) : (
+          <Fragment>
+            {this.renderAbstract(type)}
+            <Button
+              className={styles.transactionHistoryButton}
+              renderIcon={InfoIcon}
+              onClick={this.handleClick}
+            >
+              View
+            </Button>
+          </Fragment>
+        )}
       </div>
     )
   }
@@ -86,11 +114,11 @@ export default class Transaction extends React.Component<Props> {
   }
 
   renderAbstract = (type: string) => {
-    const { time, label, amount, isNetworkFee, to, from } = this.props.tx
+    const { time, label, amount, isNetworkFee, to, from, image } = this.props.tx
 
     const contactTo = this.findContact(to)
     const contactToExists = contactTo !== to
-
+    const logo = image && <img src={image} alt={`${label}`} />
     const txDate = this.renderTxDate(time)
 
     switch (type) {
@@ -103,7 +131,10 @@ export default class Transaction extends React.Component<Props> {
               </div>
             </div>
             {txDate}
-            <div className={styles.txLabelContainer}>{label}</div>
+            <div className={styles.txLabelContainer}>
+              {logo}
+              {label}
+            </div>
             <div className={styles.txAmountContainer}>{amount}</div>
             <div className={styles.txToContainer}>
               <Fragment>
@@ -129,7 +160,10 @@ export default class Transaction extends React.Component<Props> {
               </div>
             </div>
             {txDate}
-            <div className={styles.txLabelContainer}>{label}</div>
+            <div className={styles.txLabelContainer}>
+              {logo}
+              {label}
+            </div>
             <div className={styles.txAmountContainer}>{amount}</div>
             <div className={styles.txToContainer}>
               {isNetworkFee ? (
@@ -178,7 +212,10 @@ export default class Transaction extends React.Component<Props> {
               </div>
             </div>
             {txDate}
-            <div className={styles.txLabelContainer}>{label}</div>
+            <div className={styles.txLabelContainer}>
+              {logo}
+              {label}
+            </div>
             <div className={styles.txAmountContainer}>{amount}</div>
             <div className={styles.txToContainer}>
               <span>{contactFrom}</span>

--- a/app/components/Blockchain/Transaction/Transaction.jsx
+++ b/app/components/Blockchain/Transaction/Transaction.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React, { Fragment } from 'react'
+import React from 'react'
 import type { Node } from 'react'
 
 import moment from 'moment'
@@ -8,15 +8,13 @@ import classNames from 'classnames'
 import { TX_TYPES } from '../../../core/constants'
 
 import Button from '../../Button'
-import PendingTransaction from './PendingTransaction'
+import PendingAbstract from './PendingAbstract'
+import ClaimAbstract from './ClaimAbstract'
+import SendAbstract from './SendAbstract'
+import ReceiveAbstract from './ReceiveAbstract'
+import InfoIcon from '../../../assets/icons/info.svg'
 import { openExplorerTx } from '../../../core/explorer'
 import styles from './Transaction.scss'
-import ClaimIcon from '../../../assets/icons/claim.svg'
-import SendIcon from '../../../assets/icons/send-tx.svg'
-import ReceiveIcon from '../../../assets/icons/receive-tx.svg'
-import ContactsAdd from '../../../assets/icons/contacts-add.svg'
-import InfoIcon from '../../../assets/icons/info.svg'
-import CopyToClipboard from '../../CopyToClipboard'
 import Tooltip from '../../Tooltip'
 
 type Props = {
@@ -53,30 +51,21 @@ export default class Transaction extends React.Component<Props> {
     } = this.props
     return (
       <div className={classNames(styles.transactionContainer, className)}>
-        {isPending ? (
-          <PendingTransaction
-            renderTxDate={this.renderTxDate}
-            findContact={this.findContact}
-            showAddContactModal={this.displayModal}
-            {...this.props.pendingTx}
-          />
-        ) : (
-          <Fragment>
-            {this.renderAbstract(type)}
-            <Button
-              className={styles.transactionHistoryButton}
-              renderIcon={InfoIcon}
-              onClick={this.handleClick}
-            >
-              View
-            </Button>
-          </Fragment>
+        {this.renderAbstract(type)}
+        {!isPending && (
+          <Button
+            className={styles.transactionHistoryButton}
+            renderIcon={InfoIcon}
+            onClick={this.handleViewTransaction}
+          >
+            View
+          </Button>
         )}
       </div>
     )
   }
 
-  findContact = (address: string): Node => {
+  findContact = (address: string): Node | string => {
     const { contacts } = this.props
     if (contacts && !isEmpty(contacts)) {
       const label = contacts[address]
@@ -95,7 +84,7 @@ export default class Transaction extends React.Component<Props> {
     this.props.showAddContactModal({ address })
   }
 
-  handleClick = () => {
+  handleViewTransaction = () => {
     const { networkId, explorer, tx } = this.props
     const { txid } = tx
     openExplorerTx(networkId, explorer, txid)
@@ -114,136 +103,43 @@ export default class Transaction extends React.Component<Props> {
   }
 
   renderAbstract = (type: string) => {
+    const { isPending, address } = this.props
     const { time, label, amount, isNetworkFee, to, from, image } = this.props.tx
-
     const contactTo = this.findContact(to)
+    const contactFrom = from && this.findContact(from)
     const contactToExists = contactTo !== to
+    const contactFromExists = contactFrom !== from
     const logo = image && <img src={image} alt={`${label}`} />
     const txDate = this.renderTxDate(time)
 
+    const abstractProps = {
+      txDate,
+      logo,
+      contactTo,
+      amount,
+      contactFrom,
+      contactToExists,
+      findContact: this.findContact,
+      showAddContactModal: this.displayModal,
+      isNetworkFee,
+      contactFromExists,
+      from,
+      address,
+      ...this.props.tx,
+    }
+
+    if (isPending) {
+      return <PendingAbstract {...abstractProps} {...this.props.pendingTx} />
+    }
+
     switch (type) {
       case TX_TYPES.CLAIM:
-        return (
-          <div className={styles.abstractContainer}>
-            <div className={styles.txTypeIconContainer}>
-              <div className={styles.claimIconContainer}>
-                <ClaimIcon />
-              </div>
-            </div>
-            {txDate}
-            <div className={styles.txLabelContainer}>
-              {logo}
-              {label}
-            </div>
-            <div className={styles.txAmountContainer}>{amount}</div>
-            <div className={styles.txToContainer}>
-              <Fragment>
-                <span>{contactTo}</span>
-                {!contactToExists && (
-                  <CopyToClipboard
-                    className={styles.copy}
-                    text={to}
-                    tooltip="Copy Public Address"
-                  />
-                )}
-              </Fragment>
-            </div>
-            <div className={styles.historyButtonPlaceholder} />
-          </div>
-        )
+        return <ClaimAbstract {...abstractProps} />
       case TX_TYPES.SEND:
-        return (
-          <div className={styles.abstractContainer}>
-            <div className={styles.txTypeIconContainer}>
-              <div className={styles.sendIconContainer}>
-                <SendIcon />
-              </div>
-            </div>
-            {txDate}
-            <div className={styles.txLabelContainer}>
-              {logo}
-              {label}
-            </div>
-            <div className={styles.txAmountContainer}>{amount}</div>
-            <div className={styles.txToContainer}>
-              {isNetworkFee ? (
-                to
-              ) : (
-                <Fragment>
-                  <span>{contactTo}</span>
-                  {!contactToExists && (
-                    <CopyToClipboard
-                      className={styles.copy}
-                      text={to}
-                      tooltip="Copy Public Address"
-                    />
-                  )}
-                </Fragment>
-              )}
-            </div>
-            {isNetworkFee ? (
-              <div className={styles.historyButtonPlaceholder} />
-            ) : (
-              <Button
-                className={styles.transactionHistoryButton}
-                renderIcon={ContactsAdd}
-                onClick={() => this.displayModal(to)}
-                disabled={contactToExists}
-              >
-                Add
-              </Button>
-            )}
-          </div>
-        )
+        return <SendAbstract {...abstractProps} />
       case TX_TYPES.RECEIVE: {
-        if (!from) {
-          // shouldn't happen but for flow's sake
-          return null
-        }
-        const contactFrom = this.findContact(from)
-        const contactFromExists = contactFrom !== from
-        const isMintTokens = from === 'MINT TOKENS'
-        const isGasClaim = this.props.address === from && !Number(amount)
-        return (
-          <div className={styles.abstractContainer}>
-            <div className={styles.txTypeIconContainer}>
-              <div className={styles.receiveIconContainer}>
-                <ReceiveIcon />
-              </div>
-            </div>
-            {txDate}
-            <div className={styles.txLabelContainer}>
-              {logo}
-              {label}
-            </div>
-            <div className={styles.txAmountContainer}>{amount}</div>
-            <div className={styles.txToContainer}>
-              <span>{contactFrom}</span>
-              {!contactFromExists &&
-                !isMintTokens && (
-                  <CopyToClipboard
-                    className={styles.copy}
-                    text={from}
-                    tooltip="Copy Public Address"
-                  />
-                )}
-            </div>
-            {isMintTokens || isGasClaim ? (
-              <div className={styles.transactionHistoryButton} />
-            ) : (
-              <Button
-                className={styles.transactionHistoryButton}
-                renderIcon={ContactsAdd}
-                onClick={() => this.displayModal(from)}
-                disabled={contactFromExists}
-              >
-                Add
-              </Button>
-            )}
-          </div>
-        )
+        return <ReceiveAbstract {...abstractProps} />
       }
-
       default:
         console.warn('renderTxTypeIcon() invoked with an invalid argument!', {
           type,

--- a/app/components/Blockchain/Transaction/Transaction.jsx
+++ b/app/components/Blockchain/Transaction/Transaction.jsx
@@ -129,7 +129,13 @@ export default class Transaction extends React.Component<Props> {
     }
 
     if (isPending) {
-      return <PendingAbstract {...abstractProps} {...this.props.pendingTx} />
+      return (
+        <PendingAbstract
+          {...abstractProps}
+          {...this.props.pendingTx}
+          renderTxDate={this.renderTxDate}
+        />
+      )
     }
 
     switch (type) {

--- a/app/components/Blockchain/Transaction/Transaction.scss
+++ b/app/components/Blockchain/Transaction/Transaction.scss
@@ -13,6 +13,13 @@
   font-family: var(--font-gotham-book);
 }
 
+.pendingTxDate {
+  @extend .txDateContainer;
+  font-style: italic;
+  font-size: 12px;
+  text-transform: uppercase;
+}
+
 .txLabelContainer {
   font-family: var(--font-gotham-book);
   font-size: 14px;
@@ -67,11 +74,11 @@
 
 .confirmationsContainer {
   max-width: 90px;
+  min-width: 90px;
   text-align: center;
   font-size: 12px;
   display: flex;
   flex-direction: column;
-  // justify-content: center;
 }
 
 .transactionContainer {

--- a/app/components/Blockchain/Transaction/Transaction.scss
+++ b/app/components/Blockchain/Transaction/Transaction.scss
@@ -16,8 +16,17 @@
 .txLabelContainer {
   font-family: var(--font-gotham-book);
   font-size: 14px;
+  display: flex;
   text-align: center;
   width: 75px;
+  flex-direction: column;
+  align-items: center;
+
+  img {
+    max-height: 25px;
+    max-width: 25px;
+    margin-bottom: 5px;
+  }
 }
 
 .txAmountContainer {
@@ -54,6 +63,15 @@
 
 .historyButtonPlaceholder {
   width: 90px;
+}
+
+.confirmationsContainer {
+  max-width: 90px;
+  text-align: center;
+  font-size: 12px;
+  display: flex;
+  flex-direction: column;
+  // justify-content: center;
 }
 
 .transactionContainer {

--- a/app/components/Contacts/ContactForm/ContactForm.jsx
+++ b/app/components/Contacts/ContactForm/ContactForm.jsx
@@ -2,7 +2,7 @@
 import React from 'react'
 import { noop } from 'lodash-es'
 
-import { wallet } from 'neon-js'
+import { wallet } from '@cityofzion/neon-js'
 
 import Button from '../../Button'
 import TextInput from '../../Inputs/TextInput'

--- a/app/components/TransactionHistory/TransactionHistoryPanel/TransactionHistoryPanel.jsx
+++ b/app/components/TransactionHistory/TransactionHistoryPanel/TransactionHistoryPanel.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react'
 import classNames from 'classnames'
-import { intersection } from 'lodash-es'
+import { intersectionBy } from 'lodash-es'
 
 import Transactions from './Transactions'
 import Panel from '../../Panel'
@@ -44,7 +44,7 @@ export default class TransactionHistory extends React.Component<Props> {
     const { transactions, pendingTransactions } = this.props
     const confirmed = transactions.map(tx => tx.txid)
     return pendingTransactions.reduce((accum, currVal) => {
-      if (confirmed.find(tx => tx === currVal.txid.substring(2))) return accum
+      if (confirmed.find(tx => tx === currVal.txid)) return accum
       accum.push(currVal)
       return accum
     }, [])
@@ -52,14 +52,11 @@ export default class TransactionHistory extends React.Component<Props> {
 
   async pruneReturnedTransactionsFromStorage() {
     const { transactions, pendingTransactions, address } = this.props
-    const confirmed = transactions.map(tx => tx.txid)
-    // NOTE: removes the '0x' prepended to every txId
-    const pending = pendingTransactions.map(tx => tx.txid.substring(2))
-    const toBePurged = intersection(confirmed, pending)
+    const toBePurged = intersectionBy(transactions, pendingTransactions, 'txId')
     // eslint-disable-next-line
-    for (const id of toBePurged) {
+    for (const transaction of toBePurged) {
       // eslint-disable-next-line
-      await pruneConfirmedOrStaleTransaction(address, id)
+      await pruneConfirmedOrStaleTransaction(address, transaction.txid)
     }
   }
 

--- a/app/components/TransactionHistory/TransactionHistoryPanel/TransactionHistoryPanel.jsx
+++ b/app/components/TransactionHistory/TransactionHistoryPanel/TransactionHistoryPanel.jsx
@@ -1,21 +1,27 @@
 // @flow
 import React from 'react'
 import classNames from 'classnames'
+import { intersection } from 'lodash-es'
 
 import Transactions from './Transactions'
 import Panel from '../../Panel'
-
+import { pruneConfirmedOrStaleTransaction } from '../../../actions/pendingTransactionActions'
 import styles from './TransactionHistoryPanel.scss'
 
 type Props = {
   className: ?string,
   transactions: Array<Object>,
+  pendingTransactions: Array<Object>,
   handleFetchAddtionalTxData: () => any,
+  getPendingTransactionInfo: ({ address: string, net: string }) => void,
+  address: string,
+  net: string,
 }
 
 export default class TransactionHistory extends React.Component<Props> {
   render() {
-    const { className, transactions } = this.props
+    this.pruneReturnedTransactionsFromStorage()
+    const { className, transactions, pendingTransactions } = this.props
     return (
       <Panel
         className={classNames(styles.transactionHistoryPanel, className)}
@@ -24,9 +30,37 @@ export default class TransactionHistory extends React.Component<Props> {
         <Transactions
           className={styles.transactions}
           transactions={transactions}
+          pendingTransactions={pendingTransactions || []}
         />
       </Panel>
     )
+  }
+
+  async pruneReturnedTransactionsFromStorage() {
+    const {
+      transactions,
+      pendingTransactions,
+      address,
+      net,
+      getPendingTransactionInfo,
+    } = this.props
+    if (
+      transactions &&
+      transactions.length &&
+      pendingTransactions &&
+      pendingTransactions.length
+    ) {
+      const confirmed = transactions.map(tx => tx.txid)
+      // NOTE: removes the '0x' prepended to every txId
+      const pending = pendingTransactions.map(tx => tx.txid.substring(2))
+      const toBePurged = intersection(confirmed, pending)
+      // eslint-disable-next-line
+      for (const id of toBePurged) {
+        // eslint-disable-next-line
+        await pruneConfirmedOrStaleTransaction(address, id)
+        getPendingTransactionInfo({ address, net })
+      }
+    }
   }
 
   handleScroll = (e: SyntheticInputEvent<EventTarget>) => {

--- a/app/components/TransactionHistory/TransactionHistoryPanel/Transactions.jsx
+++ b/app/components/TransactionHistory/TransactionHistoryPanel/Transactions.jsx
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react'
 import classNames from 'classnames'
+import { isEmpty } from 'lodash-es'
 
 import Transaction from '../../Blockchain/Transaction'
 import TransactionList from '../../Blockchain/Transaction/TransactionList'
@@ -21,10 +22,7 @@ export default class Transactions extends React.Component<Props> {
 
   render() {
     const { className, transactions, pendingTransactions } = this.props
-    if (
-      !transactions.length === 0 &&
-      (!pendingTransactions || !pendingTransactions.length)
-    ) {
+    if (isEmpty(transactions) && isEmpty(pendingTransactions)) {
       return (
         <div className={classNames(styles.noTransactions, className)}>
           <LogoWithStrikethrough />

--- a/app/components/TransactionHistory/TransactionHistoryPanel/Transactions.jsx
+++ b/app/components/TransactionHistory/TransactionHistoryPanel/Transactions.jsx
@@ -11,13 +11,20 @@ import styles from './Transactions.scss'
 type Props = {
   className?: string,
   transactions: Array<Object>,
+  pendingTransactions: Array<Object>,
 }
 
 export default class Transactions extends React.Component<Props> {
-  render() {
-    const { className, transactions } = this.props
+  static defaultProps = {
+    pendingTransactions: [],
+  }
 
-    if (transactions.length === 0) {
+  render() {
+    const { className, transactions, pendingTransactions } = this.props
+    if (
+      !transactions.length === 0 &&
+      (!pendingTransactions || !pendingTransactions.length)
+    ) {
       return (
         <div className={classNames(styles.noTransactions, className)}>
           <LogoWithStrikethrough />
@@ -27,6 +34,10 @@ export default class Transactions extends React.Component<Props> {
 
     return (
       <TransactionList className={className} alternateRows>
+        {pendingTransactions &&
+          pendingTransactions.map((tx, i) => (
+            <Transaction isPending pendingTx={tx} key={i} />
+          ))}
         {transactions.map((tx, i) => <Transaction tx={tx} key={i} />)}
       </TransactionList>
     )

--- a/app/components/TransactionHistory/TransactionHistoryPanel/index.js
+++ b/app/components/TransactionHistory/TransactionHistoryPanel/index.js
@@ -1,9 +1,11 @@
 // @flow
 import { compose } from 'recompose'
-import { withData, withActions } from 'spunky'
+import { connect } from 'react-redux'
+import { withData, withActions, withCall } from 'spunky'
 
 import TransactionHistoryPanel from './TransactionHistoryPanel'
 import transactionHistoryActions from '../../../actions/transactionHistoryActions'
+import { getPendingTransactionInfo } from '../../../actions/pendingTransactionActions'
 import withProgressPanel from '../../../hocs/withProgressPanel'
 import withAuthData from '../../../hocs/withAuthData'
 import withNetworkData from '../../../hocs/withNetworkData'
@@ -22,13 +24,28 @@ const mapAccountActionsToProps = (actions, props) => ({
     }),
 })
 
+const mapDispatchToProps = dispatch => ({
+  getPendingTransactionInfo: ({ address, net }) =>
+    dispatch(getPendingTransactionInfo.call({ address, net })),
+})
+
+const mapPendingTransactionInfoToProps = pendingTransactions => ({
+  pendingTransactions,
+})
+
 export default compose(
+  connect(
+    null,
+    mapDispatchToProps,
+  ),
   withAuthData(),
   withNetworkData(),
   withProgressPanel(transactionHistoryActions, {
     title: 'Transaction History',
   }),
   withActions(transactionHistoryActions, mapAccountActionsToProps),
+  withCall(getPendingTransactionInfo),
+  withData(getPendingTransactionInfo, mapPendingTransactionInfoToProps),
   withLoadingProp(transactionHistoryActions),
   withData(transactionHistoryActions, mapTransactionsDataToProps),
 )(TransactionHistoryPanel)

--- a/app/components/TransactionHistory/TransactionHistoryPanel/index.js
+++ b/app/components/TransactionHistory/TransactionHistoryPanel/index.js
@@ -1,6 +1,5 @@
 // @flow
 import { compose } from 'recompose'
-import { connect } from 'react-redux'
 import { withData, withActions, withCall } from 'spunky'
 
 import TransactionHistoryPanel from './TransactionHistoryPanel'
@@ -24,20 +23,11 @@ const mapAccountActionsToProps = (actions, props) => ({
     }),
 })
 
-const mapDispatchToProps = dispatch => ({
-  getPendingTransactionInfo: ({ address, net }) =>
-    dispatch(getPendingTransactionInfo.call({ address, net })),
-})
-
 const mapPendingTransactionInfoToProps = pendingTransactions => ({
-  pendingTransactions,
+  pendingTransactions: pendingTransactions || [],
 })
 
 export default compose(
-  connect(
-    null,
-    mapDispatchToProps,
-  ),
   withAuthData(),
   withNetworkData(),
   withProgressPanel(transactionHistoryActions, {

--- a/app/containers/Encrypt/index.js
+++ b/app/containers/Encrypt/index.js
@@ -1,6 +1,6 @@
 // @flow
 import { compose, withProps } from 'recompose'
-import { wallet } from 'neon-js'
+import { wallet } from '@cityofzion/neon-js'
 import { validatePassphraseLength } from '../../core/wallet'
 
 import Encrypt from './Encrypt'

--- a/app/containers/LoginLedgerNanoS/LoginLedgerNanoS.jsx
+++ b/app/containers/LoginLedgerNanoS/LoginLedgerNanoS.jsx
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react'
-import { wallet } from 'neon-js'
+import { wallet } from '@cityofzion/neon-js'
 import { progressValues } from 'spunky'
 import classNames from 'classnames'
 import { get } from 'lodash-es'

--- a/app/containers/Send/Send.jsx
+++ b/app/containers/Send/Send.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react'
 import { uniqueId, get } from 'lodash-es'
-import { wallet } from 'neon-js'
+import { wallet } from '@cityofzion/neon-js'
 import {
   toNumber,
   toBigNumber,
@@ -327,6 +327,8 @@ export default class Send extends React.Component<Props, State> {
         })
       })
       .catch((error: Object) => {
+        // TODO: here is where we must generate the expected txId locally
+        // and then add it to our pending tx arr
         this.setState({
           sendError: true,
           sendErrorMessage: error.message,

--- a/app/containers/Send/index.js
+++ b/app/containers/Send/index.js
@@ -22,14 +22,11 @@ import withSuccessNotification from '../../hocs/withSuccessNotification'
 import withFailureNotification from '../../hocs/withFailureNotification'
 import { MODAL_TYPES } from '../../core/constants'
 import withTokensData from '../../hocs/withTokensData'
-import { addPendingTransaction } from '../../actions/pendingTransactionActions'
 
 const mapDispatchToProps = (dispatch: Function) =>
   bindActionCreators(
     {
       sendTransaction,
-      addPendingTransaction: ({ address, txId }) =>
-        addPendingTransaction.call({ address, txId }),
       showSendModal: props => dispatch(showModal(MODAL_TYPES.SEND, props)),
     },
     dispatch,

--- a/app/containers/Send/index.js
+++ b/app/containers/Send/index.js
@@ -22,11 +22,14 @@ import withSuccessNotification from '../../hocs/withSuccessNotification'
 import withFailureNotification from '../../hocs/withFailureNotification'
 import { MODAL_TYPES } from '../../core/constants'
 import withTokensData from '../../hocs/withTokensData'
+import { addPendingTransaction } from '../../actions/pendingTransactionActions'
 
 const mapDispatchToProps = (dispatch: Function) =>
   bindActionCreators(
     {
       sendTransaction,
+      addPendingTransaction: ({ address, txId }) =>
+        addPendingTransaction.call({ address, txId }),
       showSendModal: props => dispatch(showModal(MODAL_TYPES.SEND, props)),
     },
     dispatch,

--- a/app/core/account.js
+++ b/app/core/account.js
@@ -1,5 +1,5 @@
 // @flow
-import { wallet } from 'neon-js'
+import { wallet } from '@cityofzion/neon-js'
 
 import { getStorage, setStorage } from './storage'
 

--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -111,6 +111,11 @@ export const TOKENS_TEST = {
 // MainNet
 export const TOKENS = tokenList
 
+export const NEO_ID =
+  'c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b'
+export const GAS_ID =
+  '602c79718b16e442de58778e148d0b1084e3b2dffd5de6b7b16cee7969282de7'
+
 export const ENDED_ICO_TOKENS = [
   'DBC',
   'RPX',

--- a/app/core/wallet.js
+++ b/app/core/wallet.js
@@ -1,5 +1,5 @@
 // @flow
-import { wallet } from 'neon-js'
+import { wallet } from '@cityofzion/neon-js'
 import { map, extend } from 'lodash-es'
 import axios from 'axios'
 

--- a/app/hocs/helpers/didLogin.js
+++ b/app/hocs/helpers/didLogin.js
@@ -1,5 +1,5 @@
 // @flow
-import { wallet } from 'neon-js'
+import { wallet } from '@cityofzion/neon-js'
 
 export default function didLogin(oldAddress: ?string, newAddress: ?string) {
   return !oldAddress && wallet.isAddress(newAddress)

--- a/app/hocs/helpers/didLogout.js
+++ b/app/hocs/helpers/didLogout.js
@@ -1,5 +1,5 @@
 // @flow
-import { wallet } from 'neon-js'
+import { wallet } from '@cityofzion/neon-js'
 
 export default function didLogout(oldAddress: ?string, newAddress: ?string) {
   return wallet.isAddress(oldAddress) && !newAddress

--- a/app/ledger/neonLedger.js
+++ b/app/ledger/neonLedger.js
@@ -1,7 +1,7 @@
 // @flow
-import { tx, wallet, u } from 'neon-js'
+import { tx, wallet, u } from '@cityofzion/neon-js'
 import { cloneDeep } from 'lodash-es'
-import type { Transaction } from 'neon-js'
+import type { Transaction } from '@cityofzion/neon-js'
 
 import LedgerNode from '@ledgerhq/hw-transport-node-hid'
 import asyncWrap from '../core/asyncHelper'

--- a/app/modules/claim.js
+++ b/app/modules/claim.js
@@ -1,5 +1,5 @@
 // @flow
-import { api, type Claims } from 'neon-js'
+import { api, type Claims } from '@cityofzion/neon-js'
 import { map, reduce } from 'lodash-es'
 
 import {

--- a/app/modules/generateWallet.js
+++ b/app/modules/generateWallet.js
@@ -127,7 +127,7 @@ export const recoverWallet = (wallet: Object): Promise<*> =>
 
       // If for some reason we have no NEP-6 wallet stored, create a default.
       if (!data) {
-        data = { ...DEFAULT_WALLET } // eslint-disable-line no-param-reassign
+        data = { ...DEFAULT_WALLET }
       }
 
       if (!wallet.accounts) {

--- a/app/modules/generateWallet.js
+++ b/app/modules/generateWallet.js
@@ -1,6 +1,6 @@
 // @flow
 import storage from 'electron-json-storage'
-import { wallet } from 'neon-js'
+import { wallet } from '@cityofzion/neon-js'
 import { isEmpty, intersectionBy } from 'lodash-es'
 
 import {

--- a/app/modules/sale.js
+++ b/app/modules/sale.js
@@ -1,5 +1,5 @@
 // @flow
-import { wallet, api } from 'neon-js'
+import { wallet, api } from '@cityofzion/neon-js'
 import { flatten, isEmpty } from 'lodash-es'
 
 import { getNode, getRPCEndpoint } from '../actions/nodeStorageActions'

--- a/app/modules/transactions.js
+++ b/app/modules/transactions.js
@@ -78,14 +78,11 @@ const makeRequest = (
 ) => {
   // NOTE: We purposefully mutate the contents of config
   // because neon-js will also mutate this same object by reference
-  // eslint-disable-next-line no-param-reassign
   config.intents = buildIntents(sendEntries)
   if (script === '') {
     return api.sendAsset(config, api.neoscan)
   }
-  // eslint-disable-next-line no-param-reassign
   config.script = script
-  // eslint-disable-next-line no-param-reassign
   config.gas = 0
   return api.doInvoke(config, api.neoscan)
 }

--- a/app/util/findAndReturnTokenInfo.js
+++ b/app/util/findAndReturnTokenInfo.js
@@ -1,0 +1,37 @@
+// @flow
+import { api } from '@cityofzion/neon-js'
+
+import { imageMap } from '../assets/nep5/png'
+import { getDefaultTokens } from '../core/nep5'
+import { ASSETS, NEO_ID, GAS_ID } from '../core/constants'
+import { getRPCEndpoint } from '../actions/nodeStorageActions'
+
+export const findAndReturnTokenInfo = async (
+  scriptHash: string,
+  net: string,
+): Promise<any> => {
+  const tokens = await getDefaultTokens()
+  const token = tokens.find(token => token.scriptHash.includes(scriptHash))
+  const getImage = symbol => imageMap[symbol]
+  if (token) return token
+  if (scriptHash.includes(NEO_ID)) {
+    return {
+      symbol: ASSETS.NEO,
+      image: getImage(ASSETS.NEO),
+    }
+  }
+  if (scriptHash.includes(GAS_ID)) {
+    return {
+      symbol: ASSETS.GAS,
+      image: getImage(ASSETS.GAS),
+    }
+  }
+  const endpoint = await getRPCEndpoint(net)
+  const tokenInfo = await api.nep5.getToken(endpoint, scriptHash).catch(e => {
+    console.error(e)
+    return {}
+  })
+  return {
+    symbol: tokenInfo.symbol,
+  }
+}

--- a/app/util/findAndReturnTokenInfo.js
+++ b/app/util/findAndReturnTokenInfo.js
@@ -6,24 +6,25 @@ import { getDefaultTokens } from '../core/nep5'
 import { ASSETS, NEO_ID, GAS_ID } from '../core/constants'
 import { getRPCEndpoint } from '../actions/nodeStorageActions'
 
+export const getImageBySymbol = (symbol: string) => imageMap[symbol]
+
 export const findAndReturnTokenInfo = async (
   scriptHash: string,
   net: string,
 ): Promise<any> => {
   const tokens = await getDefaultTokens()
   const token = tokens.find(token => token.scriptHash.includes(scriptHash))
-  const getImage = symbol => imageMap[symbol]
   if (token) return token
   if (scriptHash.includes(NEO_ID)) {
     return {
       symbol: ASSETS.NEO,
-      image: getImage(ASSETS.NEO),
+      image: getImageBySymbol(ASSETS.NEO),
     }
   }
   if (scriptHash.includes(GAS_ID)) {
     return {
       symbol: ASSETS.GAS,
-      image: getImage(ASSETS.GAS),
+      image: getImageBySymbol(ASSETS.GAS),
     }
   }
   const endpoint = await getRPCEndpoint(net)

--- a/app/util/nns.js
+++ b/app/util/nns.js
@@ -1,9 +1,0 @@
-import { rpc } from 'neon-js'
-
-export const resolveNnsDomain = name =>
-  rpc
-    .queryRPC('https://apiwallet.nel.group/api/mainnet', {
-      method: 'getresolvedaddress',
-      params: [name],
-    })
-    .then(data => data.result[0].data)

--- a/app/util/pluralize.js
+++ b/app/util/pluralize.js
@@ -1,3 +1,3 @@
 // @flow
 export const pluralize = (word: string, items: number) =>
-  items > 1 ? `${word}s` : word
+  items === 1 ? word : `${word}s`

--- a/flow-typed/declarations.js
+++ b/flow-typed/declarations.js
@@ -1,7 +1,7 @@
 // @flow
 /* eslint-disable */
 
-import { type Fixed8 } from 'neon-js'
+import { type Fixed8 } from '@cityofzion/neon-js'
 
 import {
   ROUTES,
@@ -79,7 +79,8 @@ declare type TxEntryType = {
   amount: number,
   label: $Values<typeof ASSETS>,
   time?: number,
-  isNetworkFee?: boolean
+  isNetworkFee?: boolean,
+  image?: string
 }
 
 declare type SymbolType = string

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     }
   },
   "dependencies": {
+    "@cityofzion/neon-js": "3.11.9",
     "@ledgerhq/hw-transport-node-hid": "4.7.6",
     "axios": "0.17.0",
     "axios-retry": "3.1.1",
@@ -94,7 +95,6 @@
     "jsqr": "1.1.1",
     "lodash-es": "4.17.11",
     "moment": "2.22.2",
-    "neon-js": "git+https://github.com/cityofzion/neon-js.git#3.11.0",
     "nock": "9.2.3",
     "prop-types": "15.6.2",
     "qrcode": "0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -131,6 +131,25 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
+"@cityofzion/neon-js@3.11.9":
+  version "3.11.9"
+  resolved "https://registry.yarnpkg.com/@cityofzion/neon-js/-/neon-js-3.11.9.tgz#c2687bbd177423f1ad4ac9f0fd627a76ef3b7c5f"
+  dependencies:
+    axios "0.18.0"
+    bignumber.js "5.0.0"
+    bn.js "^4.11.8"
+    bs58 "4.0.1"
+    bs58check "2.1.2"
+    crypto-js "3.1.9-1"
+    elliptic "6.4.1"
+    js-scrypt "0.2.0"
+    loglevel "1.6.1"
+    loglevel-plugin-prefix "0.8.4"
+    scrypt-js "2.0.4"
+    secure-random "1.1.1"
+    semver "5.6.0"
+    wif "2.0.6"
+
 "@concordance/react@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@concordance/react/-/react-1.0.0.tgz#fcf3cad020e5121bfd1c61d05bc3516aac25f734"
@@ -1078,7 +1097,7 @@ axios@0.17.0:
     follow-redirects "^1.2.3"
     is-buffer "^1.1.5"
 
-axios@^0.18.0:
+axios@0.18.0:
   version "0.18.0"
   resolved "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
   dependencies:
@@ -2270,7 +2289,7 @@ bluebird@~3.4.1:
   version "3.4.7"
   resolved "http://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"
 
-bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
+bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.11.8, bn.js@^4.4.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
 
@@ -2442,13 +2461,13 @@ browserslist@^3.2.6:
     caniuse-lite "^1.0.30000844"
     electron-to-chromium "^1.3.47"
 
-bs58@^4.0.0, bs58@^4.0.1:
+bs58@4.0.1, bs58@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
   dependencies:
     base-x "^3.0.2"
 
-bs58check@<3.0.0, bs58check@^2.1.2:
+bs58check@2.1.2, bs58check@<3.0.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/bs58check/-/bs58check-2.1.2.tgz#53b018291228d82a5aa08e7d796fdafda54aebfc"
   dependencies:
@@ -3450,7 +3469,7 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
-crypto-js@^3.1.9-1:
+crypto-js@3.1.9-1:
   version "3.1.9-1"
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.9-1.tgz#fda19e761fc077e01ffbfdc6e9fdfc59e8806cd8"
 
@@ -4321,7 +4340,7 @@ electron@2.0.12:
     electron-download "^3.0.1"
     extract-zip "^1.0.3"
 
-elliptic@^6.0.0, elliptic@^6.4.1:
+elliptic@6.4.1, elliptic@^6.0.0:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.1.tgz#c2d0b7776911b86722c632c3c06c60f2f819939a"
   dependencies:
@@ -7075,7 +7094,7 @@ js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.4.9"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.9.tgz#748911fb04f48a60c4771b375cac45a80df11c03"
 
-js-scrypt@^0.2.0:
+js-scrypt@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/js-scrypt/-/js-scrypt-0.2.0.tgz#7a62b701b4616e70ad0cde544627aabb99d7fe39"
   dependencies:
@@ -7586,11 +7605,11 @@ log-symbols@^2.1.0:
   dependencies:
     chalk "^2.0.1"
 
-loglevel-plugin-prefix@^0.8.4:
+loglevel-plugin-prefix@0.8.4:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz#2fe0e05f1a820317d98d8c123e634c1bd84ff644"
 
-loglevel@^1.4.1, loglevel@^1.6.1:
+loglevel@1.6.1, loglevel@^1.4.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
 
@@ -8075,24 +8094,6 @@ negotiator@0.6.1:
 neo-async@^2.5.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.0.tgz#b9d15e4d71c6762908654b5183ed38b753340835"
-
-"neon-js@git+https://github.com/cityofzion/neon-js.git#3.11.0":
-  version "3.11.0"
-  resolved "git+https://github.com/cityofzion/neon-js.git#9decadb662c766c6e66df6201f1ca28290c0e644"
-  dependencies:
-    axios "^0.18.0"
-    bignumber.js "5.0.0"
-    bs58 "^4.0.1"
-    bs58check "^2.1.2"
-    crypto-js "^3.1.9-1"
-    elliptic "^6.4.1"
-    js-scrypt "^0.2.0"
-    loglevel "^1.6.1"
-    loglevel-plugin-prefix "^0.8.4"
-    scrypt-js "^2.0.3"
-    secure-random "^1.1.1"
-    semver "^5.5.1"
-    wif "^2.0.6"
 
 next-tick@1:
   version "1.0.0"
@@ -10569,7 +10570,7 @@ schema-utils@^0.4.0, schema-utils@^0.4.5:
     ajv "^6.1.0"
     ajv-keywords "^3.1.0"
 
-scrypt-js@^2.0.3:
+scrypt-js@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-2.0.4.tgz#32f8c5149f0797672e551c07e230f834b6af5f16"
 
@@ -10584,7 +10585,7 @@ sdp@^1.0.0:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/sdp/-/sdp-1.5.4.tgz#8e038f6ddb14bd765ae1f4b5216e12094511e0d0"
 
-secure-random@^1.1.1:
+secure-random@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/secure-random/-/secure-random-1.1.1.tgz#0880f2d8c5185f4bcb4684058c836b4ddb07145a"
 
@@ -10604,7 +10605,7 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1:
+"semver@2 || 3 || 4 || 5", semver@5.6.0, semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
 
@@ -12276,7 +12277,7 @@ widest-line@^2.0.0:
   dependencies:
     string-width "^2.1.1"
 
-wif@^2.0.6:
+wif@2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/wif/-/wif-2.0.6.tgz#08d3f52056c66679299726fade0d432ae74b4704"
   dependencies:


### PR DESCRIPTION
![send-enhancements-3](https://user-images.githubusercontent.com/13072035/50543538-4f9af280-0b98-11e9-8aef-21d6585ee57b.gif)

TODO:
- ~Fix bug preventing correct hash from being generated during contract invocation~

- Fix error messaging in Send timeout to direct users to take a look at activity **(separate PR)**
- Add number of pending tx on top of Activity logo based on spunky state **(separate PR)**
<img src="https://user-images.githubusercontent.com/13072035/50406544-0146b780-0784-11e9-9498-dcd13252ea0f.png" height="300" />

**What current issue(s) from Trello/Github does this address?**
Solves at least part of https://github.com/CityOfZion/neon-wallet/issues/1741 and a lot of problems that arise during periods of network instability ie what **exactly** is the status of my transaction

**What problem does this PR solve?**
This creates an internal storage log of "pending" transactions that the user has attempted to broadcast to the network. We generate a transaction ID locally before broadcasting to a node and then use this ID to poll the blockchain for confirmations/transaction status. Once the transaction reaches ~40~ 10 confirmations OR the neoscan API responds with this transaction id we purge the id from local storage.

**How did you solve this problem?**
By generating the transaction locally _before_ making the request to the node and then storing the determined tx id in local storage. UPDATE: It is not currently possible (that I know of) to take the an InvocationTransaction script and reverse engineer it to calculate the exact outputs as an alternative I decided to pass around the send entries array and conditionally use its value instead in the event of the transaction being an invocation.

**How did you make sure your solution works?**
Manual testing - incoming unit and integration tests. **(separate PR)**

**Are there any special changes in the code that we should be aware of?**
- Adds images to the Activity page 🎉 
- Updates neon-js to `3.11.9`  and installs via npm instead of github
- Sets timeout of RPC requests to `60000`MS  instead of the default `30000`

**Is there anything else we should know?**
~**NOTE:** for some reason the hashes I am generating for tokens (not GAS or NEO) are not creating the correct hash and I am actively investigating~

- [ ] Unit tests written?
