### PR TITLE
feature: UI enhancements for unconfirmed transactions flow

### DIFF
--- a/app/actions/pendingTransactionActions.js
+++ b/app/actions/pendingTransactionActions.js
@@ -16,33 +16,6 @@ const STORAGE_KEY = 'pendingTransactions'
 const MINIMUM_CONFIRMATIONS = 10
 const INVALID_TX_ERROR_MESSAGE = 'Unknown transaction'
 
-type PendingTransactions = {
-  [address: string]: Array<any>,
-}
-
-type PendingTransaction = {
-  vout: Array<{ asset: string, address: string, value: string }>,
-  sendEntries: Array<SendEntryType>,
-  confirmations: number,
-  txid: string,
-  net_fee: string,
-  blocktime: number,
-  type: string,
-}
-
-type ParsedPendingTransaction = {
-  confirmations: number,
-  txid: string,
-  net_fee: string,
-  blocktime: number,
-  to: string,
-  amount: string,
-  asset: {
-    symbol: string,
-    image: string,
-  },
-}
-
 export const parseContractTransaction = async (
   transaction: PendingTransaction,
   net: string,

--- a/app/actions/pendingTransactionActions.js
+++ b/app/actions/pendingTransactionActions.js
@@ -134,7 +134,6 @@ export const pruneConfirmedOrStaleTransaction = async (
 ) => {
   const storage = await getPendingTransactions()
   if (Array.isArray(storage[address])) {
-    console.log(storage[address])
     storage[address] = storage[address].filter(
       // use includes here to be indifferent to 0x prefix
       transaction => transaction.hash && !transaction.hash.includes(txId),
@@ -203,7 +202,6 @@ export const addPendingTransaction = createActions(
   ({ address, tx, net }) => async (): Promise<
     Array<ParsedPendingTransaction>,
   > => {
-    console.log('adding pending transaction', { address, tx, net })
     const transactions = await getPendingTransactions()
 
     if (Array.isArray(transactions[address])) {

--- a/app/actions/pendingTransactionActions.js
+++ b/app/actions/pendingTransactionActions.js
@@ -14,6 +14,7 @@ import {
 export const ID = 'pendingTransactions'
 const STORAGE_KEY = 'pendingTransactions'
 const MINIMUM_CONFIRMATIONS = 10
+const INVALID_TX_ERROR_MESSAGE = 'Unknown transaction'
 
 type PendingTransactions = {
   [address: string]: Array<any>,
@@ -168,7 +169,7 @@ export const fetchTransactionInfo = async (
                 transaction.hash
               }`,
             )
-            if (e.message === 'Unknown transaction') {
+            if (e.message === INVALID_TX_ERROR_MESSAGE) {
               await pruneConfirmedOrStaleTransaction(address, transaction.hash)
             }
           })

--- a/app/actions/pendingTransactionActions.js
+++ b/app/actions/pendingTransactionActions.js
@@ -117,7 +117,7 @@ export const pruneConfirmedOrStaleTransaction = async (
 }
 
 export const fetchTransactionInfo = async (
-  transactions: PendingTransactions,
+  transactions: PendingTransactions = {},
   address: string,
   net: string,
 ) => {

--- a/app/components/Send/SendPanel/ActivityLink/ActivityLink.jsx
+++ b/app/components/Send/SendPanel/ActivityLink/ActivityLink.jsx
@@ -11,9 +11,8 @@ type Props = {
 
 export const ActivityLink = ({ error }: Props) => (
   <div>
-    {error
-      ? 'Although an error occured its possible your transaction was processed. '
-      : ' '}
+    {error &&
+      'Although an error occurred its possible your transaction was processed.'}{' '}
     Check the
     <NavLink id="wallet-manager" exact to={ROUTES.TRANSACTION_HISTORY}>
       <span> activity </span>

--- a/app/components/Send/SendPanel/ActivityLink/ActivityLink.jsx
+++ b/app/components/Send/SendPanel/ActivityLink/ActivityLink.jsx
@@ -1,0 +1,23 @@
+// @flow
+import React from 'react'
+import { NavLink } from 'react-router-dom'
+
+import { ROUTES } from '../../../../core/constants'
+import styles from './ActivityLink.scss'
+
+type Props = {
+  error: boolean,
+}
+
+export const ActivityLink = ({ error }: Props) => (
+  <div>
+    {error
+      ? 'Although an error occured its possible your transaction was processed. '
+      : ' '}
+    Check the
+    <NavLink id="wallet-manager" exact to={ROUTES.TRANSACTION_HISTORY}>
+      <span> activity </span>
+    </NavLink>{' '}
+    tab to see the status of your transaction.
+  </div>
+)

--- a/app/components/Send/SendPanel/ActivityLink/index.js
+++ b/app/components/Send/SendPanel/ActivityLink/index.js
@@ -1,0 +1,3 @@
+import { ActivityLink } from './ActivityLink'
+
+export default ActivityLink

--- a/app/components/Send/SendPanel/SendError/index.jsx
+++ b/app/components/Send/SendPanel/SendError/index.jsx
@@ -7,6 +7,7 @@ import DialogueBox from '../../../DialogueBox'
 
 import BackIcon from '../../../../assets/icons/arrow.svg'
 import WarningIcon from '../../../../assets/icons/warning.svg'
+import ActivityLink from '../ActivityLink'
 
 import styles from './SendError.scss'
 
@@ -30,7 +31,7 @@ const SendError = ({ resetViewsAfterError, sendErrorMessage }: Props) => (
     </div>
     <DialogueBox
       icon={<WarningIcon />}
-      text="Your transaction has not been processed. Press the button below to go back and try again."
+      renderText={() => <ActivityLink error />}
       className={styles.sendErrorDialogueBox}
     />
     <Button

--- a/app/components/Send/SendPanel/SendSuccess/SendSuccess.scss
+++ b/app/components/Send/SendPanel/SendSuccess/SendSuccess.scss
@@ -1,10 +1,15 @@
 @import '../../../../styles/variables';
 
 .sendSuccessHeader {
-  padding: 60px 30px;
+  padding: 60px 30px 15px 60px;
   align-items: center;
   display: flex;
   justify-content: center;
+}
+
+.activityLinkText {
+  text-align: center;
+  font-family: var(--font-gotham-light);
 }
 
 .sendSuccessHeaderIcon {

--- a/app/components/Send/SendPanel/SendSuccess/index.jsx
+++ b/app/components/Send/SendPanel/SendSuccess/index.jsx
@@ -4,12 +4,11 @@ import React from 'react'
 import CheckMarkIcon from '../../../../assets/icons/confirm-circle.svg'
 import Transaction from '../../../Blockchain/Transaction'
 import TransactionList from '../../../Blockchain/Transaction/TransactionList'
-
 import { pluralize } from '../../../../util/pluralize'
 import { createFormattedDate } from '../../../../util/createFormattedDate'
-
 import styles from './SendSuccess.scss'
 import { TX_TYPES } from '../../../../core/constants'
+import ActivityLink from '../ActivityLink'
 
 type Props = {
   sendRowDetails: Array<*>,
@@ -49,6 +48,9 @@ export default class SendSuccess extends React.Component<Props> {
               Transaction ID: {txid}
             </p>
           </div>
+        </div>
+        <div className={styles.activityLinkText}>
+          <ActivityLink />
         </div>
         <div className={styles.sendSuccessBody}>
           <h2 className={styles.sendSuccessBodyHeaderText}>

--- a/app/containers/App/Sidebar/Sidebar.jsx
+++ b/app/containers/App/Sidebar/Sidebar.jsx
@@ -22,9 +22,10 @@ import DarkLogoWithoutText from '../../../assets/images/logo-without-text.png'
 type Props = {
   className: string,
   theme: ThemeType,
+  pendingTransactionsCount: number,
 }
 
-const Sidebar = ({ className, theme }: Props) => {
+const Sidebar = ({ className, theme, pendingTransactionsCount }: Props) => {
   const themeBasedLogo =
     theme === 'Light' ? LightLogoWithoutText : DarkLogoWithoutText
 
@@ -53,6 +54,11 @@ const Sidebar = ({ className, theme }: Props) => {
           className={styles.navItem}
           activeClassName={styles.active}
         >
+          {!!pendingTransactionsCount && (
+            <div className={styles.pendingTransactionsCount}>
+              {pendingTransactionsCount}
+            </div>
+          )}
           <HistoryIcon />
           <div> Activity </div>
         </NavLink>

--- a/app/containers/App/Sidebar/Sidebar.jsx
+++ b/app/containers/App/Sidebar/Sidebar.jsx
@@ -54,7 +54,7 @@ const Sidebar = ({ className, theme, pendingTransactionsCount }: Props) => {
           className={styles.navItem}
           activeClassName={styles.active}
         >
-          {!!pendingTransactionsCount && (
+          {pendingTransactionsCount > 0 && (
             <div className={styles.pendingTransactionsCount}>
               {pendingTransactionsCount}
             </div>

--- a/app/containers/App/Sidebar/Sidebar.scss
+++ b/app/containers/App/Sidebar/Sidebar.scss
@@ -37,6 +37,22 @@ $size: 68px;
   }
 }
 
+.pendingTransactionsCount {
+  position: fixed;
+  height: 24px;
+  width: 24px;
+  background-color: var(--input-error);
+  margin-top: -22px !important;
+  margin-left: 10px;
+  border-radius: 100px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  font-family: var(--font-gotham-book);
+  font-size: 14px !important;
+}
+
 .navItem {
   display: flex;
   justify-content: center;

--- a/app/containers/App/Sidebar/index.js
+++ b/app/containers/App/Sidebar/index.js
@@ -1,5 +1,6 @@
 // @flow
 import { compose } from 'recompose'
+import { get } from 'lodash-es'
 import { withData } from 'spunky'
 import { withRouter } from 'react-router-dom'
 
@@ -9,8 +10,7 @@ import { addPendingTransaction } from '../../../actions/pendingTransactionAction
 const mapPendingTransactionsDataToProps = (
   pendingTransactions: Array<any>,
 ) => ({
-  pendingTransactionsCount:
-    (Array.isArray(pendingTransactions) && pendingTransactions.length) || 0,
+  pendingTransactionsCount: get(pendingTransactions, 'length', 0),
 })
 
 export default compose(

--- a/app/containers/App/Sidebar/index.js
+++ b/app/containers/App/Sidebar/index.js
@@ -8,7 +8,7 @@ import Sidebar from './Sidebar'
 import { addPendingTransaction } from '../../../actions/pendingTransactionActions'
 
 const mapPendingTransactionsDataToProps = (
-  pendingTransactions: Array<any>,
+  pendingTransactions: Array<PendingTransactions>,
 ) => ({
   pendingTransactionsCount: get(pendingTransactions, 'length', 0),
 })

--- a/app/containers/App/Sidebar/index.js
+++ b/app/containers/App/Sidebar/index.js
@@ -1,9 +1,19 @@
 // @flow
 import { compose } from 'recompose'
+import { withData } from 'spunky'
 import { withRouter } from 'react-router-dom'
 
 import Sidebar from './Sidebar'
+import { addPendingTransaction } from '../../../actions/pendingTransactionActions'
+
+const mapPendingTransactionsDataToProps = (
+  pendingTransactions: Array<any>,
+) => ({
+  pendingTransactionsCount:
+    (Array.isArray(pendingTransactions) && pendingTransactions.length) || 0,
+})
 
 export default compose(
   withRouter, // allow `NavLink` components to re-render when the window location changes
+  withData(addPendingTransaction, mapPendingTransactionsDataToProps),
 )(Sidebar)

--- a/app/modules/transactions.js
+++ b/app/modules/transactions.js
@@ -201,7 +201,6 @@ export const sendTransaction = ({
     } finally {
       const outputs = get(config, 'tx.outputs')
       const hash = get(config, 'tx.hash')
-
       dispatch(
         addPendingTransaction.call({
           address: config.address,
@@ -209,6 +208,7 @@ export const sendTransaction = ({
             hash,
             sendEntries,
           },
+          net,
         }),
       )
     }

--- a/app/styles/main.global.scss
+++ b/app/styles/main.global.scss
@@ -40,6 +40,7 @@
   --font-gotham-medium: 'Gotham-Medium', var(--font-fallback);
   --font-gotham-bold: 'Gotham-Bold', var(--font-fallback);
   --font-gotham-thin: 'Gotham-Thin', var(--font-fallback);
+  --font-gotham-light: 'Gotham-Light', var(--font-fallback);
   --font-gotham-book: 'Gotham-Book', var(--font-fallback);
 }
 

--- a/flow-typed/declarations.js
+++ b/flow-typed/declarations.js
@@ -83,6 +83,33 @@ declare type TxEntryType = {
   image?: string
 }
 
+type PendingTransactions = {
+  [address: string]: Array<any>,
+}
+
+type PendingTransaction = {
+  vout: Array<{ asset: string, address: string, value: string }>,
+  sendEntries: Array<SendEntryType>,
+  confirmations: number,
+  txid: string,
+  net_fee: string,
+  blocktime: number,
+  type: string,
+}
+
+type ParsedPendingTransaction = {
+  confirmations: number,
+  txid: string,
+  net_fee: string,
+  blocktime: number,
+  to: string,
+  amount: string,
+  asset: {
+    symbol: string,
+    image: string,
+  },
+}
+
 declare type SymbolType = string
 
 declare type NetworkItemType = {


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
This PR is part II of https://github.com/CityOfZion/neon-wallet/pull/1766 and provides some subtle updates to the UI to help users understand the exact state of their unconfirmed transactions.

![send-enhancements-4](https://user-images.githubusercontent.com/13072035/50563828-8890af80-0cdd-11e9-8002-ee46843e8666.gif)

<img width="1103" alt="screen shot 2018-12-31 at 9 22 19 am" src="https://user-images.githubusercontent.com/13072035/50563838-97776200-0cdd-11e9-8ac1-a374b504d9ef.png">
<img width="1186" alt="screen shot 2018-12-31 at 9 22 47 am" src="https://user-images.githubusercontent.com/13072035/50563856-b249d680-0cdd-11e9-9604-143cd39c90df.png">

**What problem does this PR solve?**
Further improves our send UX

**How did you solve this problem?**
By extending the work started in https://github.com/CityOfZion/neon-wallet/pull/1766

**How did you make sure your solution works?**
Manual testing locally

**Are there any special changes in the code that we should be aware of?**
I updated `addPendingTransaction` to always return the retrieved information from the blockchain when adding a tx to storage so that the SideBar can know about only transactions returned from `getRawTransaction`  as opposed to every transaction that gets added to storage.

**Is there anything else we should know?**

- [ ] Unit tests written?
