### PR TITLE
Chore/fix copy address

### DIFF
--- a/app/components/Blockchain/Transaction/ClaimAbstract.jsx
+++ b/app/components/Blockchain/Transaction/ClaimAbstract.jsx
@@ -44,11 +44,13 @@ export default class ClaimAbstract extends React.Component<Props> {
           <div className={styles.txToContainer}>
             <Fragment>
               <span>{contactTo}</span>
-              { <CopyToClipboard
+              {
+                <CopyToClipboard
                   className={styles.copy}
                   text={to}
                   tooltip="Copy Public Address"
-                /> }
+                />
+              }
             </Fragment>
           </div>
           <div className={styles.historyButtonPlaceholder} />

--- a/app/components/Blockchain/Transaction/ClaimAbstract.jsx
+++ b/app/components/Blockchain/Transaction/ClaimAbstract.jsx
@@ -44,13 +44,11 @@ export default class ClaimAbstract extends React.Component<Props> {
           <div className={styles.txToContainer}>
             <Fragment>
               <span>{contactTo}</span>
-              {(
-                <CopyToClipboard
+              { <CopyToClipboard
                   className={styles.copy}
                   text={to}
                   tooltip="Copy Public Address"
-                />
-              )}
+                /> }
             </Fragment>
           </div>
           <div className={styles.historyButtonPlaceholder} />

--- a/app/components/Blockchain/Transaction/ClaimAbstract.jsx
+++ b/app/components/Blockchain/Transaction/ClaimAbstract.jsx
@@ -44,7 +44,7 @@ export default class ClaimAbstract extends React.Component<Props> {
           <div className={styles.txToContainer}>
             <Fragment>
               <span>{contactTo}</span>
-              {!contactToExists && (
+              {(
                 <CopyToClipboard
                   className={styles.copy}
                   text={to}

--- a/app/components/Blockchain/Transaction/PendingAbstract.jsx
+++ b/app/components/Blockchain/Transaction/PendingAbstract.jsx
@@ -64,13 +64,11 @@ export default class PendingAbstract extends React.Component<Props> {
           <div className={styles.txToContainer}>
             <Fragment>
               <span>{contactTo}</span>
-              {(
-                <CopyToClipboard
+              {<CopyToClipboard
                   className={styles.copy}
                   text={to}
                   tooltip="Copy Public Address"
-                />
-              )}
+                />}
             </Fragment>
           </div>
           <Button

--- a/app/components/Blockchain/Transaction/PendingAbstract.jsx
+++ b/app/components/Blockchain/Transaction/PendingAbstract.jsx
@@ -64,11 +64,13 @@ export default class PendingAbstract extends React.Component<Props> {
           <div className={styles.txToContainer}>
             <Fragment>
               <span>{contactTo}</span>
-              {<CopyToClipboard
+              {
+                <CopyToClipboard
                   className={styles.copy}
                   text={to}
                   tooltip="Copy Public Address"
-                />}
+                />
+              }
             </Fragment>
           </div>
           <Button

--- a/app/components/Blockchain/Transaction/PendingAbstract.jsx
+++ b/app/components/Blockchain/Transaction/PendingAbstract.jsx
@@ -64,7 +64,7 @@ export default class PendingAbstract extends React.Component<Props> {
           <div className={styles.txToContainer}>
             <Fragment>
               <span>{contactTo}</span>
-              {!contactToExists && (
+              {(
                 <CopyToClipboard
                   className={styles.copy}
                   text={to}

--- a/app/components/Blockchain/Transaction/ReceiveAbstract.jsx
+++ b/app/components/Blockchain/Transaction/ReceiveAbstract.jsx
@@ -52,8 +52,7 @@ export default class ReceiveAbstract extends React.Component<Props> {
           <div className={styles.txAmountContainer}>{amount}</div>
           <div className={styles.txToContainer}>
             <span>{contactFrom}</span>
-            {!contactFromExists &&
-              !isMintTokens && (
+            { !isMintTokens && (
                 <CopyToClipboard
                   className={styles.copy}
                   text={from}

--- a/app/components/Blockchain/Transaction/ReceiveAbstract.jsx
+++ b/app/components/Blockchain/Transaction/ReceiveAbstract.jsx
@@ -52,7 +52,7 @@ export default class ReceiveAbstract extends React.Component<Props> {
           <div className={styles.txAmountContainer}>{amount}</div>
           <div className={styles.txToContainer}>
             <span>{contactFrom}</span>
-            { !isMintTokens && (
+            {!isMintTokens && (
                 <CopyToClipboard
                   className={styles.copy}
                   text={from}

--- a/app/components/Blockchain/Transaction/ReceiveAbstract.jsx
+++ b/app/components/Blockchain/Transaction/ReceiveAbstract.jsx
@@ -53,12 +53,12 @@ export default class ReceiveAbstract extends React.Component<Props> {
           <div className={styles.txToContainer}>
             <span>{contactFrom}</span>
             {!isMintTokens && (
-                <CopyToClipboard
-                  className={styles.copy}
-                  text={from}
-                  tooltip="Copy Public Address"
-                />
-              )}
+              <CopyToClipboard
+                className={styles.copy}
+                text={from}
+                tooltip="Copy Public Address"
+              />
+            )}
           </div>
           {isMintTokens || isGasClaim ? (
             <div className={styles.transactionHistoryButton} />

--- a/app/components/Blockchain/Transaction/SendAbstract.jsx
+++ b/app/components/Blockchain/Transaction/SendAbstract.jsx
@@ -53,7 +53,7 @@ export default class SendAbstract extends React.Component<Props> {
             ) : (
               <Fragment>
                 <span>{contactTo}</span>
-                {!contactToExists && (
+                {(
                   <CopyToClipboard
                     className={styles.copy}
                     text={to}

--- a/app/components/Blockchain/Transaction/SendAbstract.jsx
+++ b/app/components/Blockchain/Transaction/SendAbstract.jsx
@@ -53,13 +53,13 @@ export default class SendAbstract extends React.Component<Props> {
             ) : (
               <Fragment>
                 <span>{contactTo}</span>
-                {(
+                {
                   <CopyToClipboard
                     className={styles.copy}
                     text={to}
                     tooltip="Copy Public Address"
                   />
-                )}
+                }
               </Fragment>
             )}
           </div>


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
[Cannot copy address for my wallet address on Activity page #1704](https://github.com/CityOfZion/neon-wallet/issues/1704)

**What problem does this PR solve?**
Cannot copy address for my wallet address on Activity page

**How did you solve this problem?**
Removed conditional checks for contact existence to always show the copy address button

**How did you make sure your solution works?**
I tested each transaction address was correctly copied upon pressing the copy address button

**Are there any special changes in the code that we should be aware of?**
No 

**Is there anything else we should know?**
No

- [ ] Unit tests written?
No