### PR TITLE
chore/add-contact-activity-button

### DIFF
--- a/app/components/Blockchain/Transaction/ClaimAbstract.jsx
+++ b/app/components/Blockchain/Transaction/ClaimAbstract.jsx
@@ -2,8 +2,10 @@
 import React, { Fragment } from 'react'
 
 import classNames from 'classnames'
+import Button from '../../Button'
 import styles from './Transaction.scss'
 import ClaimIcon from '../../../assets/icons/claim.svg'
+import ContactsAdd from '../../../assets/icons/contacts-add.svg'
 import CopyToClipboard from '../../CopyToClipboard'
 
 type Props = {
@@ -14,6 +16,7 @@ type Props = {
   contactTo: React$Node | string,
   to: string,
   contactToExists: boolean,
+  showAddContactModal: (from: string) => void,
 }
 
 export default class ClaimAbstract extends React.Component<Props> {
@@ -26,6 +29,7 @@ export default class ClaimAbstract extends React.Component<Props> {
       contactTo,
       to,
       contactToExists,
+      showAddContactModal,
     } = this.props
     return (
       <div className={classNames(styles.transactionContainer)}>
@@ -53,7 +57,16 @@ export default class ClaimAbstract extends React.Component<Props> {
               }
             </Fragment>
           </div>
-          <div className={styles.historyButtonPlaceholder} />
+          {
+            <Button
+              className={styles.transactionHistoryButton}
+              renderIcon={ContactsAdd}
+              onClick={() => showAddContactModal(to)}
+              disabled={contactToExists}
+            >
+              Add
+            </Button>
+          }
         </div>
       </div>
     )

--- a/app/components/Blockchain/Transaction/ClaimAbstract.jsx
+++ b/app/components/Blockchain/Transaction/ClaimAbstract.jsx
@@ -48,25 +48,21 @@ export default class ClaimAbstract extends React.Component<Props> {
           <div className={styles.txToContainer}>
             <Fragment>
               <span>{contactTo}</span>
-              {
-                <CopyToClipboard
-                  className={styles.copy}
-                  text={to}
-                  tooltip="Copy Public Address"
-                />
-              }
+              <CopyToClipboard
+                className={styles.copy}
+                text={to}
+                tooltip="Copy Public Address"
+              />
             </Fragment>
           </div>
-          {
-            <Button
-              className={styles.transactionHistoryButton}
-              renderIcon={ContactsAdd}
-              onClick={() => showAddContactModal(to)}
-              disabled={contactToExists}
-            >
-              Add
-            </Button>
-          }
+          <Button
+            className={styles.transactionHistoryButton}
+            renderIcon={ContactsAdd}
+            onClick={() => showAddContactModal(to)}
+            disabled={contactToExists}
+          >
+            Add
+          </Button>
         </div>
       </div>
     )

--- a/app/components/Blockchain/Transaction/ReceiveAbstract.jsx
+++ b/app/components/Blockchain/Transaction/ReceiveAbstract.jsx
@@ -60,16 +60,14 @@ export default class ReceiveAbstract extends React.Component<Props> {
               />
             )}
           </div>
-          {
-            <Button
-              className={styles.transactionHistoryButton}
-              renderIcon={ContactsAdd}
-              onClick={() => showAddContactModal(from)}
-              disabled={contactFromExists}
-            >
-              Add
-            </Button>
-          }
+          <Button
+            className={styles.transactionHistoryButton}
+            renderIcon={ContactsAdd}
+            onClick={() => showAddContactModal(from)}
+            disabled={contactFromExists}
+          >
+            Add
+          </Button>
         </div>
       </div>
     )

--- a/app/components/Blockchain/Transaction/ReceiveAbstract.jsx
+++ b/app/components/Blockchain/Transaction/ReceiveAbstract.jsx
@@ -60,9 +60,7 @@ export default class ReceiveAbstract extends React.Component<Props> {
               />
             )}
           </div>
-          {isMintTokens || isGasClaim ? (
-            <div className={styles.transactionHistoryButton} />
-          ) : (
+          {
             <Button
               className={styles.transactionHistoryButton}
               renderIcon={ContactsAdd}
@@ -71,7 +69,7 @@ export default class ReceiveAbstract extends React.Component<Props> {
             >
               Add
             </Button>
-          )}
+          }
         </div>
       </div>
     )


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
[Cannot add contact for my wallet address on Activity page #1703](https://github.com/CityOfZion/neon-wallet/issues/1703)

**What problem does this PR solve?**
One can now add their own address to contacts.

**How did you solve this problem?**
Code was added to all transaction types that conditionally shows an add contact button if the contact does not already exist in the contacts.

**How did you make sure your solution works?**
I tested the buttons for on the activity view.

**Are there any special changes in the code that we should be aware of?**
No

**Is there anything else we should know?**
No
- [ ] Unit tests written?
No
