### PR TITLE
feature: functionality without historical pricing from cryptocompare

### DIFF
--- a/app/components/Dashboard/AssetBalancesPanel/AssetBalancesPanel.jsx
+++ b/app/components/Dashboard/AssetBalancesPanel/AssetBalancesPanel.jsx
@@ -95,7 +95,7 @@ export default class AssetBalancesPanel extends React.Component<Props> {
                   )}
                   id="priceChangeGas"
                 >
-                  this.getGASFormattedPriceChange()
+                  {this.getGASFormattedPriceChange()}
                 </span>
               )}
             </div>

--- a/app/components/Dashboard/AssetBalancesPanel/AssetBalancesPanel.jsx
+++ b/app/components/Dashboard/AssetBalancesPanel/AssetBalancesPanel.jsx
@@ -60,15 +60,17 @@ export default class AssetBalancesPanel extends React.Component<Props> {
               <span className={styles.value} id="neoWalletValue">
                 {this.getFormattedFiatBalance(this.getNEOValue())}
               </span>
-              <span
-                className={classNames(
-                  styles.change,
-                  styles[this.getNEOPriceChangeDirection()],
-                )}
-                id="priceChangeNeo"
-              >
-                {this.getNEOFormattedPriceChange()}
-              </span>
+              {!Number.isNaN(this.props.neoPriceChange.toNumber()) && (
+                <span
+                  className={classNames(
+                    styles.change,
+                    styles[this.getNEOPriceChangeDirection()],
+                  )}
+                  id="priceChangeNeo"
+                >
+                  {this.getNEOFormattedPriceChange()}
+                </span>
+              )}
             </div>
             <div className={styles.asset}>
               <div className={classNames(styles.label, styles.assetName)}>
@@ -85,15 +87,17 @@ export default class AssetBalancesPanel extends React.Component<Props> {
               <span className={styles.value} id="gasWalletValue">
                 {this.getFormattedFiatBalance(this.getGASValue())}
               </span>
-              <span
-                className={classNames(
-                  styles.change,
-                  styles[this.getGASPriceChangeDirection()],
-                )}
-                id="priceChangeGas"
-              >
-                {this.getGASFormattedPriceChange()}
-              </span>
+              {!Number.isNaN(this.props.gasPriceChange.toNumber()) && (
+                <span
+                  className={classNames(
+                    styles.change,
+                    styles[this.getGASPriceChangeDirection()],
+                  )}
+                  id="priceChangeGas"
+                >
+                  this.getGASFormattedPriceChange()
+                </span>
+              )}
             </div>
           </div>
         ) : (

--- a/app/components/Dashboard/AssetBalancesPanel/index.js
+++ b/app/components/Dashboard/AssetBalancesPanel/index.js
@@ -34,11 +34,11 @@ const mapPricesDataToProps = ({ NEO, GAS }) => ({
 const mapPriceChangeDataToProps = (prices: Object) => {
   const oldNeo = toBigNumber(get(prices, `[${ASSETS.NEO}][0].close`, 0))
   const newNeo = toBigNumber(
-    get(prices, `[${ASSETS.NEO}][prices[${ASSETS.NEO}].length - 1].close`, 0),
+    get(prices, `[${ASSETS.NEO}][${prices[ASSETS.NEO].length - 1}].close`, 0),
   )
   const oldGas = toBigNumber(get(prices, `[${ASSETS.GAS}][0].close`, 0))
   const newGas = toBigNumber(
-    get(prices, `[${ASSETS.GAS}][prices[${ASSETS.GAS}].length - 1].close`, 0),
+    get(prices, `[${ASSETS.GAS}][${prices[ASSETS.GAS].length - 1}].close`, 0),
   )
 
   return {

--- a/app/components/Dashboard/AssetBalancesPanel/index.js
+++ b/app/components/Dashboard/AssetBalancesPanel/index.js
@@ -1,6 +1,6 @@
 // @flow
 import { compose } from 'recompose'
-import { values, omit } from 'lodash-es'
+import { values, omit, get } from 'lodash-es'
 import { withActions, withData } from 'spunky'
 
 import AssetBalancesPanel from './AssetBalancesPanel'
@@ -32,13 +32,13 @@ const mapPricesDataToProps = ({ NEO, GAS }) => ({
 })
 
 const mapPriceChangeDataToProps = (prices: Object) => {
-  const oldNeo = toBigNumber(prices[ASSETS.NEO][0].close)
+  const oldNeo = toBigNumber(get(prices, `[${ASSETS.NEO}][0].close`, 0))
   const newNeo = toBigNumber(
-    prices[ASSETS.NEO][prices[ASSETS.NEO].length - 1].close,
+    get(prices, `[${ASSETS.NEO}][prices[${ASSETS.NEO}].length - 1].close`, 0),
   )
-  const oldGas = toBigNumber(prices[ASSETS.GAS][0].close)
+  const oldGas = toBigNumber(get(prices, `[${ASSETS.GAS}][0].close`, 0))
   const newGas = toBigNumber(
-    prices[ASSETS.GAS][prices[ASSETS.GAS].length - 1].close,
+    get(prices, `[${ASSETS.GAS}][prices[${ASSETS.GAS}].length - 1].close`, 0),
   )
 
   return {

--- a/app/components/Dashboard/PriceHistoryPanel/PriceHistoryChart.jsx
+++ b/app/components/Dashboard/PriceHistoryPanel/PriceHistoryChart.jsx
@@ -10,7 +10,7 @@ import {
   YAxis,
   Tooltip,
 } from 'recharts'
-import { get } from 'lodash-es'
+import { get, isEmpty } from 'lodash-es'
 
 import AxisLabel from './AxisLabel'
 import { formatFiat } from '../../../core/formatters'
@@ -55,7 +55,9 @@ export default class PriceHistoryChart extends React.Component<Props, State> {
   render = (): React$Node => {
     const { className, prices, timeKey, priceKey } = this.props
 
-    return (
+    return isEmpty(prices) ? (
+      <div>Oops! Historical market data is not available at this time.</div>
+    ) : (
       <ResponsiveContainer
         className={classNames(styles.priceHistoryChart, className)}
       >
@@ -103,7 +105,7 @@ export default class PriceHistoryChart extends React.Component<Props, State> {
   }
 
   tooltipContent = (tooltipProps: Object) =>
-    !!tooltipProps.payload.length && (
+    !!get(tooltipProps, '.payload.length') && (
       <div className={styles.tooltipContainer}>
         <div className={styles.tooltipTime}>
           {this.formatLabel(get(tooltipProps.payload[0], 'payload.time', 0))}

--- a/app/components/Dashboard/PriceHistoryPanel/PriceHistoryPanel.jsx
+++ b/app/components/Dashboard/PriceHistoryPanel/PriceHistoryPanel.jsx
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react'
 import classNames from 'classnames'
-import { find } from 'lodash-es'
+import { find, get } from 'lodash-es'
 
 import PriceHistoryChart from './PriceHistoryChart'
 import Panel from '../../Panel'
@@ -159,16 +159,18 @@ export default class PriceHistoryPanel extends React.Component<Props> {
     })
 
     return (
-      <div className={classes}>
-        {change >= 0 && '+'}
-        {(change * 100).toFixed(2)}%
-      </div>
+      !Number.isNaN(change) && (
+        <div className={classes}>
+          {change >= 0 && '+'}
+          {(change * 100).toFixed(2)}%
+        </div>
+      )
     )
   }
 
   getInitialPrice = (): number => {
     const { prices, priceKey } = this.props
-    return prices[0][priceKey]
+    return get(prices, `[0][${priceKey}]`)
   }
 
   getPriceChange = () =>


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
https://github.com/CityOfZion/neon-wallet/issues/1677

**What problem does this PR solve?**
Because of the way the data is being accessed in neon-wallet the app will crash if the data structure does not conform to what the app was expecting. This has been on my TODO for some time and unfortunately it is biting us in production right now.

**How did you solve this problem?**
By conditionally rendering components and using lodash get

**How did you make sure your solution works?**
By testing locally

<img width="663" alt="screen shot 2019-01-09 at 6 28 28 pm" src="https://user-images.githubusercontent.com/13072035/50940092-cc518a80-143c-11e9-91cc-7e18f8f16bf6.png">

(also the percentage changes have been removed in the asset panel)

**Are there any special changes in the code that we should be aware of?**

**Is there anything else we should know?**

- [ ] Unit tests written?
