### PR TITLE
chore/fix receive panel layout bug

### DIFF
--- a/app/components/Receive/ReceivePanel/index.jsx
+++ b/app/components/Receive/ReceivePanel/index.jsx
@@ -58,7 +58,6 @@ export default class ReceivePanel extends React.Component<Props, State> {
     const { address } = this.props
     return (
       <Panel
-        className={styles.receivePanel}
         renderHeader={() => <ReceivePanelHeader address={address} />}
         contentClassName={styles.receivePanelContent}
       >

--- a/app/components/Receive/ReceivePanel/styles.scss
+++ b/app/components/Receive/ReceivePanel/styles.scss
@@ -7,9 +7,6 @@
   justify-content: center;
 }
 
-.receivePanel {
-}
-
 .receivePanelContent {
   display: flex;
   padding: 0;

--- a/app/components/Receive/ReceivePanel/styles.scss
+++ b/app/components/Receive/ReceivePanel/styles.scss
@@ -8,7 +8,7 @@
 }
 
 .receivePanel {
-  height: 100%;
+  // height: 100%;
 }
 
 .receivePanelContent {
@@ -59,7 +59,7 @@
   background: var(--panel-background);
 
   ul {
-    margin-bottom: 12px !important;
+    margin-bottom: 0px !important;
     margin: 14px auto;
     padding-bottom: 15px !important;
     padding-left: 0;

--- a/app/components/Receive/ReceivePanel/styles.scss
+++ b/app/components/Receive/ReceivePanel/styles.scss
@@ -59,7 +59,7 @@
   background: var(--panel-background);
 
   ul {
-    margin-bottom: 0px !important;
+    margin-bottom: 12px !important;
     margin: 14px auto;
     padding-bottom: 15px !important;
     padding-left: 0;

--- a/app/components/Receive/ReceivePanel/styles.scss
+++ b/app/components/Receive/ReceivePanel/styles.scss
@@ -8,7 +8,6 @@
 }
 
 .receivePanel {
-  // height: 100%;
 }
 
 .receivePanelContent {


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
[Bug: Fix Broken Layout in Receive (dev) #1788](https://github.com/CityOfZion/neon-wallet/issues/1788)

**What problem does this PR solve?**
Please see the screenshot in the above issue. The receive panel header was misaligned.

**How did you solve this problem?**
I adjusted the style sheet for the panel.

**How did you make sure your solution works?**
I tested it.

**Are there any special changes in the code that we should be aware of?**
No.

**Is there anything else we should know?**
I searched commits to find the correct one to provide context as to why this change was applied as the only outcome of the change that I could find was the alignment bug. Line 11 of style.css
https://github.com/CityOfZion/neon-wallet/commit/c03263b26f15770b113b615483d0bf043247cd1e#diff-49e0eb5369f7f556ca2b256f936f5e87R11

- [ ] Unit tests written?
No.