### PR TITLE
chore: fixes minor bugs in release

### DIFF
--- a/__tests__/components/__snapshots__/TransactionHistoryPanel.test.js.snap
+++ b/__tests__/components/__snapshots__/TransactionHistoryPanel.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TransactionHistoryPanel renders without crashing 1`] = `
-<withData(Connect(withData(withProps(Connect(withActions(Connect(withProgress(withProgressComponents(Connect(withActions(Connect(withCall(Connect(withData(Connect(withProgress(withProps(Connect(withData(TransactionHistory))))))))))))))))))))
+<withData(Connect(withData(withProps(Connect(withActions(Connect(withProgress(withProgressComponents(Connect(withActions(Connect(withActions(Connect(withCall(Connect(withData(Connect(withProgress(withProps(Connect(withData(TransactionHistory))))))))))))))))))))))
   address="AWy7RNBVr9vDadRMK9p7i7Z1tL7GrLAxoh"
   dispatch={[Function]}
   store={

--- a/app/components/TransactionHistory/TransactionHistoryPanel/TransactionHistoryPanel.jsx
+++ b/app/components/TransactionHistory/TransactionHistoryPanel/TransactionHistoryPanel.jsx
@@ -11,7 +11,8 @@ import styles from './TransactionHistoryPanel.scss'
 type Props = {
   className: ?string,
   transactions: Array<Object>,
-  handleFetchAdditionalTxData: () => any,
+  handleFetchAdditionalTxData: () => void,
+  handleGetPendingTransactionInfo: () => void,
   pendingTransactions: Array<Object>,
   address: string,
 }
@@ -51,12 +52,18 @@ export default class TransactionHistory extends React.Component<Props> {
   }
 
   async pruneReturnedTransactionsFromStorage() {
-    const { transactions, pendingTransactions, address } = this.props
-    const toBePurged = intersectionBy(transactions, pendingTransactions, 'txId')
+    const {
+      transactions,
+      pendingTransactions,
+      address,
+      handleGetPendingTransactionInfo,
+    } = this.props
+    const toBePurged = intersectionBy(transactions, pendingTransactions, 'txid')
     // eslint-disable-next-line
     for (const transaction of toBePurged) {
       // eslint-disable-next-line
       await pruneConfirmedOrStaleTransaction(address, transaction.txid)
+      handleGetPendingTransactionInfo()
     }
   }
 

--- a/app/components/TransactionHistory/TransactionHistoryPanel/index.js
+++ b/app/components/TransactionHistory/TransactionHistoryPanel/index.js
@@ -14,12 +14,20 @@ const mapTransactionsDataToProps = transactions => ({
   transactions,
 })
 
-const mapAccountActionsToProps = (actions, props) => ({
+const mapAccountActionsToProps = (actions, { net, address }) => ({
   handleFetchAdditionalTxData: () =>
     actions.call({
-      net: props.net,
-      address: props.address,
+      net,
+      address,
       shouldIncrementPagination: true,
+    }),
+})
+
+const mapPendingTransactionActionsToProps = (actions, { net, address }) => ({
+  handleGetPendingTransactionInfo: () =>
+    actions.call({
+      net,
+      address,
     }),
 })
 
@@ -34,6 +42,7 @@ export default compose(
     title: 'Transaction History',
   }),
   withActions(transactionHistoryActions, mapAccountActionsToProps),
+  withActions(getPendingTransactionInfo, mapPendingTransactionActionsToProps),
   withCall(getPendingTransactionInfo),
   withData(getPendingTransactionInfo, mapPendingTransactionInfoToProps),
   withLoadingProp(transactionHistoryActions),


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
This PR fixes a problem that was causing this for loop to unnecessarily be iterated over and thus calling `pruneConfirmedOrStaleTransaction()`

```
    for (const transaction of toBePurged) {
      // eslint-disable-next-line
      await pruneConfirmedOrStaleTransaction(address, transaction.txid)
      handleGetPendingTransactionInfo()
    }
```

It also maps the `getPendingTransactionInfo` to props of the transaction history component so that the action can be dispatched after pending transactions are pruned from storage. This was causing issues in the delay between when the count in the sidebar would be removed. Previously the count would only decrement after two confirmations because the action was not being dispatched, now it decrements when the neoscan API returns the tx OR the node reports two confirmations.

**How did you solve this problem?**
Mapping the action to props and fixing the typo

**How did you make sure your solution works?**
Manual testing

**Are there any special changes in the code that we should be aware of?**
N/A

**Is there anything else we should know?**
N/A

- [ ] Unit tests written?
