### PR TITLE
feature: adds polling to activity tab

### DIFF
--- a/__tests__/components/__snapshots__/TransactionHistoryPanel.test.js.snap
+++ b/__tests__/components/__snapshots__/TransactionHistoryPanel.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TransactionHistoryPanel renders without crashing 1`] = `
-<withData(Connect(withData(withProps(Connect(withActions(Connect(withProgress(withProgressComponents(Connect(withActions(Connect(withActions(Connect(withCall(Connect(withData(Connect(withProgress(withProps(Connect(withData(TransactionHistory))))))))))))))))))))))
+<withData(Connect(withData(withProps(Connect(withActions(Connect(withProgress(withProgressComponents(Connect(withActions(Connect(withActions(Connect(withCall(Connect(withData(Connect(withProgress(withProps(Connect(withData(Connect(Connect(withProgress(LoadedNotifier)))))))))))))))))))))))))
   address="AWy7RNBVr9vDadRMK9p7i7Z1tL7GrLAxoh"
   dispatch={[Function]}
   store={

--- a/app/components/Send/SendPanel/SendSuccess/index.jsx
+++ b/app/components/Send/SendPanel/SendSuccess/index.jsx
@@ -39,7 +39,7 @@ export default class SendSuccess extends React.Component<Props> {
           <CheckMarkIcon className={styles.sendSuccessHeaderIcon} />
           <div className={styles.sendSuccessHeaderInfo}>
             <h1 className={styles.sendSuccessHeaderInfoText}>
-              {numberOfItems} {pluralize('Transfer', numberOfItems)} completed
+              {numberOfItems} {pluralize('Transfer', numberOfItems)} pending
             </h1>
             <p className={styles.sendSuccessParagraphText}>
               {this.txFormattedDate}

--- a/app/components/TransactionHistory/TransactionHistoryPanel/TransactionHistoryPanel.jsx
+++ b/app/components/TransactionHistory/TransactionHistoryPanel/TransactionHistoryPanel.jsx
@@ -13,14 +13,27 @@ type Props = {
   transactions: Array<Object>,
   handleFetchAdditionalTxData: () => void,
   handleGetPendingTransactionInfo: () => void,
+  handleRefreshTxData: () => void,
   pendingTransactions: Array<Object>,
   address: string,
 }
 
+const REFRESH_INTERVAL_MS = 30000
+
 export default class TransactionHistory extends React.Component<Props> {
+  transactionDataInterval: IntervalID
+
   static defaultProps = {
     transactions: [],
     pendingTransactions: [],
+  }
+
+  componentDidMount() {
+    this.addPolling()
+  }
+
+  componentWillUnmount() {
+    this.removePolling()
   }
 
   render() {
@@ -39,6 +52,19 @@ export default class TransactionHistory extends React.Component<Props> {
         />
       </Panel>
     )
+  }
+
+  addPolling = () => {
+    this.transactionDataInterval = setInterval(async () => {
+      await this.props.handleGetPendingTransactionInfo()
+      this.props.handleRefreshTxData()
+    }, REFRESH_INTERVAL_MS)
+  }
+
+  removePolling = () => {
+    if (this.transactionDataInterval) {
+      clearInterval(this.transactionDataInterval)
+    }
   }
 
   pruneConfirmedTransactionsFromPending() {

--- a/app/components/TransactionHistory/TransactionHistoryPanel/index.js
+++ b/app/components/TransactionHistory/TransactionHistoryPanel/index.js
@@ -9,6 +9,7 @@ import withProgressPanel from '../../../hocs/withProgressPanel'
 import withAuthData from '../../../hocs/withAuthData'
 import withNetworkData from '../../../hocs/withNetworkData'
 import withLoadingProp from '../../../hocs/withLoadingProp'
+import withSuccessNotification from '../../../hocs/withSuccessNotification'
 
 const mapTransactionsDataToProps = transactions => ({
   transactions,
@@ -20,6 +21,12 @@ const mapAccountActionsToProps = (actions, { net, address }) => ({
       net,
       address,
       shouldIncrementPagination: true,
+    }),
+  handleRefreshTxData: () =>
+    actions.call({
+      net,
+      address,
+      shouldIncrementPagination: false,
     }),
 })
 
@@ -47,4 +54,8 @@ export default compose(
   withData(getPendingTransactionInfo, mapPendingTransactionInfoToProps),
   withLoadingProp(transactionHistoryActions),
   withData(transactionHistoryActions, mapTransactionsDataToProps),
+  withSuccessNotification(
+    transactionHistoryActions,
+    'Received latest transaction information.',
+  ),
 )(TransactionHistoryPanel)

--- a/app/containers/Dashboard/Dashboard.jsx
+++ b/app/containers/Dashboard/Dashboard.jsx
@@ -25,7 +25,7 @@ type Props = {
 const REFRESH_INTERVAL_MS = 30000
 
 export default class Dashboard extends Component<Props> {
-  walletDataInterval: ?number
+  walletDataInterval: ?IntervalID
 
   componentDidMount() {
     this.addPolling()
@@ -80,7 +80,6 @@ export default class Dashboard extends Component<Props> {
   }
 
   addPolling = () => {
-    // $FlowFixMe
     this.walletDataInterval = setInterval(
       this.props.loadWalletData,
       REFRESH_INTERVAL_MS,
@@ -88,9 +87,7 @@ export default class Dashboard extends Component<Props> {
   }
 
   removePolling = () => {
-    // $FlowFixMe
     if (this.walletDataInterval) {
-      // $FlowFixMe
       clearInterval(this.walletDataInterval)
     }
   }

--- a/app/modules/transactions.js
+++ b/app/modules/transactions.js
@@ -190,7 +190,7 @@ export const sendTransaction = ({
       dispatch(
         showSuccessNotification({
           message:
-            'Transaction complete! Your balance will automatically update when the blockchain has processed it.',
+            'Transaction pending! Your balance will automatically update when the blockchain has processed it.',
         }),
       )
       return resolve(response)


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**

**What problem does this PR solve?**
This small PR adds polling to the `TransactionHistoryPanel` component (very similar how it is done in Dashboard) - enhancing user experience by allowing the activity tab to "refresh" itself every 30 seconds without forcing user to mash refresh. The polling will query the current selected node using getrawtransaction AND will query the neoscan API

This PR also changes some verbage in the app from "completed / complete" to "pending"

**How did you solve this problem?**

**How did you make sure your solution works?**
Careful manual testing.

**Are there any special changes in the code that we should be aware of?**

**Is there anything else we should know?**

- [ ] Unit tests written?
