### PR TITLE
feature: reimplements dynamic token hashes

### DIFF
--- a/app/core/nep5.js
+++ b/app/core/nep5.js
@@ -1,5 +1,6 @@
 // @flow
-import { map } from 'lodash-es'
+import { map, isEmpty } from 'lodash-es'
+import axios from 'axios'
 
 import { toBigNumber } from './math'
 import { COIN_DECIMAL_LENGTH } from './formatters'
@@ -11,6 +12,8 @@ import {
 } from './constants'
 import { imageMap } from '../assets/nep5/png'
 
+let fetchedTokens
+
 export const adjustDecimalAmountForTokenTransfer = (value: string): string =>
   toBigNumber(value)
     .times(10 ** COIN_DECIMAL_LENGTH)
@@ -19,36 +22,54 @@ export const adjustDecimalAmountForTokenTransfer = (value: string): string =>
 
 const getTokenEntry = ((): Function => {
   let id = 1
+
   return (
     symbol: string,
     scriptHash: string,
     networkId: string,
     name: string,
     decimals: number,
+    networkData: Object = {},
   ) => ({
     id: `${id++}`, // eslint-disable-line no-plusplus
     symbol,
     scriptHash,
     networkId,
     isUserGenerated: false,
+    totalSupply: networkData.totalSupply,
+    decimals: networkData.decimals,
     image: imageMap[symbol],
-    name,
-    decimals,
   })
 })()
 
 export const getDefaultTokens = async (): Promise<Array<TokenItemType>> => {
   const tokens = []
+  // Prevent duplicate requests here
+  if (!fetchedTokens) {
+    const response = await axios
+      // use a time stamp query param to prevent caching
+      .get(
+        `https://raw.githubusercontent.com/CityOfZion/neo-tokens/master/tokenList.json?timestamp=${new Date().getTime()}`,
+      )
+      .catch(error => {
+        console.error('Falling back to hardcoded list of NEP5 tokens!', error)
+        // if request to gh fails use hardcoded list
+        fetchedTokens = TOKENS
+      })
+    if (response && response.data && !isEmpty(response.data)) {
+      fetchedTokens = response.data
+    } else {
+      fetchedTokens = TOKENS
+    }
+  }
 
   tokens.push(
-    ...map(TOKENS, tokenData =>
+    ...map(fetchedTokens, tokenData =>
       getTokenEntry(
         tokenData.symbol,
         tokenData.networks['1'].hash,
         MAIN_NETWORK_ID,
-
-        tokenData.networks['1'].name,
-        tokenData.networks['1'].decimals,
+        tokenData.networks['1'],
       ),
     ),
   )


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
Before the release of v2 it was suggested that we eliminate the need to rely on github for token hash data since then it was proposed that this feature be brought back.

**What problem does this PR solve?**
This PR eliminates the need to release a new binary when we want to add token hash data to the application.

**How did you solve this problem?**
By fetching the data from `https://raw.githubusercontent.com/CityOfZion/neo-tokens/master/tokenList.json`

**How did you make sure your solution works?**
Testing locally

**Are there any special changes in the code that we should be aware of?**

**Is there anything else we should know?**

- [ ] Unit tests written?
