### PR TITLE
chore: yarn dev issues on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Setup:
 Developing:
 
 - `yarn dev` - Start the application in development mode with hot reloading enabled
+  - There is a known condition that may arise on Linux systems where `yarn dev` builds but Neon never opens. Try using `yarn dev >/dev/null`.
 
 Running (for production):
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "postinstall": "electron-builder install-app-deps && electron-rebuild --force --module_dir . -w node-hid -v 1.8.4",
     "start": "cross-env NODE_ENV=production electron .",
     "assets": "cross-env NODE_ENV=production webpack --config ./config/webpack.config.prod",
-    "dev": "cross-env START_HOT=1 NODE_ENV=development node_modules/.bin/webpack-dev-server --config ./config/webpack.config.dev",
+    "dev": "cross-env START_HOT=1 NODE_ENV=development node_modules/.bin/webpack-dev-server --progress --config ./config/webpack.config.dev",
     "start-dev": "cross-env NODE_ENV=development electron . --enable-logging --remote-debugging-port=9222",
     "assets-dev": "cross-env NODE_ENV=development webpack --config ./config/webpack.config.dev",
     "test": "npm rebuild node-hid && ./node_modules/.bin/jest --coverage",

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   "scripts": {
     "postinstall": "electron-builder install-app-deps && electron-rebuild --force --module_dir . -w node-hid -v 1.8.4",
     "start": "cross-env NODE_ENV=production electron .",
-    "assets": "cross-env NODE_ENV=production webpack --config ./config/webpack.config.prod",
+    "assets": "cross-env NODE_ENV=production webpack --config ./config/webpack.config.prod --progress",
     "dev": "cross-env START_HOT=1 NODE_ENV=development node_modules/.bin/webpack-dev-server --progress --config ./config/webpack.config.dev",
-    "start-dev": "cross-env NODE_ENV=development electron . --enable-logging --remote-debugging-port=9222",
-    "assets-dev": "cross-env NODE_ENV=development webpack --config ./config/webpack.config.dev",
+    "start-dev": "cross-env NODE_ENV=development electron . --enable-logging --remote-debugging-port=9222 --progress",
+    "assets-dev": "cross-env NODE_ENV=development webpack --config ./config/webpack.config.dev --progress",
     "test": "npm rebuild node-hid && ./node_modules/.bin/jest --coverage",
     "test-ci": "yarn test && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
     "test:e2e": "ava __e2e__/*.e2e.js --timeout=120s -s",


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
When executing 'yarn dev' no indication of progress was showing before. Now the build status is output as it goes.

This PR also addresses an issue with Linux (experienced personally on Ubuntu 18.04) where 'yarn dev' builds but Neon never opens. A note was made on the readme.

**What problem does this PR solve?**
The PR resolves the issue of no clear feedback to the developer of build progress.

This PR also addresses an issue with Linux (experienced personally on Ubuntu 18.04) where 'yarn dev' builds but Neon never opens. A note was made on the readme.

**How did you solve this problem?**
I added the flag --progress to the package.json build script named 'dev'.

**How did you make sure your solution works?**
I tested it and verified it showed progress.

**Are there any special changes in the code that we should be aware of?**
No.

**Is there anything else we should know?**
No.

- [ ] Unit tests written?
No.