### PR TITLE
feature: activity export enhancements

### DIFF
--- a/app/containers/TransactionHistory/TransactionHistory.jsx
+++ b/app/containers/TransactionHistory/TransactionHistory.jsx
@@ -18,8 +18,6 @@ import { parseAbstractData } from '../../actions/transactionHistoryActions'
 
 const { dialog, app } = require('electron').remote
 
-console.log()
-
 type Props = {
   showSuccessNotification: ({ message: string }) => string,
   showErrorNotification: ({ message: string }) => string,

--- a/app/containers/TransactionHistory/TransactionHistory.jsx
+++ b/app/containers/TransactionHistory/TransactionHistory.jsx
@@ -6,7 +6,6 @@ import { api } from '@cityofzion/neon-js'
 import axios from 'axios'
 import { omit } from 'lodash-es'
 import moment from 'moment'
-// import { app } from 'electron'
 
 import HeaderBar from '../../components/HeaderBar'
 import TransactionHistoryPanel from '../../components/TransactionHistory/TransactionHistoryPanel'


### PR DESCRIPTION
This PR accomplishes two things:
1.) adds disabled state to the new export button in the activity tab so that users cant mash this (or automate the mashing)

2.) Updates the default path of the exported csv to `<path to documents>/neon-wallet-activity-${moment().unix()}.csv`

Verified manually that file export is still working exactly as expected