### PR TITLE
feature: adds watch only address (part I)

### DIFF
--- a/app/actions/authActions.js
+++ b/app/actions/authActions.js
@@ -13,6 +13,10 @@ type WifLoginProps = {
   wif: string,
 }
 
+type WatchOnlyLoginProps = {
+  address: string,
+}
+
 type LedgerLoginProps = {
   publicKey: string,
   signingFunction: Function,
@@ -46,6 +50,20 @@ export const wifLoginActions = createActions(
     return {
       wif: account.WIF,
       address: account.address,
+      isHardwareLogin: false,
+    }
+  },
+)
+
+export const watchOnlyLoginActions = createActions(
+  ID,
+  ({ address }: WatchOnlyLoginProps) => (): AccountType => {
+    if (!wallet.isAddress(address)) {
+      throw new Error('Invalid public key entered')
+    }
+
+    return {
+      address,
       isHardwareLogin: false,
     }
   },

--- a/app/containers/EditWallet/EditWallet.scss
+++ b/app/containers/EditWallet/EditWallet.scss
@@ -24,7 +24,7 @@
   width: 100%;
   height: 100%;
   flex-direction: column;
-  width: 500px;
+  width: 550px;
   margin-bottom: auto;
 }
 

--- a/app/containers/Home/Home.jsx
+++ b/app/containers/Home/Home.jsx
@@ -7,6 +7,7 @@ import LoginPrivateKey from '../LoginPrivateKey'
 import LoginNep2 from '../LoginNep2'
 import LoginLedgerNanoS from '../LoginLedgerNanoS'
 import LoginLocalStorage from '../LoginLocalStorage'
+import LoginWatchOnly from '../LoginWatchOnly'
 import Button from '../../components/Button'
 import styles from './Home.scss'
 import AddIcon from '../../assets/icons/add.svg'
@@ -18,7 +19,6 @@ import pack from '../../../package.json'
 type State = {
   tabIndex: number,
 }
-
 type Props = {
   loading: boolean,
   theme: ThemeType,
@@ -36,6 +36,10 @@ const LOGIN_OPTIONS = {
   NEP2: {
     render: () => <LoginNep2 />,
     display: 'Encrypted Key',
+  },
+  watch: {
+    render: () => <LoginWatchOnly />,
+    display: 'Watch only',
   },
   ledger: {
     render: () => <LoginLedgerNanoS />,

--- a/app/containers/Home/Home.scss
+++ b/app/containers/Home/Home.scss
@@ -175,7 +175,7 @@ $navigation-margin: 20px;
   align-items: center;
   margin: auto;
   min-height: 550px;
-  width: 600px;
+  width: 650px;
 }
 
 .buttonRow {
@@ -259,7 +259,7 @@ $navigation-margin: 20px;
 .inputContainer {
   display: flex;
   flex-direction: column;
-  width: 500px;
+  width: 550px;
   align-items: center;
 }
 

--- a/app/containers/LoginWatchOnly/LoginWatchOnly.jsx
+++ b/app/containers/LoginWatchOnly/LoginWatchOnly.jsx
@@ -1,13 +1,8 @@
 // @flow
 import React from 'react'
-import { type ProgressState } from 'spunky'
 
-import QrCodeScanner from '../../components/QrCodeScanner'
 import Button from '../../components/Button'
-// import PasswordInput from '../../components/Inputs/PasswordInput/PasswordInput'
 import LoginIcon from '../../assets/icons/login.svg'
-import GridIcon from '../../assets/icons/grid.svg'
-import Close from '../../assets/icons/close.svg'
 import styles from '../Home/Home.scss'
 import TextInput from '../../components/Inputs/TextInput'
 

--- a/app/containers/LoginWatchOnly/LoginWatchOnly.jsx
+++ b/app/containers/LoginWatchOnly/LoginWatchOnly.jsx
@@ -1,0 +1,67 @@
+// @flow
+import React from 'react'
+import { type ProgressState } from 'spunky'
+
+import QrCodeScanner from '../../components/QrCodeScanner'
+import Button from '../../components/Button'
+// import PasswordInput from '../../components/Inputs/PasswordInput/PasswordInput'
+import LoginIcon from '../../assets/icons/login.svg'
+import GridIcon from '../../assets/icons/grid.svg'
+import Close from '../../assets/icons/close.svg'
+import styles from '../Home/Home.scss'
+import TextInput from '../../components/Inputs/TextInput'
+
+type Props = {
+  watchOnlyLogin: (content: string) => void,
+}
+
+type State = {
+  address: string,
+}
+
+export default class LoginPrivateKey extends React.Component<Props, State> {
+  state = {
+    address: '',
+  }
+
+  render = () => {
+    const { watchOnlyLogin } = this.props
+    const { address } = this.state
+
+    return (
+      <div id="loginPrivateKey" className={styles.flexContainer}>
+        <form
+          onSubmit={e => {
+            e.preventDefault()
+            watchOnlyLogin(address)
+          }}
+        >
+          <React.Fragment>
+            <div className={styles.centeredInput}>
+              <TextInput
+                textInputClassName={styles.privateKeyInput}
+                placeholder="Enter a public key here"
+                value={address}
+                onChange={(e: Object) =>
+                  this.setState({ address: e.target.value })
+                }
+                autoFocus
+              />
+            </div>
+            <div className={styles.privateKeyLoginButtonRow}>
+              <Button
+                id="loginButton"
+                primary
+                type="submit"
+                renderIcon={LoginIcon}
+                disabled={address.length < 10}
+              >
+                Login
+              </Button>
+            </div>
+          </React.Fragment>
+        </form>
+      </div>
+    )
+  }
+}

--- a/app/containers/LoginWatchOnly/index.js
+++ b/app/containers/LoginWatchOnly/index.js
@@ -1,0 +1,17 @@
+// @flow
+import { compose } from 'recompose'
+import { withActions, withProgress } from 'spunky'
+
+import LoginWatchOnly from './LoginWatchOnly'
+import withFailureNotification from '../../hocs/withFailureNotification'
+import { watchOnlyLoginActions } from '../../actions/authActions'
+
+const mapActionsToProps = actions => ({
+  watchOnlyLogin: address => actions.call({ address }),
+})
+
+export default compose(
+  withActions(watchOnlyLoginActions, mapActionsToProps),
+  withFailureNotification(watchOnlyLoginActions),
+  withProgress(watchOnlyLoginActions),
+)(LoginWatchOnly)

--- a/app/styles/main.global.scss
+++ b/app/styles/main.global.scss
@@ -236,7 +236,7 @@ input::placeholder {
     li {
       display: flex;
       margin: auto;
-      font-size: 12px;
+      font-size: 11px;
       color: #ced0d4;
       cursor: pointer;
       padding-bottom: 10px;


### PR DESCRIPTION
![watch-only](https://user-images.githubusercontent.com/13072035/57655932-5bf67980-7594-11e9-9086-fa1977b4e870.gif)

**What current issue(s) from Trello/Github does this address?**
https://github.com/CityOfZion/neon-wallet/issues/1827

(begins the process of tackling https://github.com/CityOfZion/neon-wallet/issues/1846)

This PR serves as a feature in itself however it is really the foundation of adding additional features such as building transactions for offline signing...

NOTE: more work needs to be done here (coming in separate PRs) to ensure high quality user experience in watch only mode (We should disable the appropriate routes and possibly address some other items I am not thinking of now)

**What problem does this PR solve?**
This gives the ability for users to enter in any valid address on the blockchain to use neon

**How did you solve this problem?**
By mostly reusing components and logic that already existed

**How did you make sure your solution works?**
Manual testing

**Are there any special changes in the code that we should be aware of?**
As mentioned previously there are things that will be broken with just this PR alone... Future work will refine the details that this lays the foundation for

**Is there anything else we should know?**

- [ ] Unit tests written?
