### PR TITLE
feature: adds encrypted key qr scan to login flow

### DIFF
--- a/__tests__/components/__snapshots__/Login.test.js.snap
+++ b/__tests__/components/__snapshots__/Login.test.js.snap
@@ -20,7 +20,7 @@ exports[`Login renders without crashing 1`] = `
       />
     </div>
     <div
-      className="privateKeyLoginButtonRow"
+      className="loginButtonRow"
     >
       <Button
         disabled={true}

--- a/app/containers/Home/Home.scss
+++ b/app/containers/Home/Home.scss
@@ -33,7 +33,7 @@ $navigation-margin: 20px;
   margin-bottom: 10px;
 }
 
-.privateKeyLoginButtonRow {
+.loginButtonRow {
   display: flex;
   margin-top: auto;
   button:first-child {
@@ -48,7 +48,7 @@ $navigation-margin: 20px;
   min-height: 17px;
 }
 
-.privateKeyLoginButtonRowScannerActive {
+.loginButtonRowScannerActive {
   button {
     width: 200px;
     margin: auto;

--- a/app/containers/LoginNep2/LoginNep2.jsx
+++ b/app/containers/LoginNep2/LoginNep2.jsx
@@ -1,60 +1,106 @@
 // @flow
 import React, { Component } from 'react'
+import { type ProgressState } from 'spunky'
 
+import QrCodeScanner from '../../components/QrCodeScanner'
 import Button from '../../components/Button'
 import PasswordInput from '../../components/Inputs/PasswordInput'
 import LoginIcon from '../../assets/icons/login.svg'
 import styles from '../Home/Home.scss'
+import GridIcon from '../../assets/icons/grid.svg'
+import Close from '../../assets/icons/close.svg'
 
 type Props = {
   loading: boolean,
   loginNep2: Function,
   cameraAvailable: boolean,
+  progress: ProgressState,
 }
 type State = {
   encryptedWIF: string,
   passphrase: string,
+  scannerActive: boolean,
 }
 
 export default class LoginNep2 extends Component<Props, State> {
   state = {
     encryptedWIF: '',
     passphrase: '',
+    scannerActive: false,
+  }
+
+  toggleScanner = () => {
+    this.setState(prevState => ({ scannerActive: !prevState.scannerActive }))
   }
 
   render() {
-    const { loading, cameraAvailable } = this.props
-    const { encryptedWIF, passphrase } = this.state
+    const { loading, cameraAvailable, progress } = this.props
+    const { encryptedWIF, passphrase, scannerActive } = this.state
 
     return (
       <div id="loginNep2" className={styles.flexContainer}>
         <form onSubmit={this.handleSubmit}>
-          <div className={styles.inputMargin}>
-            <PasswordInput
-              placeholder="Encrypted Key"
-              autoFocus
-              value={encryptedWIF}
-              disabled={loading}
-              onChange={e => this.setState({ encryptedWIF: e.target.value })}
-            />
-          </div>
-          <PasswordInput
-            placeholder="Password"
-            value={passphrase}
-            disabled={loading}
-            onChange={e => this.setState({ passphrase: e.target.value })}
-          />
-          <Button
-            id="loginButton"
-            primary
-            type="submit"
-            className={styles.loginButtonMargin}
-            renderIcon={LoginIcon}
-            disabled={loading || !this.isValid()}
-            shouldCenterButtonLabelText
-          >
-            Login
-          </Button>
+          {scannerActive ? (
+            <React.Fragment>
+              <div className={styles.scannerContainer}>
+                <QrCodeScanner
+                  callback={this.handleSubmit}
+                  callbackProgress={progress}
+                  width="316"
+                  height="178"
+                />
+              </div>
+              <div className={styles.privateKeyLoginButtonRowScannerActive}>
+                <Button
+                  id="scan-private-key-qr-button"
+                  renderIcon={Close}
+                  onClick={this.toggleScanner}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </React.Fragment>
+          ) : (
+            <React.Fragment>
+              <div className={styles.inputMargin}>
+                <PasswordInput
+                  placeholder="Encrypted Key"
+                  autoFocus
+                  value={encryptedWIF}
+                  disabled={loading}
+                  onChange={e =>
+                    this.setState({ encryptedWIF: e.target.value })
+                  }
+                />
+              </div>
+              <PasswordInput
+                placeholder="Password"
+                value={passphrase}
+                disabled={loading}
+                onChange={e => this.setState({ passphrase: e.target.value })}
+              />
+              <Button
+                id="scan-private-key-qr-button"
+                primary
+                renderIcon={GridIcon}
+                onClick={this.toggleScanner}
+                disabled={!cameraAvailable}
+              >
+                Scan QR
+              </Button>
+              <Button
+                id="loginButton"
+                primary
+                type="submit"
+                className={styles.loginButtonMargin}
+                renderIcon={LoginIcon}
+                disabled={loading || !this.isValid()}
+                shouldCenterButtonLabelText
+              >
+                Login
+              </Button>
+            </React.Fragment>
+          )}
         </form>
       </div>
     )

--- a/app/containers/LoginNep2/LoginNep2.jsx
+++ b/app/containers/LoginNep2/LoginNep2.jsx
@@ -44,7 +44,9 @@ export default class LoginNep2 extends Component<Props, State> {
             <React.Fragment>
               <div className={styles.scannerContainer}>
                 <QrCodeScanner
-                  callback={this.handleSubmit}
+                  callback={encryptedWIF =>
+                    this.setState({ encryptedWIF, scannerActive: false })
+                  }
                   callbackProgress={progress}
                   width="316"
                   height="178"
@@ -79,26 +81,28 @@ export default class LoginNep2 extends Component<Props, State> {
                 disabled={loading}
                 onChange={e => this.setState({ passphrase: e.target.value })}
               />
-              <Button
-                id="scan-private-key-qr-button"
-                primary
-                renderIcon={GridIcon}
-                onClick={this.toggleScanner}
-                disabled={!cameraAvailable}
-              >
-                Scan QR
-              </Button>
-              <Button
-                id="loginButton"
-                primary
-                type="submit"
-                className={styles.loginButtonMargin}
-                renderIcon={LoginIcon}
-                disabled={loading || !this.isValid()}
-                shouldCenterButtonLabelText
-              >
-                Login
-              </Button>
+              <div className={styles.loginButtonRow}>
+                <Button
+                  id="scan-private-key-qr-button"
+                  primary
+                  renderIcon={GridIcon}
+                  onClick={this.toggleScanner}
+                  disabled={!cameraAvailable}
+                >
+                  Scan QR
+                </Button>
+                <Button
+                  id="loginButton"
+                  primary
+                  type="submit"
+                  className={styles.loginButtonMargin}
+                  renderIcon={LoginIcon}
+                  disabled={loading || !this.isValid()}
+                  shouldCenterButtonLabelText
+                >
+                  Login
+                </Button>
+              </div>
             </React.Fragment>
           )}
         </form>

--- a/app/containers/LoginNep2/LoginNep2.jsx
+++ b/app/containers/LoginNep2/LoginNep2.jsx
@@ -50,7 +50,7 @@ export default class LoginNep2 extends Component<Props, State> {
                   height="178"
                 />
               </div>
-              <div className={styles.privateKeyLoginButtonRowScannerActive}>
+              <div className={styles.loginButtonRowScannerActive}>
                 <Button
                   id="scan-private-key-qr-button"
                   renderIcon={Close}

--- a/app/containers/LoginNep2/LoginNep2.jsx
+++ b/app/containers/LoginNep2/LoginNep2.jsx
@@ -9,8 +9,8 @@ import styles from '../Home/Home.scss'
 type Props = {
   loading: boolean,
   loginNep2: Function,
+  cameraAvailable: boolean,
 }
-
 type State = {
   encryptedWIF: string,
   passphrase: string,
@@ -23,7 +23,7 @@ export default class LoginNep2 extends Component<Props, State> {
   }
 
   render() {
-    const { loading } = this.props
+    const { loading, cameraAvailable } = this.props
     const { encryptedWIF, passphrase } = this.state
 
     return (

--- a/app/containers/LoginNep2/index.js
+++ b/app/containers/LoginNep2/index.js
@@ -1,6 +1,6 @@
 // @flow
 import { compose } from 'recompose'
-import { withActions } from 'spunky'
+import { withActions, withProgress } from 'spunky'
 
 import LoginNep2 from './LoginNep2'
 import withLoadingProp from '../../hocs/withLoadingProp'
@@ -18,5 +18,6 @@ export default compose(
   withActions(nep2LoginActions, mapActionsToProps),
   withLoadingProp(nep2LoginActions, { strategy: pureStrategy }),
   withFailureNotification(nep2LoginActions),
+  withProgress(nep2LoginActions),
   withCameraAvailability,
 )(LoginNep2)

--- a/app/containers/LoginNep2/index.js
+++ b/app/containers/LoginNep2/index.js
@@ -7,6 +7,7 @@ import withLoadingProp from '../../hocs/withLoadingProp'
 import withFailureNotification from '../../hocs/withFailureNotification'
 import pureStrategy from '../../hocs/helpers/pureStrategy'
 import { nep2LoginActions } from '../../actions/authActions'
+import withCameraAvailability from '../../hocs/withCameraAvailability'
 
 const mapActionsToProps = actions => ({
   loginNep2: (passphrase, encryptedWIF) =>
@@ -17,4 +18,5 @@ export default compose(
   withActions(nep2LoginActions, mapActionsToProps),
   withLoadingProp(nep2LoginActions, { strategy: pureStrategy }),
   withFailureNotification(nep2LoginActions),
+  withCameraAvailability,
 )(LoginNep2)

--- a/app/containers/LoginPrivateKey/LoginPrivateKey.jsx
+++ b/app/containers/LoginPrivateKey/LoginPrivateKey.jsx
@@ -53,7 +53,7 @@ export default class LoginPrivateKey extends React.Component<Props, State> {
                   height="178"
                 />
               </div>
-              <div className={styles.privateKeyLoginButtonRowScannerActive}>
+              <div className={styles.loginButtonRowScannerActive}>
                 <Button
                   id="scan-private-key-qr-button"
                   renderIcon={Close}
@@ -76,7 +76,7 @@ export default class LoginPrivateKey extends React.Component<Props, State> {
                   autoFocus
                 />
               </div>
-              <div className={styles.privateKeyLoginButtonRow}>
+              <div className={styles.loginButtonRow}>
                 <Button
                   id="scan-private-key-qr-button"
                   primary

--- a/app/containers/LoginWatchOnly/LoginWatchOnly.jsx
+++ b/app/containers/LoginWatchOnly/LoginWatchOnly.jsx
@@ -43,7 +43,7 @@ export default class LoginPrivateKey extends React.Component<Props, State> {
                 autoFocus
               />
             </div>
-            <div className={styles.privateKeyLoginButtonRow}>
+            <div className={styles.loginButtonRow}>
               <Button
                 id="loginButton"
                 primary


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
https://github.com/CityOfZion/neon-wallet/issues/1854

**What problem does this PR solve?**
This PR allows users to scan a QR of their encrypted key in order to login

NOTE: password still must be added

**How did you solve this problem?**
By reusing the components we already have in our lib and by using a similar flow as exposed in `LoginPrivateKey.jsx`

**How did you make sure your solution works?**
Manual testing

**Are there any special changes in the code that we should be aware of?**

**Is there anything else we should know?**
Currently the app does not expose any qr codes for encrypted keys however a future PR will add them in the appropriate places (both during wallet creation and in settings).  We should avoid merging this work until that is complete.

We _could_ encode the password to the encrypted wallet in the QR however for consistency I think it makes most sense to just encode the key.

- [ ] Unit tests written?
