### PR TITLE
feature: login verbage refactor

### DIFF
--- a/app/containers/Home/Home.jsx
+++ b/app/containers/Home/Home.jsx
@@ -27,19 +27,19 @@ type Props = {
 const LOGIN_OPTIONS = {
   LOCAL_STORAGE: {
     render: () => <LoginLocalStorage />,
-    display: 'Saved Wallet',
+    display: 'Saved',
   },
   PRIVATE_KEY: {
     render: () => <LoginPrivateKey />,
-    display: 'Private Key',
+    display: 'Private',
   },
   NEP2: {
     render: () => <LoginNep2 />,
-    display: 'Encrypted Key',
+    display: 'Encrypted',
   },
   watch: {
     render: () => <LoginWatchOnly />,
-    display: 'Watch only',
+    display: 'Watch',
   },
   ledger: {
     render: () => <LoginLedgerNanoS />,

--- a/app/containers/Home/Home.scss
+++ b/app/containers/Home/Home.scss
@@ -175,7 +175,7 @@ $navigation-margin: 20px;
   align-items: center;
   margin: auto;
   min-height: 550px;
-  width: 650px;
+  width: 600px;
 }
 
 .buttonRow {
@@ -259,7 +259,7 @@ $navigation-margin: 20px;
 .inputContainer {
   display: flex;
   flex-direction: column;
-  width: 550px;
+  width: 500px;
   align-items: center;
 }
 

--- a/app/containers/LoginWatchOnly/LoginWatchOnly.jsx
+++ b/app/containers/LoginWatchOnly/LoginWatchOnly.jsx
@@ -35,7 +35,7 @@ export default class LoginPrivateKey extends React.Component<Props, State> {
             <div className={styles.centeredInput}>
               <TextInput
                 textInputClassName={styles.privateKeyInput}
-                placeholder="Enter a public key here"
+                placeholder="Enter a NEO address here"
                 value={address}
                 onChange={(e: Object) =>
                   this.setState({ address: e.target.value })

--- a/app/styles/main.global.scss
+++ b/app/styles/main.global.scss
@@ -236,7 +236,7 @@ input::placeholder {
     li {
       display: flex;
       margin: auto;
-      font-size: 11px;
+      font-size: 12px;
       color: #ced0d4;
       cursor: pointer;
       padding-bottom: 10px;


### PR DESCRIPTION
This simple PR accomplishes four things:
1.) Reduces clutter in the "login tabs" by removing excessive verbage
2.) Increases the font size of the text in the tabs
3.) Changes the placeholder text of the "Watch" option
4.) Reduces recent aspect changes to the width of the "Home" container

BEFORE:
<img width="734" alt="Screen Shot 2019-05-21 at 9 36 33 AM" src="https://user-images.githubusercontent.com/13072035/58110523-ebabb180-7bac-11e9-8b1a-34a4f4ed1f80.png">
<img width="697" alt="Screen Shot 2019-05-21 at 9 36 40 AM" src="https://user-images.githubusercontent.com/13072035/58110524-ebabb180-7bac-11e9-9119-45f1b9cefc3f.png">

AFTER:
<img width="659" alt="Screen Shot 2019-05-21 at 9 46 19 AM" src="https://user-images.githubusercontent.com/13072035/58110716-4d6c1b80-7bad-11e9-910d-e8c54531579c.png">

