### PR TITLE
feature suggestion: We should render a QR for encrypted keys (without passwords)

### DIFF
--- a/app/components/Root/Routes.jsx
+++ b/app/components/Root/Routes.jsx
@@ -22,6 +22,7 @@ import TokenSale from '../../containers/TokenSale'
 import Encrypt from '../../containers/Encrypt'
 import NodeSelect from '../../containers/NodeSelect'
 import News from '../../containers/News'
+import EncryptQR from '../Settings/EncryptQR'
 import { ROUTES } from '../../core/constants'
 
 export default () => (
@@ -74,7 +75,11 @@ export default () => (
         path={ROUTES.DISPLAY_WALLET_QRS}
         render={props => <DisplayWalletAccountsQrCodes {...props} />}
       />
-
+      <Route
+        exact
+        path={ROUTES.DISPLAY_ENCRYPTED_WIF_QR}
+        render={props => <EncryptQR {...props} />}
+      />
       <Route exact path={ROUTES.SETTINGS} component={Settings} />
       <PrivateRoute
         exact

--- a/app/components/Settings/EncryptPanel/EncryptPanel.jsx
+++ b/app/components/Settings/EncryptPanel/EncryptPanel.jsx
@@ -1,6 +1,5 @@
 // @flow
 import React from 'react'
-import { noop } from 'lodash-es'
 import classNames from 'classnames'
 
 import { ROUTES } from '../../../core/constants'
@@ -11,33 +10,19 @@ import LockIcon from '../../../assets/icons/lock.svg'
 import CloseButton from '../../CloseButton'
 import styles from './EncryptPanel.scss'
 
-type State = {
-  encryptedkey: string,
-}
-
 type Props = {
   handleSubmit: Function,
   validatePassphraseLength: Function,
   isWIF: Function,
   className: string,
   title: string,
+  resetEncryptedWIF: Function,
+  encryptedWIF: string,
 }
 
-export default class EncryptPanel extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props)
-
-    this.state = {
-      encryptedkey: '',
-    }
-  }
-
-  static defaultProps = {
-    handleSubmit: noop,
-  }
-
+export default class EncryptPanel extends React.Component<Props> {
   render() {
-    const { className } = this.props
+    const { className, resetEncryptedWIF, encryptedWIF } = this.props
 
     return (
       <FullHeightPanel
@@ -48,40 +33,37 @@ export default class EncryptPanel extends React.Component<Props, State> {
         renderHeaderIcon={this.renderIcon}
         renderInstructions={this.renderInstructions}
       >
-        {this.renderPanelContent()}
+        {this.renderPanelContent(encryptedWIF, resetEncryptedWIF)}
       </FullHeightPanel>
     )
   }
 
   renderHeader = () => <span>{this.props.title}</span>
 
-  renderInstructions = () => {
-    const { encryptedkey } = this.state
-    if (!encryptedkey) {
+  renderInstructions = encryptedWIF => {
+    if (!encryptedWIF) {
       return <div>Choose a passphrase to encrypt an existing key</div>
     }
   }
 
-  renderPanelContent = () => {
-    const { encryptedkey } = this.state
-    if (!encryptedkey) {
+  renderPanelContent = (encryptedWIF, resetEncryptedWIF) => {
+    if (!encryptedWIF) {
       return (
         <EncryptForm
           submitLabel="Generate Encrypted Key"
           onSubmit={this.onSubmit}
-          encryptPrivateKey={encryptedkey}
+          encryptPrivateKey={encryptedWIF}
           isWIF={this.props.isWIF}
           validatePassphraseLength={this.props.validatePassphraseLength}
         />
       )
     }
     return (
-      <EncryptSuccess encryptedKey={encryptedkey} handleReset={this.reset} />
+      <EncryptSuccess
+        encryptedKey={encryptedWIF}
+        handleReset={resetEncryptedWIF}
+      />
     )
-  }
-
-  reset = () => {
-    this.setState({ encryptedkey: '' })
   }
 
   renderIcon = () => (
@@ -96,7 +78,6 @@ export default class EncryptPanel extends React.Component<Props, State> {
     confirmPassphrase: string,
   ) => {
     const { handleSubmit } = this.props
-    const result = handleSubmit(privateKey, passphrase, confirmPassphrase)
-    this.setState({ encryptedkey: result })
+    handleSubmit(privateKey, passphrase, confirmPassphrase)
   }
 }

--- a/app/components/Settings/EncryptPanel/index.js
+++ b/app/components/Settings/EncryptPanel/index.js
@@ -1,1 +1,33 @@
-export { default } from './EncryptPanel'
+// @flow
+
+import { connect } from 'react-redux'
+import { compose } from 'recompose'
+import { bindActionCreators } from 'redux'
+
+import {
+  getEncryptedWIF,
+  resetEncryptedWIF,
+} from '../../../modules/generateEncryptedWIF'
+
+import EncryptPanel from './EncryptPanel'
+
+const mapStateToProps = (state: Object) => ({
+  //  wif: getWIF(state),
+  //  address: getAddress(state),
+  encryptedWIF: getEncryptedWIF(state),
+  //  passphrase: getPassphrase(state),
+})
+
+const actionCreators = {
+  resetEncryptedWIF,
+}
+
+const mapDispatchToProps = dispatch =>
+  bindActionCreators(actionCreators, dispatch)
+
+export default compose(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  ),
+)(EncryptPanel)

--- a/app/components/Settings/EncryptQR/EncryptQR.jsx
+++ b/app/components/Settings/EncryptQR/EncryptQR.jsx
@@ -1,0 +1,85 @@
+// @flow
+import React, { Component } from 'react'
+
+import Button from '../../Button'
+import { ROUTES } from '../../../core/constants'
+import styles from './EncryptQR.scss'
+import FullHeightPanel from '../../Panel/FullHeightPanel'
+
+import CheckIcon from '../../../assets/icons/check.svg'
+import CloseButton from '../../CloseButton'
+import BackButton from '../../BackButton'
+
+import ConfirmIcon from '../../../assets/icons/confirm.svg'
+import CopyIcon from '../../../assets/icons/copy.svg'
+import withCopyCanvasToClipboard from '../../../hocs/withCopyCanvasToClipboard'
+import AddIcon from '../../../assets/icons/add.svg'
+
+type Props = {
+  encryptedWIF: string,
+  handleCopy: (?HTMLCanvasElement, string, ?boolean) => Promise<void>,
+  handleCreateCanvas: (?HTMLCanvasElement, string) => any,
+  copied: boolean,
+}
+
+class EncryptQR extends Component<Props, State> {
+  encryptedCanvas: ?HTMLCanvasElement
+
+  componentDidMount() {
+    const { encryptedWIF } = this.props
+    this.props.handleCreateCanvas(this.encryptedCanvas, encryptedWIF)
+  }
+
+  render() {
+    return (
+      <FullHeightPanel
+        headerText="Encrypted QR Code"
+        renderInstructions={false}
+        headerContainerClassName={styles.headerIconMargin}
+        renderHeaderIcon={() => <CheckIcon />}
+        renderCloseButton={() => <CloseButton routeTo={ROUTES.SETTINGS} />}
+        renderBackButton={() => <BackButton routeTo={ROUTES.ENCRYPT} />}
+        iconColor="#F7BC33"
+      >
+        <div
+          id="encrypted-wif-qr-codes"
+          className={styles.encryptedKeyContainer}
+        >
+          <div className={styles.qrContainer}>
+            <div className={styles.qr}>
+              <label> encrypted key </label>
+              <canvas
+                ref={node => {
+                  this.encryptedCanvas = node
+                }}
+              />
+              <Button
+                className={styles.submitButton}
+                renderIcon={() =>
+                  this.props.copied ? <ConfirmIcon /> : <CopyIcon />
+                }
+                type="submit"
+                onClick={() => {
+                  this.props.handleCopy(this.encryptedCanvas, 'encrypted-wif')
+                }}
+              >
+                Copy Code Image
+              </Button>
+            </div>
+          </div>
+        </div>
+        <div className={styles.qrPrintButtonContainer}>
+          <Button renderIcon={AddIcon} primary onClick={this.handlePrint}>
+            Print
+          </Button>
+        </div>
+      </FullHeightPanel>
+    )
+  }
+
+  handlePrint = () => {
+    window.print()
+  }
+}
+
+export default withCopyCanvasToClipboard(EncryptQR)

--- a/app/components/Settings/EncryptQR/EncryptQR.scss
+++ b/app/components/Settings/EncryptQR/EncryptQR.scss
@@ -1,0 +1,43 @@
+.encryptedKeyContainer {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  flex: 1;
+}
+
+.qrContainer {
+  display: flex;
+  justify-content: space-around;
+  flex: 1;
+  margin-top: 24px;
+  width: 100%;
+
+  .qr {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  canvas {
+    min-width: 200px;
+    min-height: 200px;
+  }
+
+  button {
+    margin-top: 12px;
+  }
+
+  label {
+    font-weight: bold;
+    font-size: 12px;
+    text-transform: uppercase;
+    opacity: var(--input-label-opacity);
+    color: var(--input-label);
+    margin-bottom: 10px;
+  }
+}
+
+.qrPrintButtonContainer {
+  margin-bottom: 50px;
+  width: 490px;
+}

--- a/app/components/Settings/EncryptQR/index.js
+++ b/app/components/Settings/EncryptQR/index.js
@@ -1,0 +1,25 @@
+// @flow
+
+import { connect } from 'react-redux'
+import { compose } from 'recompose'
+// import { bindActionCreators } from 'redux'
+import { getEncryptedWIF } from '../../../modules/generateEncryptedWIF'
+
+import EncryptQR from './EncryptQR'
+
+const mapStateToProps = (state: Object) => ({
+  //  wif: getWIF(state),
+  //  address: getAddress(state),
+  encryptedWIF: getEncryptedWIF(state),
+  //  passphrase: getPassphrase(state),
+})
+
+// const mapDispatchToProps = dispatch =>
+// bindActionCreators({ ()=> {} }, dispatch)
+
+export default compose(
+  connect(
+    mapStateToProps,
+    //  mapDispatchToProps,
+  ),
+)(EncryptQR)

--- a/app/components/Settings/EncryptSuccess/EncryptSuccess.jsx
+++ b/app/components/Settings/EncryptSuccess/EncryptSuccess.jsx
@@ -1,7 +1,10 @@
 // @flow
 import React from 'react'
+import { NavLink } from 'react-router-dom'
 import { noop } from 'lodash-es'
-
+import { ROUTES } from '../../../core/constants'
+import GridIcon from '../../../assets/icons/grid.svg'
+import AddIcon from '../../../assets/icons/add.svg'
 import LockIcon from '../../../assets/icons/lock.svg'
 import CopyToClipboard from '../../CopyToClipboard'
 import Button from '../../Button'
@@ -39,6 +42,21 @@ export default class EncryptSuccess extends React.Component<Props> {
               />
             </div>
           </div>
+          <div className={styles.buttonContainer}>
+            <Button renderIcon={AddIcon} primary onClick={this.handlePrint}>
+              Print
+            </Button>
+            <NavLink
+              id="display-encrypted-wif-qr"
+              exact
+              to={ROUTES.DISPLAY_ENCRYPTED_WIF_QR}
+            >
+              <Button primary renderIcon={() => <GridIcon />} type="submit">
+                Generate QR Codes
+              </Button>
+            </NavLink>
+          </div>
+
           <Button
             className={styles.encryptResetButton}
             onClick={handleReset}
@@ -50,5 +68,9 @@ export default class EncryptSuccess extends React.Component<Props> {
         </div>
       </section>
     )
+  }
+
+  handlePrint = () => {
+    window.print()
   }
 }

--- a/app/components/Settings/EncryptSuccess/EncryptSuccess.scss
+++ b/app/components/Settings/EncryptSuccess/EncryptSuccess.scss
@@ -52,3 +52,24 @@ $encrypt-icon-size: 24px;
     }
   }
 }
+
+.buttonContainer {
+  width: 100%;
+  margin-top: auto;
+  display: flex;
+  align-items: flex-end;
+  margin-bottom: 50px;
+  flex: 1;
+  justify-content: space-between;
+
+  button {
+    width: 225px;
+  }
+
+  button:first-child {
+    margin-right: 12px;
+  }
+  button:last-child {
+    margin-right: 0;
+  }
+}

--- a/app/containers/CreateWallet/CreateWallet.jsx
+++ b/app/containers/CreateWallet/CreateWallet.jsx
@@ -31,6 +31,7 @@ type State = {
   passphraseError: string,
   passphrase2Error: string,
   wif: string,
+  encryptedWIF: String,
   walletName: string,
   submitButtonDisabled: boolean,
 }
@@ -46,6 +47,7 @@ export default class CreateWallet extends React.Component<Props, State> {
     passphraseError: '',
     passphrase2Error: '',
     wif: '',
+    encryptedWIF: '',
     walletName: '',
     submitButtonDisabled: false,
   }
@@ -54,7 +56,13 @@ export default class CreateWallet extends React.Component<Props, State> {
     this.setState({ submitButtonDisabled: true })
     e.preventDefault()
     const { history, option } = this.props
-    const { passphrase, passphrase2, wif, walletName } = this.state
+    const {
+      passphrase,
+      passphrase2,
+      wif,
+      encryptedWIF,
+      walletName,
+    } = this.state
     const { generateNewWalletAccount, authenticated } = this.props
     generateNewWalletAccount(
       passphrase,
@@ -68,7 +76,15 @@ export default class CreateWallet extends React.Component<Props, State> {
   }
 
   render = () => {
-    const { passphraseError, passphrase2Error, wif, walletName } = this.state
+    const {
+      passphraseError,
+      passphrase2Error,
+      wif,
+      walletName,
+      encryptedWIF,
+    } = this.state
+    console.log('XXXXXXXXXXXXXXXX encryptedWIF ' + encryptedWIF)
+    console.log('XXXXXXXXXXXXXXXX wif ' + wif)
     const { option, authenticated } = this.props
     const conditionalPanelProps = {}
     if (authenticated) {

--- a/app/containers/CreateWallet/CreateWallet.jsx
+++ b/app/containers/CreateWallet/CreateWallet.jsx
@@ -31,7 +31,6 @@ type State = {
   passphraseError: string,
   passphrase2Error: string,
   wif: string,
-  encryptedWIF: String,
   walletName: string,
   submitButtonDisabled: boolean,
 }
@@ -47,7 +46,6 @@ export default class CreateWallet extends React.Component<Props, State> {
     passphraseError: '',
     passphrase2Error: '',
     wif: '',
-    encryptedWIF: '',
     walletName: '',
     submitButtonDisabled: false,
   }
@@ -56,13 +54,7 @@ export default class CreateWallet extends React.Component<Props, State> {
     this.setState({ submitButtonDisabled: true })
     e.preventDefault()
     const { history, option } = this.props
-    const {
-      passphrase,
-      passphrase2,
-      wif,
-      encryptedWIF,
-      walletName,
-    } = this.state
+    const { passphrase, passphrase2, wif, walletName } = this.state
     const { generateNewWalletAccount, authenticated } = this.props
     generateNewWalletAccount(
       passphrase,
@@ -76,15 +68,7 @@ export default class CreateWallet extends React.Component<Props, State> {
   }
 
   render = () => {
-    const {
-      passphraseError,
-      passphrase2Error,
-      wif,
-      walletName,
-      encryptedWIF,
-    } = this.state
-    console.log('XXXXXXXXXXXXXXXX encryptedWIF ' + encryptedWIF)
-    console.log('XXXXXXXXXXXXXXXX wif ' + wif)
+    const { passphraseError, passphrase2Error, wif, walletName } = this.state
     const { option, authenticated } = this.props
     const conditionalPanelProps = {}
     if (authenticated) {

--- a/app/containers/DisplayWalletAccounts/DisplayWalletAccounts.jsx
+++ b/app/containers/DisplayWalletAccounts/DisplayWalletAccounts.jsx
@@ -22,6 +22,7 @@ type Props = {
   walletName: string,
   address: string,
   wif: string,
+  encryptedWIF: string,
   passphrase: string,
   isImport: boolean,
   authenticated: boolean,
@@ -33,6 +34,7 @@ class DisplayWalletAccounts extends Component<Props> {
       passphrase,
       address,
       wif,
+      encryptedWIF,
       walletName,
       isImport,
       authenticated,
@@ -44,6 +46,7 @@ class DisplayWalletAccounts extends Component<Props> {
         type: 'password',
       },
       { label: 'Private Key', value: wif, type: 'text' },
+      { label: 'Encrypted Key', value: encryptedWIF, type: 'text' },
       { label: 'Public Address', value: address, type: 'text' },
     ]
     if (walletName) {
@@ -87,7 +90,10 @@ class DisplayWalletAccounts extends Component<Props> {
               <div key={item.label} className={styles.detailRow}>
                 <div
                   className={classNames(styles.input, {
-                    [styles.reducedInputFontSize]: item.label === 'Private Key',
+                    [styles.reducedInputFontSize]: [
+                      'Private Key',
+                      'Encrypted Key',
+                    ].includes(item.label),
                   })}
                 >
                   {item.type === 'text' ? (

--- a/app/containers/DisplayWalletAccounts/DisplayWalletAccounts.scss
+++ b/app/containers/DisplayWalletAccounts/DisplayWalletAccounts.scss
@@ -4,7 +4,7 @@
   width: 100%;
   justify-content: center;
   align-items: center;
-  margin-bottom: 10px;
+  margin-bottom: 40px;
 }
 
 .detailsContainer {
@@ -12,6 +12,7 @@
   flex-direction: column;
   justify-content: center;
   flex: 1;
+  margin-top: 15px;
 }
 
 .qrContainer {
@@ -86,6 +87,7 @@
   display: flex;
   align-items: flex-end;
   margin-bottom: 50px;
+  margin-top: 25px;
   flex: 1;
   justify-content: space-between;
 
@@ -113,7 +115,7 @@
 
 .reducedInputFontSize {
   input {
-    font-size: 12px !important;
+    font-size: 11.5px !important;
   }
 }
 

--- a/app/containers/DisplayWalletAccounts/DisplayWalletAccountsQrCodes/DisplayWalletAccountsQrCodes.jsx
+++ b/app/containers/DisplayWalletAccounts/DisplayWalletAccountsQrCodes/DisplayWalletAccountsQrCodes.jsx
@@ -19,6 +19,7 @@ type Props = {
   walletName: string,
   address: string,
   wif: string,
+  encryptedWIF: string,
   passphrase: string,
   isImport: boolean,
   authenticated: boolean,
@@ -30,6 +31,7 @@ type Props = {
 type State = {
   publicCopied: boolean,
   privateCopied: boolean,
+  encryptedCopied: boolean,
 }
 
 class DisplayWalletAccountsQrCodes extends Component<Props, State> {
@@ -37,10 +39,13 @@ class DisplayWalletAccountsQrCodes extends Component<Props, State> {
 
   privateCanvas: ?HTMLCanvasElement
 
+  encryptedCanvas: ?HTMLCanvasElement
+
   componentDidMount() {
-    const { address, wif } = this.props
+    const { address, wif, encryptedWIF } = this.props
     this.props.handleCreateCanvas(this.publicCanvas, address)
     this.props.handleCreateCanvas(this.privateCanvas, wif)
+    this.props.handleCreateCanvas(this.encryptedCanvas, encryptedWIF)
   }
 
   render() {
@@ -92,6 +97,14 @@ class DisplayWalletAccountsQrCodes extends Component<Props, State> {
               <canvas
                 ref={node => {
                   this.privateCanvas = node
+                }}
+              />
+            </div>
+            <div className={styles.qr}>
+              <label> encrypted key </label>
+              <canvas
+                ref={node => {
+                  this.encryptedCanvas = node
                 }}
               />
             </div>

--- a/app/containers/Encrypt/Encrypt.jsx
+++ b/app/containers/Encrypt/Encrypt.jsx
@@ -7,25 +7,28 @@ import LockIcon from '../../assets/icons/lock.svg'
 import styles from './Encrypt.scss'
 
 type Props = {
-  encryptPrivateKey: Function,
+  generateNewEncryptedWIF: Function,
   isWIF: Function,
   validatePassphraseLength: Function,
 }
 
 export default class Encrypt extends React.Component<Props> {
   static defaultProps = {
-    encryptPrivateKey: noop,
     validatePassphraseLength: noop,
     isWIF: noop,
   }
 
   render = () => {
-    const { encryptPrivateKey, isWIF, validatePassphraseLength } = this.props
+    const {
+      generateNewEncryptedWIF,
+      isWIF,
+      validatePassphraseLength,
+    } = this.props
     return (
       <div className={styles.encrypt}>
         <EncryptPanel
           title="Encrypt Private Key"
-          handleSubmit={encryptPrivateKey}
+          handleSubmit={generateNewEncryptedWIF}
           isWIF={isWIF}
           validatePassphraseLength={validatePassphraseLength}
         />

--- a/app/containers/Encrypt/index.js
+++ b/app/containers/Encrypt/index.js
@@ -1,26 +1,27 @@
 // @flow
+
+import { connect } from 'react-redux'
+import { bindActionCreators } from 'redux'
+
 import { compose, withProps } from 'recompose'
 import { wallet } from '@cityofzion/neon-js'
 import { validatePassphraseLength } from '../../core/wallet'
-
+import { generateNewEncryptedWIF } from '../../modules/generateEncryptedWIF'
 import Encrypt from './Encrypt'
 
-const encryptPrivateKey = (privateKey, passphrase, confirmPassphrase) => {
-  if (passphrase !== confirmPassphrase) {
-    throw new Error('Passphrases do not match')
-  }
-  if (!validatePassphraseLength(passphrase)) {
-    throw new Error('Please choose a longer passphrase')
-  }
-  if (privateKey && !wallet.isWIF(privateKey)) {
-    throw new Error('The private key is not valid')
-  }
-  return wallet.encrypt(privateKey, passphrase)
+const actionCreators = {
+  generateNewEncryptedWIF,
 }
 
+const mapDispatchToProps = dispatch =>
+  bindActionCreators(actionCreators, dispatch)
+
 export default compose(
+  connect(
+    null,
+    mapDispatchToProps,
+  ),
   withProps({
-    encryptPrivateKey,
     isWIF: wallet.isWIF,
     validatePassphraseLength,
   }),

--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -52,6 +52,8 @@ export const ROUTES = {
   DISPLAY_WALLET_KEYS_AUTHENTICATED: '/display-wallet-keys-authenticated',
   DISPLAY_WALLET_QRS: '/display-wallet-qrs',
   DISPLAY_WALLET_QRS_AUTHENTICATED: '/display-wallet-qrs-authenticated',
+  DISPLAY_ENCRYPTED_WIF_QR: '/display-encrypted-wif-qr',
+  DISPLAY_ENCRYPTED_WIF: 'display-encrypted-wif',
   WALLET_MANAGER: '/wallet-manager',
   EDIT_WALLET: '/edit-wallet/:key/:label',
   SEND: '/send/',

--- a/app/modules/generateEncryptedWIF.js
+++ b/app/modules/generateEncryptedWIF.js
@@ -1,0 +1,73 @@
+// @flow
+
+import { wallet } from '@cityofzion/neon-js'
+
+import { validatePassphraseLength } from '../core/wallet'
+
+// Constants
+export const NEW_ENCRYPTED_WIF = 'NEW_ENCRYPTED_WIF'
+export const RESET_ENCRYPTED_WIF = 'RESET_ENCRYPTED_WIF'
+
+export const generateNewEncryptedWIF = (wif, passphrase, confirmPassphrase) => {
+  if (passphrase !== confirmPassphrase) {
+    throw new Error('Passphrases do not match')
+  }
+  if (!validatePassphraseLength(passphrase)) {
+    throw new Error('Please choose a longer passphrase')
+  }
+  if (wif && !wallet.isWIF(wif)) {
+    throw new Error('The private key is not valid')
+  }
+
+  const encryptedWIF = wallet.encrypt(wif, passphrase)
+  return {
+    type: NEW_ENCRYPTED_WIF,
+    payload: { encryptedWIF },
+  }
+}
+
+export function resetEncryptedWIF() {
+  return {
+    type: RESET_ENCRYPTED_WIF,
+  }
+}
+
+// state getters
+// export const getWIF = (state: Object) => state.generateEncryptedWIF.wif
+
+// export const getAddress = (state: Object) => state.generateEncryptedWIF.address
+// export const getPassphrase = (state: Object) => state.generateEncryptedWIF.passphrase
+
+export const getEncryptedWIF = (state: Object) =>
+  state.generateEncryptedWIF.encryptedWIF
+
+const initialState = {
+  encryptedWIF: null,
+}
+
+export default (state: Object = initialState, action: ReduxAction) => {
+  switch (action.type) {
+    case NEW_ENCRYPTED_WIF: {
+      const {
+        // passphrase,
+        // wif,
+        // address,
+        encryptedWIF,
+      } = action.payload
+      return {
+        ...state,
+        // wif,
+        // address,
+        // passphrase,
+        encryptedWIF,
+        // walletName,
+        // isImport,
+      }
+    }
+    case RESET_ENCRYPTED_WIF: {
+      return { ...initialState }
+    }
+    default:
+      return state
+  }
+}

--- a/app/modules/index.js
+++ b/app/modules/index.js
@@ -3,12 +3,15 @@ import { combineReducers } from 'redux'
 import { reducer as spunky } from 'spunky'
 
 import generateWallet from './generateWallet'
+import generateEncryptedWIF from './generateEncryptedWIF'
+
 import claim from './claim'
 import notifications from './notifications'
 import modal from './modal'
 
 export default combineReducers({
   spunky,
+  generateEncryptedWIF,
   generateWallet,
   claim,
   notifications,


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**

#1862

**What problem does this PR solve?**

The PR add the feature to render QR code for the encrypted key.

**How did you solve this problem?**

I followed more or less the logic for rendering the QR code for private key and public address and adapted it for the encrypted key. This logic is essentially stored in these two modules: 

- `DisplayWalletAccountsQrCodes`
- `DisplayWalletAccounts`


**How did you make sure your solution works?**

- I tested manually the rendering of the encrypted key QR for these two scenarios:
   1) `Create Wallet`
   2) `Encrypt Key` (option available in the setting section.)

- I also did run `yarn test` and all the existing tests are passing.

**Are there any special changes in the code that we should be aware of?**

Yes. We should also include the option to render encrypted key QR code after selecting the option 
`Import Wallet`

This will be done in the next PR addressing issue #1863.

**Is there anything else we should know?**

- [ ] Unit tests written?
