### PR TITLE
chore: fixes margin bug in DisplayWalletAccounts.scss

### DIFF
--- a/app/containers/DisplayWalletAccounts/DisplayWalletAccounts.scss
+++ b/app/containers/DisplayWalletAccounts/DisplayWalletAccounts.scss
@@ -83,11 +83,10 @@
 
 .buttonContainer {
   width: 100%;
-  margin-top: auto;
   display: flex;
   align-items: flex-end;
   margin-bottom: 50px;
-  margin-top: 25px;
+  margin-top: 50px;
   flex: 1;
   justify-content: space-between;
 

--- a/app/containers/DisplayWalletAccounts/DisplayWalletAccounts.scss
+++ b/app/containers/DisplayWalletAccounts/DisplayWalletAccounts.scss
@@ -48,7 +48,7 @@
 }
 
 .qrPrintButtonContainer {
-  margin-bottom: 50px;
+  margin-bottom: 40px;
   width: 490px;
 }
 
@@ -85,8 +85,8 @@
   width: 100%;
   display: flex;
   align-items: flex-end;
-  margin-bottom: 50px;
-  margin-top: 50px;
+  margin-bottom: 40px;
+  margin-top: 40px;
   flex: 1;
   justify-content: space-between;
 


### PR DESCRIPTION
Fixes a minor CSS bug in the `DisplayWalletAccounts.jsx` component. Related PR can be found here https://github.com/CityOfZion/neon-wallet/pull/1873

BEFORE:
<img width="622" alt="Screen Shot 2019-06-25 at 9 34 46 PM" src="https://user-images.githubusercontent.com/13072035/60144641-2f3ba180-9791-11e9-9a03-cd58baaaa394.png">

AFTER:
<img width="626" alt="Screen Shot 2019-06-25 at 9 32 46 PM" src="https://user-images.githubusercontent.com/13072035/60144625-23e87600-9791-11e9-82c3-d056f025fe25.png">

