### PR TITLE
Ability to submit a feature request / issue report from Neon

### DIFF
--- a/app/components/Modals/GitHubIssueModal/GitHubIssue.scss
+++ b/app/components/Modals/GitHubIssueModal/GitHubIssue.scss
@@ -1,0 +1,11 @@
+.newsPanel {
+  height: 100%;
+}
+
+.IssueContainer {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: center;
+}

--- a/app/components/Modals/GitHubIssueModal/GitHubIssueModal.jsx
+++ b/app/components/Modals/GitHubIssueModal/GitHubIssueModal.jsx
@@ -1,0 +1,88 @@
+// @flow
+import React from 'react'
+import BaseModal from '../BaseModal'
+import styles from './GitHubIssue.scss'
+import Panel from '../../Panel'
+import {
+  GITHUB_ISSUE_LINK,
+  AWESOME_NEO_LINK,
+  REDDIT_NEO_LINK,
+  DISCORD_INVITE_LINK,
+} from '../../../core/constants'
+
+const { shell } = require('electron').remote
+
+type Props = {
+  hideModal: () => any,
+}
+
+export default class GitHubIssueModal extends React.Component<Props> {
+  render() {
+    const { hideModal } = this.props
+    return (
+      <BaseModal
+        title="Manage Tokens"
+        hideModal={hideModal}
+        style={{
+          content: {
+            width: '550px',
+            height: '550px',
+          },
+        }}
+      >
+        <div className={styles.IssueContainer}>
+          <Panel className={styles.newsPanel}>
+            <h3>Support</h3> A gentle reminder, github issues are meant to be
+            used by developers for maintaining and improving the codebase, and
+            is not the proper location for support issues. Questions such as
+            <ul>
+              <li>
+                <em>"Why can't I log in?" </em>
+              </li>
+              <li>
+                <em>"I lost my private key, is there anyway to recover it?"</em>
+              </li>
+              <li>
+                <em> "Why is my balance not showing?"</em>
+              </li>
+            </ul>
+            should be asked in proper support channels such as the
+            <a
+              onClick={() => shell.openExternal(REDDIT_NEO_LINK)}
+              title={REDDIT_NEO_LINK}
+            >
+              {' '}
+              NEO subreddit
+            </a>
+            , or the official{' '}
+            <a
+              onClick={() => shell.openExternal(DISCORD_INVITE_LINK)}
+              title={DISCORD_INVITE_LINK}
+            >
+              {' '}
+              NEO Discord Channel.{' '}
+            </a>
+            You should also check the list of{' '}
+            <a
+              onClick={() => shell.openExternal(AWESOME_NEO_LINK)}
+              title={AWESOME_NEO_LINK}
+            >
+              {' '}
+              frequently asked questions (FAQ)
+            </a>{' '}
+            to see if your question has been answered there already.
+            <h3>Feature Request / Bug Report</h3>
+            Thank you for submitting a Github issue here:
+            <a
+              onClick={() => shell.openExternal(GITHUB_ISSUE_LINK)}
+              title={GITHUB_ISSUE_LINK}
+            >
+              {' '}
+              link.
+            </a>
+          </Panel>
+        </div>
+      </BaseModal>
+    )
+  }
+}

--- a/app/components/Modals/GitHubIssueModal/GitHubIssueModal.jsx
+++ b/app/components/Modals/GitHubIssueModal/GitHubIssueModal.jsx
@@ -10,14 +10,13 @@ import {
   DISCORD_INVITE_LINK,
 } from '../../../core/constants'
 
-const { shell } = require('electron').remote
-
 type Props = {
   hideModal: () => any,
 }
 
 export default class GitHubIssueModal extends React.Component<Props> {
   render() {
+    const { shell } = require('electron').remote
     const { hideModal } = this.props
     return (
       <BaseModal

--- a/app/components/Modals/GitHubIssueModal/index.jsx
+++ b/app/components/Modals/GitHubIssueModal/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './GitHubIssueModal'

--- a/app/containers/ModalRenderer/ModalRenderer.jsx
+++ b/app/containers/ModalRenderer/ModalRenderer.jsx
@@ -10,6 +10,7 @@ import ReceiveModal from '../../components/Modals/ReceiveModal'
 import SendModal from '../../components/Modals/SendModal'
 import GeneratedTransactionModal from '../../components/Modals/GeneratedTransactionModal'
 import ImportTransactionModal from '../../components/Modals/ImportTransactionModal'
+import GitHubIssueModal from '../../components/Modals/GitHubIssueModal'
 
 import { MODAL_TYPES } from '../../core/constants'
 
@@ -22,6 +23,7 @@ const {
   RECEIVE,
   GENERATED_TRANSACTION,
   IMPORT_TRANSACTION,
+  GITHUB_ISSUE,
 } = MODAL_TYPES
 
 const MODAL_COMPONENTS = {
@@ -33,6 +35,7 @@ const MODAL_COMPONENTS = {
   [SEND]: SendModal,
   [GENERATED_TRANSACTION]: GeneratedTransactionModal,
   [IMPORT_TRANSACTION]: ImportTransactionModal,
+  [GITHUB_ISSUE]: GitHubIssueModal,
 }
 
 type Props = {

--- a/app/containers/Settings/Settings.jsx
+++ b/app/containers/Settings/Settings.jsx
@@ -20,7 +20,6 @@ import {
   ROUTES,
   MODAL_TYPES,
   COZ_DONATIONS_ADDRESS,
-  DISCORD_INVITE_LINK,
   THEMES,
 } from '../../core/constants'
 import styles from './Settings.scss'
@@ -36,7 +35,7 @@ import TimeIcon from '../../assets/icons/time-icon.svg'
 import SaveIcon from '../../assets/icons/save-icon.svg'
 import pack from '../../../package.json'
 
-const { dialog, shell } = require('electron').remote
+const { dialog } = require('electron').remote
 
 type Props = {
   setAccounts: (Array<Object>) => any,
@@ -96,7 +95,6 @@ export const loadWalletRecovery = (
     })
   })
 }
-
 export default class Settings extends Component<Props, State> {
   static defaultProps = {
     explorer: DEFAULT_EXPLORER,
@@ -191,13 +189,16 @@ export default class Settings extends Component<Props, State> {
     this.props.showModal(MODAL_TYPES.TOKEN)
   }
 
+  openGitHubIssueModal = () => {
+    this.props.showModal(MODAL_TYPES.GITHUB_ISSUE)
+  }
+
   render() {
     const {
       showSuccessNotification,
       showErrorNotification,
       setAccounts,
     } = this.props
-
     const parsedCurrencyOptions = Object.keys(CURRENCIES).map(key => ({
       value: key,
       label: key.toUpperCase(),
@@ -354,16 +355,13 @@ export default class Settings extends Component<Props, State> {
     </div>
   )
 
-  openDiscordLink = () => shell.openExternal(DISCORD_INVITE_LINK)
-
   renderHeader = () => (
     <div className={styles.settingsPanelHeader}>
       <div className={styles.settingsPanelHeaderItem}>
         Manage your neon wallet - v{pack.version}
       </div>
       <div className={styles.settingsPanelHeaderItem}>
-        Community Support:{' '}
-        <a onClick={this.openDiscordLink}>{DISCORD_INVITE_LINK}</a>
+        <a onClick={this.openGitHubIssueModal}>Need Help?</a>
       </div>
     </div>
   )

--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -6,6 +6,13 @@ import nodesTestNet from './nodes-test-net.json'
 export const NEON_WALLET_RELEASE_LINK =
   'https://github.com/CityOfZion/neon-wallet/releases'
 
+export const GITHUB_ISSUE_LINK =
+  'https://github.com/CityOfZion/neon-wallet/issues/new'
+
+export const AWESOME_NEO_LINK =
+  'https://github.com/CityOfZion/awesome-NEO/blob/master/resources/faq.md'
+
+export const REDDIT_NEO_LINK = 'https://www.reddit.com/r/NEO/'
 export const DISCORD_INVITE_LINK = 'https://discordapp.com/invite/R8v48YA'
 export const COZ_DONATIONS_ADDRESS = 'Adr3XjZ5QDzVJrWvzmsTTchpLRRGSzgS5A'
 
@@ -92,6 +99,7 @@ export const MODAL_TYPES = {
   RECEIVE: 'RECEIVE',
   GENERATED_TRANSACTION: 'GENERATED_TRANSACTION',
   IMPORT_TRANSACTION: 'IMPORT_TRANSACTION',
+  GITHUB_ISSUE: 'GITHUB_ISSUE',
 }
 
 export const TX_TYPES = {


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**

#1825 

**What problem does this PR solve?**

This PR provide users the option to open a feature request or to report a bug from Neon.

**How did you solve this problem?**

I have added a new modal component (GitHubIssueModal.jsx) which will be displayed when one clicks the `Need Help?` link. This component contains all the necessary information to get support and to open a new github issue. 

**How did you make sure your solution works?**

Manually tested the feature.

**Are there any special changes in the code that we should be aware of?**

Yes. The links provided in the github modal component (GitHubIssueModal.jsx) will not open the web pages immediately. The users will need to be patient and wait few seconds.

**Is there anything else we should know?**

- [ ] Unit tests written?
