### PR TITLE
feature: only render 'generate transaction JSON' button in watch only mode

### DIFF
--- a/app/components/Send/SendPanel/index.jsx
+++ b/app/components/Send/SendPanel/index.jsx
@@ -110,17 +110,18 @@ const SendPanel = ({
           disabled={shouldDisableSendButton(sendRowDetails)}
         />
       </div>
-      <Button
-        className={styles.generateTransactionButton}
-        renderIcon={() => <EditIcon />}
-        type="submit"
-        disabled={shouldDisableSendButton(sendRowDetails)}
-        onClick={() => handleSubmit(true)}
-        id="generate-transaction-json"
-      >
-        Generate Transaction JSON
-      </Button>
-      {!isWatchOnly && (
+      {isWatchOnly ? (
+        <Button
+          className={styles.generateTransactionButton}
+          renderIcon={() => <EditIcon />}
+          type="submit"
+          disabled={shouldDisableSendButton(sendRowDetails)}
+          onClick={() => handleSubmit(true)}
+          id="generate-transaction-json"
+        >
+          Generate Transaction JSON
+        </Button>
+      ) : (
         <Button
           primary
           className={styles.sendFormButton}


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
N/A

**What problem does this PR solve?**
To avoid confusion with our users we only present the button to generate a transaction for offline signing when the user is logged in via watch only mode

**How did you solve this problem?**
With a simple ternary in the JSX that was basically already there

**How did you make sure your solution works?**
Manual testing

**Are there any special changes in the code that we should be aware of?**

**Is there anything else we should know?**

- [ ] Unit tests written?
