### PR TITLE
Add configurable price exception handling of token symbol

### DIFF
--- a/app/actions/pricesActions.js
+++ b/app/actions/pricesActions.js
@@ -5,20 +5,22 @@ import { get, map } from 'lodash-es'
 
 import { getDefaultTokens } from '../core/nep5'
 import { getSettings } from './settingsActions'
-import { ASSETS, TOKENS } from '../core/constants'
+import { ASSETS } from '../core/constants'
 
-export const PRICE_API_SYMBOL_EXCEPTIONS = (() => {
+const getPriceApiSymbolExceptions = (tokens: Array<TokenItemType>) => {
   const directMap = {}
   const reverseMap = {}
 
-  map(TOKENS, token => {
+  map(tokens, token => {
     if (token.symbol !== undefined && token.cryptocompareSymbol !== undefined) {
       directMap[token.symbol] = token.cryptocompareSymbol
+      // $FlowFixMe
       reverseMap[token.cryptocompareSymbol] = token.symbol
     }
   })
+
   return { direct: directMap, reverse: reverseMap }
-})()
+}
 
 function mapPrices(pricingData: Array<any>, currency) {
   const upperCasedCurrency = currency.toUpperCase()
@@ -52,6 +54,8 @@ const apiCallWrapper = async (url, currency) => {
 async function getPrices() {
   try {
     const tokens = await getDefaultTokens()
+    const PRICE_API_SYMBOL_EXCEPTIONS = getPriceApiSymbolExceptions(tokens)
+
     const settings = await getSettings()
     const { currency } = settings
     const joinedTokens = tokens

--- a/app/actions/pricesActions.js
+++ b/app/actions/pricesActions.js
@@ -55,15 +55,11 @@ async function getPrices() {
     const settings = await getSettings()
     const { currency } = settings
     const joinedTokens = tokens
-      .map((token: TokenItemType) => {
+      .map((token: TokenItemType) =>
         // We pass to the cryptocompare api the token cryptocompareSymbol
         // if they are available. Otherwise we pass the token symbol.
-        return get(
-          PRICE_API_SYMBOL_EXCEPTIONS.direct,
-          token.symbol,
-          token.symbol,
-        )
-      })
+        get(PRICE_API_SYMBOL_EXCEPTIONS.direct, token.symbol, token.symbol),
+      )
       .concat([ASSETS.NEO, ASSETS.GAS])
       .join(',')
 

--- a/app/actions/pricesActions.js
+++ b/app/actions/pricesActions.js
@@ -1,19 +1,28 @@
 // @flow
 import axios from 'axios'
 import { createActions } from 'spunky'
-import { get } from 'lodash-es'
+import { get, map } from 'lodash-es'
 
 import { getDefaultTokens } from '../core/nep5'
 import { getSettings } from './settingsActions'
-import { ASSETS } from '../core/constants'
+import { ASSETS, TOKENS } from '../core/constants'
 
-const PRICE_API_SYMBOL_EXCEPTIONS = {
-  SOUL: 'SOUL*',
-}
+export const PRICE_API_SYMBOL_EXCEPTIONS = (() => {
+  const directMap = {}
+  const reverseMap = {}
+
+  map(TOKENS, token => {
+    if (token.symbol !== undefined && token.cryptocompareSymbol !== undefined) {
+      directMap[token.symbol] = token.cryptocompareSymbol
+      reverseMap[token.cryptocompareSymbol] = token.symbol
+    }
+  })
+  return { direct: directMap, reverse: reverseMap }
+})()
 
 function mapPrices(pricingData: Array<any>, currency) {
   const upperCasedCurrency = currency.toUpperCase()
-  return pricingData.reduce(
+  const prices = pricingData.reduce(
     (accum: Object, price: { currency: { upperCasedCurrency: Object } }) => {
       const priceInSelectedCurrency = price[upperCasedCurrency]
       if (price && priceInSelectedCurrency) {
@@ -26,6 +35,18 @@ function mapPrices(pricingData: Array<any>, currency) {
     },
     {},
   )
+
+  return prices
+}
+
+const apiCall = async url => {
+  const priceDataResponse = await axios.get(url)
+  return Object.values(priceDataResponse.data.RAW)
+}
+
+const apiCallWrapper = async (url, currency) => {
+  const pricingArray = await apiCall(url)
+  return mapPrices(pricingArray, currency)
 }
 
 async function getPrices() {
@@ -34,17 +55,42 @@ async function getPrices() {
     const settings = await getSettings()
     const { currency } = settings
     const joinedTokens = tokens
-      .map((token: TokenItemType) =>
-        get(PRICE_API_SYMBOL_EXCEPTIONS, token.symbol, token.symbol),
-      )
+      .map((token: TokenItemType) => {
+        // We pass to the cryptocompare api the token cryptocompareSymbol
+        // if they are available. Otherwise we pass the token symbol.
+        return get(
+          PRICE_API_SYMBOL_EXCEPTIONS.direct,
+          token.symbol,
+          token.symbol,
+        )
+      })
       .concat([ASSETS.NEO, ASSETS.GAS])
       .join(',')
 
     const url = `https://min-api.cryptocompare.com/data/pricemultifull?fsyms=${joinedTokens}&tsyms=${currency.toUpperCase()}`
+    const prices = await apiCallWrapper(url, currency)
 
-    const priceDataResponse = await axios.get(url)
-    const pricingArray = Object.values(priceDataResponse.data.RAW)
-    return mapPrices(pricingArray, currency)
+    // We need to perform a second api call because there may be token that have price listed only in relationship to NEO.
+    // As of now, (27.07.2019), for instance NEX price can't be retrieve via the first api call above.
+    // Therefore we need a second api call with currency NEO.
+    const url2 = `https://min-api.cryptocompare.com/data/pricemultifull?fsyms=${joinedTokens}&tsyms=NEO`
+    const neoPrices = await apiCallWrapper(url2, 'NEO')
+
+    // Build final prices map
+    Object.entries(neoPrices).forEach(([key, value]) => {
+      if (!(key in prices)) {
+        prices[key] = parseFloat(value) * prices.NEO
+      }
+    })
+
+    // Adjust price map keys: within the app we use the token symbol to retrieve the price.
+    // Therefore we need to replace the token cryptocompareSimbol key with the corrisponding token
+    // Symbol.
+    Object.entries(prices).forEach(([key, value]) => {
+      prices[get(PRICE_API_SYMBOL_EXCEPTIONS.reverse, key, key)] = value
+    })
+
+    return prices
   } catch (error) {
     console.error('An error occurred getting price data', { error })
     return {}

--- a/app/core/nep5.js
+++ b/app/core/nep5.js
@@ -47,7 +47,6 @@ const getTokenEntry = ((): Function => {
 export const getDefaultTokens = async (): Promise<Array<TokenItemType>> => {
   const tokens = []
   // Prevent duplicate requests here
-
   if (!fetchedTokens) {
     const response = await axios
       // use a time stamp query param to prevent caching

--- a/app/core/nep5.js
+++ b/app/core/nep5.js
@@ -25,6 +25,7 @@ const getTokenEntry = ((): Function => {
 
   return (
     symbol: string,
+    cryptocompareSymbol: string,
     scriptHash: string,
     networkId: string,
     name: string,
@@ -33,6 +34,7 @@ const getTokenEntry = ((): Function => {
   ) => ({
     id: `${id++}`, // eslint-disable-line no-plusplus
     symbol,
+    cryptocompareSymbol,
     scriptHash,
     networkId,
     isUserGenerated: false,
@@ -45,6 +47,7 @@ const getTokenEntry = ((): Function => {
 export const getDefaultTokens = async (): Promise<Array<TokenItemType>> => {
   const tokens = []
   // Prevent duplicate requests here
+
   if (!fetchedTokens) {
     const response = await axios
       // use a time stamp query param to prevent caching
@@ -67,6 +70,7 @@ export const getDefaultTokens = async (): Promise<Array<TokenItemType>> => {
     ...map(fetchedTokens, tokenData =>
       getTokenEntry(
         tokenData.symbol,
+        tokenData.cryptocompareSymbol,
         tokenData.networks['1'].hash,
         MAIN_NETWORK_ID,
         tokenData.networks['1'].name,
@@ -75,9 +79,10 @@ export const getDefaultTokens = async (): Promise<Array<TokenItemType>> => {
       ),
     ),
   )
+
   tokens.push(
     ...map(TOKENS_TEST, (scriptHash, symbol) =>
-      getTokenEntry(symbol, scriptHash, TEST_NETWORK_ID),
+      getTokenEntry(symbol, undefined, scriptHash, TEST_NETWORK_ID),
     ),
   )
 

--- a/app/core/tokenList.json
+++ b/app/core/tokenList.json
@@ -68,6 +68,7 @@
   },
   "AVA": {
     "symbol": "AVA",
+    "cryptocompareSymbol": "AVALA",
     "companyName": "Travala",
     "type": "NEP5",
     "networks": {
@@ -440,7 +441,8 @@
         "totalSupply": 1
       }
     },
-    "image": "https://rawgit.com/CityOfZion/neo-tokens/master/assets/svg/nnn.svg"
+    "image":
+      "https://rawgit.com/CityOfZion/neo-tokens/master/assets/svg/nnn.svg"
   },
   "NOS": {
     "symbol": "NOS",
@@ -692,6 +694,7 @@
   },
   "SOUL": {
     "symbol": "SOUL",
+    "cryptocompareSymbol": "SOUL*",
     "companyName": "Phantasma",
     "type": "NEP5",
     "networks": {

--- a/flow-typed/declarations.js
+++ b/flow-typed/declarations.js
@@ -125,6 +125,7 @@ declare type TokenItemType = {
   networkId: string,
   isUserGenerated: boolean,
   symbol?: string,
+  cryptocompareSymbol?: string, 
   totalSupply?: number,
   decimals?: number,
   image?: ?string,


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**

#1889 

**What problem does this PR solve?**

Often the token symbol in `tokenList.json` does not match the [cryptocompare](https://www.cryptocompare.com/) api symbol. For these exceptions, the api does not deliver any price for the token. With this PR we make the exception handling of such cases configurable (as suggested by @hal0x2328 ). For instance to fix the token `simbol AVA` going forward, we simply add the corresponding `cryptocompareSymbol  AVALA` in the `tokenList.json`.


**How did you solve this problem?**

Adjusted the code to consume the new cryptocompareSymbol key in the `tokenList.json`.

**How did you make sure your solution works?**

manual testing:

![image](https://user-images.githubusercontent.com/30392990/61998321-8db8b000-b0ae-11e9-8e71-8d380eaf5a19.png)

**Are there any special changes in the code that we should be aware of?**

Yes. Currently the neon-wallet application is pulling first the `tokenList.json` from a different repository, (https://github.com/CityOfZion/neo-tokens), and not from the [local `tokenList.json`](https://github.com/CityOfZion/neon-wallet/blob/dev/app/core/tokenList.json). If the retrieval of the token list from the above repository failed the neon-wallet application will use the local token list.

So, If we accept and merge this PR into dev, we need to make sure to create a PR in https://github.com/CityOfZion/neo-tokens and add the exception handling of `AVA` and `SOUL` as we done in our local `tokenList.json`.

**Is there anything else we should know?**

- [ ] Unit tests written?
