### PR TITLE
Fix sending transaction from an account with balance more than 15 significant digits.

### DIFF
--- a/__tests__/core/wallet.test.js
+++ b/__tests__/core/wallet.test.js
@@ -1,0 +1,14 @@
+import { validateTransactionBeforeSending } from '../../app/core/wallet'
+
+describe('validateTransactionBeforeSending tests', () => {
+  test('balance of type number and with more than 15 significant digts', () => {
+    const sendEntry = {
+      address: 'APuTTqoxaLvRPTvRSYAtnkF851AWW7kBMZ',
+      amount: '100000000.00000001',
+      symbol: 'OBT',
+    }
+    expect(
+      validateTransactionBeforeSending(100000000.00000001, sendEntry),
+    ).toEqual(null)
+  })
+})

--- a/app/core/wallet.js
+++ b/app/core/wallet.js
@@ -70,7 +70,7 @@ export const validateTransactionBeforeSending = (
     return 'You cannot send fractional amounts of NEO.'
   }
 
-  if (toBigNumber(amount).gt(balance)) {
+  if (toBigNumber(amount).gt(toBigNumber(balance))) {
     return `You do not have enough ${symbol} to send.`
   }
 


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**

#1899

**What problem does this PR solve?**

When sending a transaction from an account with balance more than 15 significant digits, neon-wallet is unable to process the transaction because the balance can't be used as input to create a `bignumber` object. This is a limitation of the package bignumber.js version 5.0.0.

**How did you solve this problem?** 

We did a workaround and used an alredy existing method, `toBigNumber`, to generate a bignumber object from an input whose type is a number and with more 15 significant digits.

**How did you make sure your solution works?**

Tested manually :
https://neoscan-testnet.io/transaction/e0d08eda33891e16700819a62ae83a04aa73a5bdd4daa24fa05ad2b1ee26f7b4
![image](https://user-images.githubusercontent.com/30392990/62417500-9cc0d480-b651-11e9-81cd-6eb00aa66151.png)



**Are there any special changes in the code that we should be aware of?**

**Is there anything else we should know?**

- [X] Unit tests written?
