### PR TITLE
feature: simplify token balances panel

### DIFF
--- a/app/components/Dashboard/TokenBalancesPanel/TokenBalancesPanel.jsx
+++ b/app/components/Dashboard/TokenBalancesPanel/TokenBalancesPanel.jsx
@@ -118,9 +118,6 @@ export default class TokenBalancesPanel extends React.Component<Props> {
       <div className={styles.tokenBalancesPanelContent}>
         <div className={styles.gridContainer}>
           <div className={classNames(styles.columnCell, styles.symbol)}>
-            Ticker
-          </div>
-          <div className={classNames(styles.columnCell, styles.name)}>
             Token
           </div>
           <div className={classNames(styles.columnCell, styles.priceLabel)}>
@@ -142,9 +139,6 @@ export default class TokenBalancesPanel extends React.Component<Props> {
                   </div>
                 )}
                 {token.symbol}
-              </span>
-              <span className={classNames(styles.rowCell, styles.tokenName)}>
-                {token.name}
               </span>
               <span className={classNames(styles.rowCell, styles.price)}>
                 {this.formatPrice(token.symbol)}

--- a/app/components/Dashboard/TokenBalancesPanel/TokenBalancesPanel.scss
+++ b/app/components/Dashboard/TokenBalancesPanel/TokenBalancesPanel.scss
@@ -21,7 +21,7 @@ a {
 
   .gridContainer {
     display: grid;
-    grid-template-columns: minmax(75px, 75px) 2fr 3fr 3fr;
+    grid-template-columns: minmax(75px, 75px) 2fr 3fr;
 
     .columnCell {
       padding-top: 12px;

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "classnames": "2.2.5",
     "cleave.js": "1.0.7",
     "compare-versions": "3.1.0",
-    "coveralls": "3.0.2",
+    "coveralls": "3.0.6",
     "electron-context-menu": "0.9.1",
     "electron-json-storage": "4.1.0",
     "electron-save-file": "1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3534,16 +3534,17 @@ cosmiconfig@^5.0.5:
     js-yaml "^3.9.0"
     parse-json "^4.0.0"
 
-coveralls@3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.0.2.tgz#f5a0bcd90ca4e64e088b710fa8dda640aea4884f"
+coveralls@3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.0.6.tgz#5c63b2759b6781118e7439bd870ba5e9ee428b25"
+  integrity sha512-Pgh4v3gCI4T/9VijVrm8Ym5v0OgjvGLKj3zTUwkvsCiwqae/p6VLzpsFNjQS2i6ewV7ef+DjFJ5TSKxYt/mCrA==
   dependencies:
     growl "~> 1.10.0"
-    js-yaml "^3.11.0"
+    js-yaml "^3.13.1"
     lcov-parse "^0.0.10"
     log-driver "^1.2.7"
     minimist "^1.2.0"
-    request "^2.85.0"
+    request "^2.86.0"
 
 crc32-stream@^2.0.0:
   version "2.0.0"
@@ -7434,7 +7435,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
 
-js-yaml@^3.11.0, js-yaml@^3.12.0, js-yaml@^3.13.1, js-yaml@^3.7.0, js-yaml@^3.8.2, js-yaml@^3.9.0, js-yaml@^3.9.1, js-yaml@~3.7.0:
+js-yaml@^3.12.0, js-yaml@^3.13.1, js-yaml@^3.7.0, js-yaml@^3.8.2, js-yaml@^3.9.0, js-yaml@^3.9.1, js-yaml@~3.7.0:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -10715,9 +10716,10 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@^2.45.0, request@^2.79.0, request@^2.81.0, request@^2.83.0, request@^2.85.0, request@^2.87.0:
+request@^2.45.0, request@^2.79.0, request@^2.81.0, request@^2.83.0, request@^2.86.0, request@^2.87.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
+  integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.8.0"


### PR DESCRIPTION
This PR updates the 'Token Balances' panel on the dashboard so that the name column (`token.name` from the neo-tokens repo) is removed and we simply refer to symbol. It also updates the column header from 'Ticker' to 'Token'. Thank you @dauTT for the recommendation

<img width="1157" alt="Screen Shot 2019-08-13 at 12 33 50 PM" src="https://user-images.githubusercontent.com/13072035/62967762-e3879a80-bdc6-11e9-8c2c-d00f614442a7.png">
