### PR TITLE
Fix gas claim bug in Watch mode

### DIFF
--- a/app/containers/Claim/Claim.jsx
+++ b/app/containers/Claim/Claim.jsx
@@ -12,23 +12,20 @@ type Props = {
   doGasClaim: Function,
   disableClaimButton: boolean,
   claimAmount: string,
+  isWatchOnly?: boolean,
 }
 
 export default class Claim extends Component<Props> {
   intervalId: ?number
 
   render() {
-    const { className, claimAmount } = this.props
+    const { className, claimAmount, isWatchOnly } = this.props
     const disabled = this.isDisabled()
 
     return (
       <div>
         <Tooltip
-          title={
-            toBigNumber(claimAmount).eq(0)
-              ? 'Address must hold NEO in order to claim GAS'
-              : 'You can claim GAS once every 5 minutes'
-          }
+          title={this.tooltipText(isWatchOnly, claimAmount)}
           disabled={!disabled}
         >
           <Button
@@ -37,7 +34,7 @@ export default class Claim extends Component<Props> {
             disabled={disabled}
             primary
             renderIcon={ClaimIcon}
-            onClick={this.handleClaim}
+            onClick={isWatchOnly ? () => {} : this.handleClaim}
           >
             Claim {this.getFormattedAmount()} GAS
           </Button>
@@ -56,4 +53,12 @@ export default class Claim extends Component<Props> {
   }
 
   getFormattedAmount = () => formatGAS(this.props.claimAmount)
+
+  tooltipText = (isWatchOnly?: boolean, claimAmount: string): string => {
+    if (isWatchOnly) return 'Gas claims are unavailable in Watch mode'
+
+    return toBigNumber(claimAmount).eq(0)
+      ? 'Address must hold NEO in order to claim GAS'
+      : 'You can claim GAS once every 5 minutes'
+  }
 }

--- a/app/containers/Claim/index.js
+++ b/app/containers/Claim/index.js
@@ -7,6 +7,7 @@ import { withData } from 'spunky'
 import Claim from './Claim'
 import claimsActions from '../../actions/claimsActions'
 import { doGasClaim, getDisableClaimButton } from '../../modules/claim'
+import withAuthData from '../../hocs/withAuthData'
 
 const mapStateToProps = (state: Object) => ({
   disableClaimButton: getDisableClaimButton(state),
@@ -24,5 +25,6 @@ export default compose(
     mapStateToProps,
     mapDispatchToProps,
   ),
+  withAuthData(),
   withData(claimsActions, mapClaimsDataToProps),
 )(Claim)


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**

#1903 

**What problem does this PR solve?**

Neon wallet user is able to click on the claim gas button in Watch mode login and this is not good as this feature is supposed to be applicable only to the user who owns the private key.

**How did you solve this problem?**
1) Disable the option to claim gas in Watch mode.
2) Provide an appropriate tooltip text to the user to inform him about point 1).

![Screencast-from-21 08 2019-00_20_06](https://user-images.githubusercontent.com/30392990/63389786-23451800-c3ad-11e9-9d6d-746b5bc7748c.gif)

**How did you make sure your solution works?**

tested the code manually under Watch mode and Normal scenario. In the Normal scenario, I own the private key and I was able to claim gas. In the Watch Mode scenario, the claim button is disabled and a tooltip warning appeared informing the user of this fact.

**Are there any special changes in the code that we should be aware of?**

**Is there anything else we should know?**

- [ ] Unit tests written?
