### PR TITLE
feature: adds block height data to Sidebar component

### DIFF
--- a/__tests__/actions/blockHeightActions.test.js
+++ b/__tests__/actions/blockHeightActions.test.js
@@ -1,23 +1,10 @@
-/* eslint-disable */
-import { api } from '@cityofzion/neon-js'
+import { rpc } from '@cityofzion/neon-js'
 
 import blockHeightActions from '../../app/actions/blockHeightActions'
 import { TEST_NETWORK_ID } from '../../app/core/constants'
 import { mockPromiseResolved } from '../testHelpers'
 
-const apiClone = Object.assign({}, api.neoscan)
-
 describe('blockHeightActions', () => {
-  beforeEach(() => {
-    jest
-      .spyOn(apiClone, 'getWalletDBHeight')
-      .mockImplementation(mockPromiseResolved(586435))
-  })
-
-  afterEach(() => {
-    jest.restoreAllMocks()
-  })
-
   describe('call', () => {
     test('returns an action object', () => {
       expect(blockHeightActions.call({ networkId: TEST_NETWORK_ID })).toEqual({
@@ -33,12 +20,11 @@ describe('blockHeightActions', () => {
       })
     })
 
-    // TODO: FIX ME!!!!
-    // test("payload function requests the network's block height", async done => {
-    //   const call = blockHeightActions.call({ networkId: TEST_NETWORK_ID })
-    //   expect(await call.payload.fn({})).toEqual(586435)
-    //   done()
-    // })
+    test("payload function requests the network's block height", async done => {
+      const call = blockHeightActions.call({ networkId: TEST_NETWORK_ID })
+      expect(await call.payload.fn({})).toBeGreaterThan(586435)
+      done()
+    })
   })
 
   describe('cancel', () => {

--- a/__tests__/actions/blockHeightActions.test.js
+++ b/__tests__/actions/blockHeightActions.test.js
@@ -1,10 +1,23 @@
 import { rpc } from '@cityofzion/neon-js'
 
-import blockHeightActions from '../../app/actions/blockHeightActions'
+import main, {
+  blockHeightActions,
+  getBlockHeight,
+} from '../../app/actions/blockHeightActions'
 import { TEST_NETWORK_ID } from '../../app/core/constants'
 import { mockPromiseResolved } from '../testHelpers'
 
 describe('blockHeightActions', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(main, 'getBlockHeight')
+      .mockImplementation(mockPromiseResolved(36))
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
   describe('call', () => {
     test('returns an action object', () => {
       expect(blockHeightActions.call({ networkId: TEST_NETWORK_ID })).toEqual({
@@ -21,8 +34,10 @@ describe('blockHeightActions', () => {
     })
 
     test("payload function requests the network's block height", async done => {
-      const call = blockHeightActions.call({ networkId: TEST_NETWORK_ID })
-      expect(await call.payload.fn({})).toBeGreaterThan(586435)
+      const spy = jest.spyOn(main, 'getBlockHeight')
+      const call = await blockHeightActions.call({ networkId: TEST_NETWORK_ID })
+      expect(await call.payload.fn({})).toEqual(36)
+      expect(spy).toHaveBeenCalledTimes(1)
       done()
     })
   })

--- a/__tests__/components/Sidebar.test.js
+++ b/__tests__/components/Sidebar.test.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import { shallow, mount } from 'enzyme'
+import { createStore, provideStore, provideState } from '../testHelpers'
+
+import Sidebar from '../../app/containers/App/Sidebar/Sidebar'
+
+const initialState = {}
+const store = createStore(initialState)
+const wrapper = shallow(<Sidebar count={200} />)
+
+describe('Sidebar', () => {
+  test('renders without crashing', () => {
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  test('renders block height when count prop present', () => {
+    console.log({ wrapper: wrapper.debug() })
+    const height = wrapper.find('#block-height')
+    expect(height.text()).toEqual('200')
+  })
+})

--- a/__tests__/components/Sidebar.test.js
+++ b/__tests__/components/Sidebar.test.js
@@ -1,20 +1,111 @@
 import React from 'react'
+import configureStore from 'redux-mock-store'
+import { Provider } from 'react-redux'
 import { shallow, mount } from 'enzyme'
+import thunk from 'redux-thunk'
+import { progressValues } from 'spunky'
+import { MemoryRouter } from 'react-router-dom'
+import { cloneDeep } from 'lodash-es'
+
 import { createStore, provideStore, provideState } from '../testHelpers'
+import Sidebar from '../../app/containers/App/Sidebar'
+import { THEMES } from '../../app/core/constants'
+import LightLogoWithoutText from '../../../assets/images/logo-without-text-black.png'
+import DarkLogoWithoutText from '../../../assets/images/logo-without-text.png'
 
-import Sidebar from '../../app/containers/App/Sidebar/Sidebar'
+const { LOADED, LOADING } = progressValues
 
-const initialState = {}
-const store = createStore(initialState)
-const wrapper = shallow(<Sidebar count={200} />)
+const initialState = {
+  spunky: {
+    auth: {
+      batch: false,
+      progress: LOADED,
+      loadedCount: 1,
+      data: {
+        isWatchOnly: false,
+      },
+    },
+    blockHeight: {
+      batch: false,
+      progress: LOADED,
+      loadedCount: 1,
+      data: 300,
+    },
+    settings: {
+      batch: false,
+      progress: LOADED,
+      loadedCount: 1,
+      data: {
+        theme: THEMES.LIGHT,
+      },
+    },
+  },
+}
+
+const setup = (state = initialState, shallowRender = true) => {
+  const store = configureStore([thunk])(state)
+  const wrapper = mount(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={['/']} keyLength={0}>
+        <Sidebar />
+      </MemoryRouter>
+    </Provider>,
+  )
+  return {
+    store,
+    wrapper,
+  }
+}
 
 describe('Sidebar', () => {
   test('renders without crashing', () => {
+    const { wrapper } = setup()
     expect(wrapper).toMatchSnapshot()
   })
 
-  test('renders block height when count prop present', () => {
+  test('renders block height when count has been loaded into redux store', () => {
+    const { wrapper } = setup()
     const height = wrapper.find('#block-height')
-    expect(height.text()).toEqual('200')
+    expect(height.text()).toEqual('300')
+  })
+
+  test('HTML element containing count will not render any text until count has been loaded', () => {
+    const testState = cloneDeep(initialState)
+    testState.spunky.blockHeight.progress = LOADING
+    testState.spunky.blockHeight.data = undefined
+    const { wrapper } = setup(testState)
+    const container = wrapper.find('#block-height-container')
+    expect(container.text()).toEqual('')
+  })
+
+  test('does render the token sale navigation option when NOT in watch only mode', () => {
+    const { wrapper } = setup()
+    const label = wrapper.find('#token-sale-label')
+    expect(label.text()).toEqual(' Token Sale ')
+
+    const container = wrapper.find('#tokensale')
+    expect(container.length).toEqual(3)
+  })
+
+  test('does not render the token sale navigation option when in watch only mode', () => {
+    const testState = cloneDeep(initialState)
+    testState.spunky.auth.data.isWatchOnly = true
+    const { wrapper } = setup(testState)
+    const container = wrapper.find('#tokensale')
+    expect(container.length).toEqual(0)
+  })
+
+  test('renders the correct logo based on selected theme (Light)', () => {
+    const { wrapper } = setup()
+    const image = wrapper.find('#neon-logo')
+    expect(image.prop('src')).toEqual(LightLogoWithoutText)
+  })
+
+  test('renders the correct logo based on selected theme (Dark)', () => {
+    const testState = cloneDeep(initialState)
+    testState.spunky.settings.data.theme = THEMES.DARK
+    const { wrapper } = setup()
+    const image = wrapper.find('#neon-logo')
+    expect(image.prop('src')).toEqual(DarkLogoWithoutText)
   })
 })

--- a/__tests__/components/Sidebar.test.js
+++ b/__tests__/components/Sidebar.test.js
@@ -14,7 +14,6 @@ describe('Sidebar', () => {
   })
 
   test('renders block height when count prop present', () => {
-    console.log({ wrapper: wrapper.debug() })
     const height = wrapper.find('#block-height')
     expect(height.text()).toEqual('200')
   })

--- a/__tests__/components/__snapshots__/Sidebar.test.js.snap
+++ b/__tests__/components/__snapshots__/Sidebar.test.js.snap
@@ -27,7 +27,6 @@ exports[`Sidebar renders without crashing 1`] = `
         id="block-height"
       >
         200
-         
       </div>
     </div>
     <NavLink

--- a/__tests__/components/__snapshots__/Sidebar.test.js.snap
+++ b/__tests__/components/__snapshots__/Sidebar.test.js.snap
@@ -1,138 +1,774 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Sidebar renders without crashing 1`] = `
-<div
-  className="container"
+<Provider
+  store={
+    Object {
+      "clearActions": [Function],
+      "dispatch": [Function],
+      "getActions": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+    }
+  }
 >
-  <div
-    className="group"
+  <MemoryRouter
+    initialEntries={
+      Array [
+        "/",
+      ]
+    }
+    keyLength={0}
   >
-    <div
-      className="logo"
+    <Router
+      history={
+        Object {
+          "action": "POP",
+          "block": [Function],
+          "canGo": [Function],
+          "createHref": [Function],
+          "entries": Array [
+            Object {
+              "hash": "",
+              "pathname": "/",
+              "search": "",
+              "state": undefined,
+            },
+          ],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "index": 0,
+          "length": 1,
+          "listen": [Function],
+          "location": Object {
+            "hash": "",
+            "pathname": "/",
+            "search": "",
+            "state": undefined,
+          },
+          "push": [Function],
+          "replace": [Function],
+        }
+      }
     >
-      <img
-        alt="neon-logo"
-        src="test-file-stub"
-      />
-    </div>
-    <div
-      className="blockHeight"
-    >
-      <div
-        className="heightText"
-      >
-        CURRENT BLOCK: 
-      </div>
-      <div
-        id="block-height"
-      >
-        200
-      </div>
-    </div>
-    <NavLink
-      activeClassName="active"
-      aria-current="page"
-      className="navItem"
-      exact={true}
-      id="dashboard"
-      to="/dashboard"
-    >
-      <Component />
-      <div>
-         Wallet 
-      </div>
-    </NavLink>
-    <NavLink
-      activeClassName="active"
-      aria-current="page"
-      className="navItem"
-      exact={true}
-      id="history"
-      to="/transactions"
-    >
-      <Component />
-      <div>
-         Activity 
-      </div>
-    </NavLink>
-    <NavLink
-      activeClassName="active"
-      aria-current="page"
-      className="navItem"
-      exact={true}
-      id="send"
-      to="/send/"
-    >
-      <Component />
-      <div>
-         Send 
-      </div>
-    </NavLink>
-    <NavLink
-      activeClassName="active"
-      aria-current="page"
-      className="navItem"
-      exact={true}
-      id="receive"
-      to="/receive"
-    >
-      <Component />
-      <div>
-         Receive 
-      </div>
-    </NavLink>
-    <NavLink
-      activeClassName="active"
-      aria-current="page"
-      className="navItem"
-      id="contacts"
-      to="/contacts"
-    >
-      <Component />
-      <div>
-         Contacts 
-      </div>
-    </NavLink>
-    <NavLink
-      activeClassName="active"
-      aria-current="page"
-      className="navItem"
-      id="tokensale"
-      to="/token-sale"
-    >
-      <Component />
-      <div>
-         Token Sale 
-      </div>
-    </NavLink>
-    <NavLink
-      activeClassName="active"
-      aria-current="page"
-      className="navItem"
-      id="News"
-      to="/news"
-    >
-      <Component />
-      <div>
-         News 
-      </div>
-    </NavLink>
-    <NavLink
-      activeClassName="active"
-      aria-current="page"
-      className="navItem"
-      id="settings"
-      to="/settings"
-    >
-      <Component />
-      <div>
-         Settings 
-      </div>
-    </NavLink>
-  </div>
-  <Connect(withActions(Connect(withActions(Logout))))
-    className="group logoutToolTipGroup navItem"
-    id="logout"
-  />
-</div>
+      <withRouter(Connect(withData(Connect(withData(Connect(withCall(Connect(withData(Sidebar)))))))))>
+        <Route>
+          <Connect(withData(Connect(withData(Connect(withCall(Connect(withData(Sidebar))))))))
+            history={
+              Object {
+                "action": "POP",
+                "block": [Function],
+                "canGo": [Function],
+                "createHref": [Function],
+                "entries": Array [
+                  Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                ],
+                "go": [Function],
+                "goBack": [Function],
+                "goForward": [Function],
+                "index": 0,
+                "length": 1,
+                "listen": [Function],
+                "location": Object {
+                  "hash": "",
+                  "pathname": "/",
+                  "search": "",
+                  "state": undefined,
+                },
+                "push": [Function],
+                "replace": [Function],
+              }
+            }
+            location={
+              Object {
+                "hash": "",
+                "pathname": "/",
+                "search": "",
+                "state": undefined,
+              }
+            }
+            match={
+              Object {
+                "isExact": true,
+                "params": Object {},
+                "path": "/",
+                "url": "/",
+              }
+            }
+          >
+            <withData(Connect(withData(Connect(withCall(Connect(withData(Sidebar)))))))
+              dispatch={[Function]}
+              history={
+                Object {
+                  "action": "POP",
+                  "block": [Function],
+                  "canGo": [Function],
+                  "createHref": [Function],
+                  "entries": Array [
+                    Object {
+                      "hash": "",
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                  ],
+                  "go": [Function],
+                  "goBack": [Function],
+                  "goForward": [Function],
+                  "index": 0,
+                  "length": 1,
+                  "listen": [Function],
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "push": [Function],
+                  "replace": [Function],
+                }
+              }
+              isWatchOnly={false}
+              location={
+                Object {
+                  "hash": "",
+                  "pathname": "/",
+                  "search": "",
+                  "state": undefined,
+                }
+              }
+              match={
+                Object {
+                  "isExact": true,
+                  "params": Object {},
+                  "path": "/",
+                  "url": "/",
+                }
+              }
+            >
+              <withData(Connect(withCall(Connect(withData(Sidebar)))))
+                dispatch={[Function]}
+                history={
+                  Object {
+                    "action": "POP",
+                    "block": [Function],
+                    "canGo": [Function],
+                    "createHref": [Function],
+                    "entries": Array [
+                      Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                    ],
+                    "go": [Function],
+                    "goBack": [Function],
+                    "goForward": [Function],
+                    "index": 0,
+                    "length": 1,
+                    "listen": [Function],
+                    "location": Object {
+                      "hash": "",
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "push": [Function],
+                    "replace": [Function],
+                  }
+                }
+                isWatchOnly={false}
+                location={
+                  Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  }
+                }
+                match={
+                  Object {
+                    "isExact": true,
+                    "params": Object {},
+                    "path": "/",
+                    "url": "/",
+                  }
+                }
+                pendingTransactionsCount={0}
+              >
+                <withCall(Connect(withData(Sidebar)))
+                  dispatch={[Function]}
+                  history={
+                    Object {
+                      "action": "POP",
+                      "block": [Function],
+                      "canGo": [Function],
+                      "createHref": [Function],
+                      "entries": Array [
+                        Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                      ],
+                      "go": [Function],
+                      "goBack": [Function],
+                      "goForward": [Function],
+                      "index": 0,
+                      "length": 1,
+                      "listen": [Function],
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "push": [Function],
+                      "replace": [Function],
+                    }
+                  }
+                  isWatchOnly={false}
+                  location={
+                    Object {
+                      "hash": "",
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    }
+                  }
+                  match={
+                    Object {
+                      "isExact": true,
+                      "params": Object {},
+                      "path": "/",
+                      "url": "/",
+                    }
+                  }
+                  pendingTransactionsCount={0}
+                  performAction={[Function]}
+                >
+                  <withoutProps(Connect(withData(Sidebar)))
+                    dispatch={[Function]}
+                    history={
+                      Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "canGo": [Function],
+                        "createHref": [Function],
+                        "entries": Array [
+                          Object {
+                            "hash": "",
+                            "pathname": "/",
+                            "search": "",
+                            "state": undefined,
+                          },
+                        ],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "index": 0,
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      }
+                    }
+                    isWatchOnly={false}
+                    location={
+                      Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      }
+                    }
+                    match={
+                      Object {
+                        "isExact": true,
+                        "params": Object {},
+                        "path": "/",
+                        "url": "/",
+                      }
+                    }
+                    pendingTransactionsCount={0}
+                    performAction={[Function]}
+                  >
+                    <Connect(withData(Sidebar))
+                      dispatch={[Function]}
+                      history={
+                        Object {
+                          "action": "POP",
+                          "block": [Function],
+                          "canGo": [Function],
+                          "createHref": [Function],
+                          "entries": Array [
+                            Object {
+                              "hash": "",
+                              "pathname": "/",
+                              "search": "",
+                              "state": undefined,
+                            },
+                          ],
+                          "go": [Function],
+                          "goBack": [Function],
+                          "goForward": [Function],
+                          "index": 0,
+                          "length": 1,
+                          "listen": [Function],
+                          "location": Object {
+                            "hash": "",
+                            "pathname": "/",
+                            "search": "",
+                            "state": undefined,
+                          },
+                          "push": [Function],
+                          "replace": [Function],
+                        }
+                      }
+                      isWatchOnly={false}
+                      location={
+                        Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        }
+                      }
+                      match={
+                        Object {
+                          "isExact": true,
+                          "params": Object {},
+                          "path": "/",
+                          "url": "/",
+                        }
+                      }
+                      pendingTransactionsCount={0}
+                    >
+                      <withData(Sidebar)
+                        count={300}
+                        dispatch={[Function]}
+                        history={
+                          Object {
+                            "action": "POP",
+                            "block": [Function],
+                            "canGo": [Function],
+                            "createHref": [Function],
+                            "entries": Array [
+                              Object {
+                                "hash": "",
+                                "pathname": "/",
+                                "search": "",
+                                "state": undefined,
+                              },
+                            ],
+                            "go": [Function],
+                            "goBack": [Function],
+                            "goForward": [Function],
+                            "index": 0,
+                            "length": 1,
+                            "listen": [Function],
+                            "location": Object {
+                              "hash": "",
+                              "pathname": "/",
+                              "search": "",
+                              "state": undefined,
+                            },
+                            "push": [Function],
+                            "replace": [Function],
+                          }
+                        }
+                        isWatchOnly={false}
+                        location={
+                          Object {
+                            "hash": "",
+                            "pathname": "/",
+                            "search": "",
+                            "state": undefined,
+                          }
+                        }
+                        match={
+                          Object {
+                            "isExact": true,
+                            "params": Object {},
+                            "path": "/",
+                            "url": "/",
+                          }
+                        }
+                        pendingTransactionsCount={0}
+                      >
+                        <div
+                          className="container"
+                        >
+                          <div
+                            className="group"
+                          >
+                            <div
+                              className="logo"
+                              id="neon-logo-container"
+                            >
+                              <img
+                                alt="neon-logo"
+                                id="neon-logo"
+                                src="test-file-stub"
+                              />
+                            </div>
+                            <div
+                              className="blockHeight"
+                              id="block-height-container"
+                            >
+                              <div
+                                className="heightText"
+                                id="block-height-label"
+                              >
+                                CURRENT BLOCK:
+                              </div>
+                              <div
+                                id="block-height"
+                              >
+                                300
+                              </div>
+                            </div>
+                            <NavLink
+                              activeClassName="active"
+                              aria-current="page"
+                              className="navItem"
+                              exact={true}
+                              id="dashboard"
+                              to="/dashboard"
+                            >
+                              <Route
+                                exact={true}
+                                path="\\\\/dashboard"
+                              >
+                                <Link
+                                  aria-current={null}
+                                  className="navItem"
+                                  id="dashboard"
+                                  replace={false}
+                                  to="/dashboard"
+                                >
+                                  <a
+                                    aria-current={null}
+                                    className="navItem"
+                                    href="/dashboard"
+                                    id="dashboard"
+                                    onClick={[Function]}
+                                  >
+                                    <Component>
+                                      <svg />
+                                    </Component>
+                                    <div>
+                                       Wallet 
+                                    </div>
+                                  </a>
+                                </Link>
+                              </Route>
+                            </NavLink>
+                            <NavLink
+                              activeClassName="active"
+                              aria-current="page"
+                              className="navItem"
+                              exact={true}
+                              id="history"
+                              to="/transactions"
+                            >
+                              <Route
+                                exact={true}
+                                path="\\\\/transactions"
+                              >
+                                <Link
+                                  aria-current={null}
+                                  className="navItem"
+                                  id="history"
+                                  replace={false}
+                                  to="/transactions"
+                                >
+                                  <a
+                                    aria-current={null}
+                                    className="navItem"
+                                    href="/transactions"
+                                    id="history"
+                                    onClick={[Function]}
+                                  >
+                                    <Component>
+                                      <svg />
+                                    </Component>
+                                    <div>
+                                       Activity 
+                                    </div>
+                                  </a>
+                                </Link>
+                              </Route>
+                            </NavLink>
+                            <NavLink
+                              activeClassName="active"
+                              aria-current="page"
+                              className="navItem"
+                              exact={true}
+                              id="send"
+                              to="/send/"
+                            >
+                              <Route
+                                exact={true}
+                                path="\\\\/send\\\\/"
+                              >
+                                <Link
+                                  aria-current={null}
+                                  className="navItem"
+                                  id="send"
+                                  replace={false}
+                                  to="/send/"
+                                >
+                                  <a
+                                    aria-current={null}
+                                    className="navItem"
+                                    href="/send/"
+                                    id="send"
+                                    onClick={[Function]}
+                                  >
+                                    <Component>
+                                      <svg />
+                                    </Component>
+                                    <div>
+                                       Send 
+                                    </div>
+                                  </a>
+                                </Link>
+                              </Route>
+                            </NavLink>
+                            <NavLink
+                              activeClassName="active"
+                              aria-current="page"
+                              className="navItem"
+                              exact={true}
+                              id="receive"
+                              to="/receive"
+                            >
+                              <Route
+                                exact={true}
+                                path="\\\\/receive"
+                              >
+                                <Link
+                                  aria-current={null}
+                                  className="navItem"
+                                  id="receive"
+                                  replace={false}
+                                  to="/receive"
+                                >
+                                  <a
+                                    aria-current={null}
+                                    className="navItem"
+                                    href="/receive"
+                                    id="receive"
+                                    onClick={[Function]}
+                                  >
+                                    <Component>
+                                      <svg />
+                                    </Component>
+                                    <div>
+                                       Receive 
+                                    </div>
+                                  </a>
+                                </Link>
+                              </Route>
+                            </NavLink>
+                            <NavLink
+                              activeClassName="active"
+                              aria-current="page"
+                              className="navItem"
+                              id="contacts"
+                              to="/contacts"
+                            >
+                              <Route
+                                path="\\\\/contacts"
+                              >
+                                <Link
+                                  aria-current={null}
+                                  className="navItem"
+                                  id="contacts"
+                                  replace={false}
+                                  to="/contacts"
+                                >
+                                  <a
+                                    aria-current={null}
+                                    className="navItem"
+                                    href="/contacts"
+                                    id="contacts"
+                                    onClick={[Function]}
+                                  >
+                                    <Component>
+                                      <svg />
+                                    </Component>
+                                    <div>
+                                       Contacts 
+                                    </div>
+                                  </a>
+                                </Link>
+                              </Route>
+                            </NavLink>
+                            <NavLink
+                              activeClassName="active"
+                              aria-current="page"
+                              className="navItem"
+                              id="tokensale"
+                              to="/token-sale"
+                            >
+                              <Route
+                                path="\\\\/token-sale"
+                              >
+                                <Link
+                                  aria-current={null}
+                                  className="navItem"
+                                  id="tokensale"
+                                  replace={false}
+                                  to="/token-sale"
+                                >
+                                  <a
+                                    aria-current={null}
+                                    className="navItem"
+                                    href="/token-sale"
+                                    id="tokensale"
+                                    onClick={[Function]}
+                                  >
+                                    <Component>
+                                      <svg />
+                                    </Component>
+                                    <div
+                                      id="token-sale-label"
+                                    >
+                                       Token Sale 
+                                    </div>
+                                  </a>
+                                </Link>
+                              </Route>
+                            </NavLink>
+                            <NavLink
+                              activeClassName="active"
+                              aria-current="page"
+                              className="navItem"
+                              id="News"
+                              to="/news"
+                            >
+                              <Route
+                                path="\\\\/news"
+                              >
+                                <Link
+                                  aria-current={null}
+                                  className="navItem"
+                                  id="News"
+                                  replace={false}
+                                  to="/news"
+                                >
+                                  <a
+                                    aria-current={null}
+                                    className="navItem"
+                                    href="/news"
+                                    id="News"
+                                    onClick={[Function]}
+                                  >
+                                    <Component>
+                                      <svg />
+                                    </Component>
+                                    <div>
+                                       News 
+                                    </div>
+                                  </a>
+                                </Link>
+                              </Route>
+                            </NavLink>
+                            <NavLink
+                              activeClassName="active"
+                              aria-current="page"
+                              className="navItem"
+                              id="settings"
+                              to="/settings"
+                            >
+                              <Route
+                                path="\\\\/settings"
+                              >
+                                <Link
+                                  aria-current={null}
+                                  className="navItem"
+                                  id="settings"
+                                  replace={false}
+                                  to="/settings"
+                                >
+                                  <a
+                                    aria-current={null}
+                                    className="navItem"
+                                    href="/settings"
+                                    id="settings"
+                                    onClick={[Function]}
+                                  >
+                                    <Component>
+                                      <svg />
+                                    </Component>
+                                    <div>
+                                       Settings 
+                                    </div>
+                                  </a>
+                                </Link>
+                              </Route>
+                            </NavLink>
+                          </div>
+                          <Connect(withActions(Connect(withActions(Logout))))
+                            className="group logoutToolTipGroup navItem"
+                            id="logout"
+                          >
+                            <withActions(Connect(withActions(Logout)))
+                              className="group logoutToolTipGroup navItem"
+                              id="logout"
+                              logout={[Function]}
+                            >
+                              <withActions(Logout)
+                                className="group logoutToolTipGroup navItem"
+                                id="logout"
+                                logout={[Function]}
+                                promptHasBeenDisplayed={[Function]}
+                              >
+                                <div
+                                  className="logout group logoutToolTipGroup navItem"
+                                  id="logout"
+                                  onClick={[Function]}
+                                >
+                                  <Component>
+                                    <svg />
+                                  </Component>
+                                  <div
+                                    className="logoutText"
+                                  >
+                                     Logout 
+                                  </div>
+                                </div>
+                              </withActions(Logout)>
+                            </withActions(Connect(withActions(Logout)))>
+                          </Connect(withActions(Connect(withActions(Logout))))>
+                        </div>
+                      </withData(Sidebar)>
+                    </Connect(withData(Sidebar))>
+                  </withoutProps(Connect(withData(Sidebar)))>
+                </withCall(Connect(withData(Sidebar)))>
+              </withData(Connect(withCall(Connect(withData(Sidebar)))))>
+            </withData(Connect(withData(Connect(withCall(Connect(withData(Sidebar)))))))>
+          </Connect(withData(Connect(withData(Connect(withCall(Connect(withData(Sidebar))))))))>
+        </Route>
+      </withRouter(Connect(withData(Connect(withData(Connect(withCall(Connect(withData(Sidebar)))))))))>
+    </Router>
+  </MemoryRouter>
+</Provider>
 `;

--- a/__tests__/components/__snapshots__/Sidebar.test.js.snap
+++ b/__tests__/components/__snapshots__/Sidebar.test.js.snap
@@ -1,0 +1,139 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Sidebar renders without crashing 1`] = `
+<div
+  className="container"
+>
+  <div
+    className="group"
+  >
+    <div
+      className="logo"
+    >
+      <img
+        alt="neon-logo"
+        src="test-file-stub"
+      />
+    </div>
+    <div
+      className="blockHeight"
+    >
+      <div
+        className="heightText"
+      >
+        CURRENT BLOCK: 
+      </div>
+      <div
+        id="block-height"
+      >
+        200
+         
+      </div>
+    </div>
+    <NavLink
+      activeClassName="active"
+      aria-current="page"
+      className="navItem"
+      exact={true}
+      id="dashboard"
+      to="/dashboard"
+    >
+      <Component />
+      <div>
+         Wallet 
+      </div>
+    </NavLink>
+    <NavLink
+      activeClassName="active"
+      aria-current="page"
+      className="navItem"
+      exact={true}
+      id="history"
+      to="/transactions"
+    >
+      <Component />
+      <div>
+         Activity 
+      </div>
+    </NavLink>
+    <NavLink
+      activeClassName="active"
+      aria-current="page"
+      className="navItem"
+      exact={true}
+      id="send"
+      to="/send/"
+    >
+      <Component />
+      <div>
+         Send 
+      </div>
+    </NavLink>
+    <NavLink
+      activeClassName="active"
+      aria-current="page"
+      className="navItem"
+      exact={true}
+      id="receive"
+      to="/receive"
+    >
+      <Component />
+      <div>
+         Receive 
+      </div>
+    </NavLink>
+    <NavLink
+      activeClassName="active"
+      aria-current="page"
+      className="navItem"
+      id="contacts"
+      to="/contacts"
+    >
+      <Component />
+      <div>
+         Contacts 
+      </div>
+    </NavLink>
+    <NavLink
+      activeClassName="active"
+      aria-current="page"
+      className="navItem"
+      id="tokensale"
+      to="/token-sale"
+    >
+      <Component />
+      <div>
+         Token Sale 
+      </div>
+    </NavLink>
+    <NavLink
+      activeClassName="active"
+      aria-current="page"
+      className="navItem"
+      id="News"
+      to="/news"
+    >
+      <Component />
+      <div>
+         News 
+      </div>
+    </NavLink>
+    <NavLink
+      activeClassName="active"
+      aria-current="page"
+      className="navItem"
+      id="settings"
+      to="/settings"
+    >
+      <Component />
+      <div>
+         Settings 
+      </div>
+    </NavLink>
+  </div>
+  <Connect(withActions(Connect(withActions(Logout))))
+    className="group logoutToolTipGroup navItem"
+    id="logout"
+  />
+</div>
+`;

--- a/app/actions/accountActions.js
+++ b/app/actions/accountActions.js
@@ -6,6 +6,7 @@ import claimsActions from './claimsActions'
 import pricesActions from './pricesActions'
 import transactionHistoryActions from './transactionHistoryActions'
 import { getPendingTransactionInfo } from './pendingTransactionActions'
+import blockHeightActions from './blockHeightActions'
 
 export const ID = 'account'
 
@@ -15,4 +16,5 @@ export default createBatchActions(ID, {
   transactions: transactionHistoryActions,
   pendingTransactionsInfo: getPendingTransactionInfo,
   prices: pricesActions,
+  blockHeight: blockHeightActions,
 })

--- a/app/actions/accountActions.js
+++ b/app/actions/accountActions.js
@@ -6,7 +6,7 @@ import claimsActions from './claimsActions'
 import pricesActions from './pricesActions'
 import transactionHistoryActions from './transactionHistoryActions'
 import { getPendingTransactionInfo } from './pendingTransactionActions'
-import blockHeightActions from './blockHeightActions'
+import { blockHeightActions } from './blockHeightActions'
 
 export const ID = 'account'
 

--- a/app/actions/blockHeightActions.js
+++ b/app/actions/blockHeightActions.js
@@ -8,15 +8,28 @@ type Props = {
   networkId: string,
 }
 
+const exportedModule = {}
+
 export const ID = 'blockHeight'
 
-export default createActions(ID, ({ networkId }: Props = {}) => async () => {
+export const getBlockHeight = async (networkId: string) => {
   let url = await getNode(networkId)
   if (isEmpty(url)) {
     url = await getRPCEndpoint(networkId)
   }
   const client = new rpc.RPCClient(url)
-
   const count = await client.getBlockCount()
   return count
-})
+}
+exportedModule.getBlockHeight = getBlockHeight
+
+export const blockHeightActions = createActions(
+  ID,
+  ({ networkId }: Props = {}) => async () => {
+    const count = await exportedModule.getBlockHeight(networkId)
+    return count
+  },
+)
+exportedModule.blockHeightActions = blockHeightActions
+
+export default exportedModule

--- a/app/actions/blockHeightActions.js
+++ b/app/actions/blockHeightActions.js
@@ -1,8 +1,8 @@
 // @flow
-import { api } from '@cityofzion/neon-js'
+import { rpc } from '@cityofzion/neon-js'
 import { createActions } from 'spunky'
-
-import { getNetworkById } from '../core/deprecated'
+import { isEmpty } from 'lodash-es'
+import { getNode, getRPCEndpoint } from './nodeStorageActions'
 
 type Props = {
   networkId: string,
@@ -11,6 +11,12 @@ type Props = {
 export const ID = 'blockHeight'
 
 export default createActions(ID, ({ networkId }: Props = {}) => async () => {
-  const network = getNetworkById(networkId)
-  return api.getWalletDBHeightFrom({ net: network }, api.neoscan)
+  let url = await getNode(networkId)
+  if (isEmpty(url)) {
+    url = await getRPCEndpoint(networkId)
+  }
+  const client = new rpc.RPCClient(url)
+
+  const count = await client.getBlockCount()
+  return count
 })

--- a/app/containers/App/Sidebar/Sidebar.jsx
+++ b/app/containers/App/Sidebar/Sidebar.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react'
+import React, { Fragment } from 'react'
 import classNames from 'classnames'
 import { NavLink } from 'react-router-dom'
 
@@ -43,12 +43,15 @@ const Sidebar = ({
           <img src={themeBasedLogo} alt="neon-logo" />
         </div>
 
-        {count && (
-          <div className={styles.blockHeight}>
-            <div className={styles.heightText}>CURRENT BLOCK: </div>
-            <div id="block-height">{count}</div>
-          </div>
-        )}
+        <div className={styles.blockHeight}>
+          {count && (
+            <Fragment>
+              <div className={styles.heightText}>CURRENT BLOCK: </div>
+              <div id="block-height">{count}</div>
+            </Fragment>
+          )}
+        </div>
+
         <NavLink
           id="dashboard"
           exact

--- a/app/containers/App/Sidebar/Sidebar.jsx
+++ b/app/containers/App/Sidebar/Sidebar.jsx
@@ -22,6 +22,7 @@ type Props = {
   className: string,
   theme: ThemeType,
   pendingTransactionsCount: number,
+  count: number,
   isWatchOnly?: boolean,
 }
 
@@ -30,6 +31,7 @@ const Sidebar = ({
   theme,
   pendingTransactionsCount,
   isWatchOnly,
+  count,
 }: Props) => {
   const themeBasedLogo =
     theme === 'Light' ? LightLogoWithoutText : DarkLogoWithoutText
@@ -41,6 +43,12 @@ const Sidebar = ({
           <img src={themeBasedLogo} alt="neon-logo" />
         </div>
 
+        {count && (
+          <div className={styles.blockHeight}>
+            <div className={styles.heightText}>CURRENT BLOCK: </div>
+            <div id="block-height">{count}</div>
+          </div>
+        )}
         <NavLink
           id="dashboard"
           exact

--- a/app/containers/App/Sidebar/Sidebar.jsx
+++ b/app/containers/App/Sidebar/Sidebar.jsx
@@ -39,14 +39,16 @@ const Sidebar = ({
   return (
     <div className={classNames(styles.container, className)}>
       <div className={styles.group}>
-        <div className={styles.logo}>
-          <img src={themeBasedLogo} alt="neon-logo" />
+        <div className={styles.logo} id="neon-logo-container">
+          <img src={themeBasedLogo} id="neon-logo" alt="neon-logo" />
         </div>
 
-        <div className={styles.blockHeight}>
+        <div id="block-height-container" className={styles.blockHeight}>
           {count && (
             <Fragment>
-              <div className={styles.heightText}>CURRENT BLOCK: </div>
+              <div id="block-height-label" className={styles.heightText}>
+                CURRENT BLOCK:
+              </div>
               <div id="block-height">{count}</div>
             </Fragment>
           )}
@@ -119,7 +121,7 @@ const Sidebar = ({
             activeClassName={styles.active}
           >
             <TokenSaleIcon />
-            <div> Token Sale </div>
+            <div id="token-sale-label"> Token Sale </div>
           </NavLink>
         )}
         <NavLink

--- a/app/containers/App/Sidebar/Sidebar.scss
+++ b/app/containers/App/Sidebar/Sidebar.scss
@@ -24,6 +24,26 @@ $size: 68px;
   }
 }
 
+.blockHeight {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-family: var(--font-gotham-book);
+  font-size: 10px;
+  text-align: center;
+  margin-top: -10px;
+  margin-bottom: 5px;
+  flex-direction: column;
+  min-height: 19px;
+  max-height: 19px;
+
+  .heightText {
+    opacity: 0.6;
+    font-size: 6px;
+    display: flex;
+  }
+}
+
 .logo {
   width: $size;
   height: $size;

--- a/app/containers/App/Sidebar/index.js
+++ b/app/containers/App/Sidebar/index.js
@@ -1,12 +1,13 @@
 // @flow
 import { compose } from 'recompose'
 import { get } from 'lodash-es'
-import { withData } from 'spunky'
+import { withData, withCall } from 'spunky'
 import { withRouter } from 'react-router-dom'
 
 import Sidebar from './Sidebar'
 import { addPendingTransaction } from '../../../actions/pendingTransactionActions'
 import withAuthData from '../../../hocs/withAuthData'
+import blockHeightActions from '../../../actions/blockHeightActions'
 
 const mapPendingTransactionsDataToProps = (
   pendingTransactions: Array<PendingTransactions>,
@@ -14,8 +15,14 @@ const mapPendingTransactionsDataToProps = (
   pendingTransactionsCount: get(pendingTransactions, 'length', 0),
 })
 
+const mapBlockHeightDataToProps = (count: Number) => ({
+  count,
+})
+
 export default compose(
   withRouter, // allow `NavLink` components to re-render when the window location changes
   withAuthData(),
   withData(addPendingTransaction, mapPendingTransactionsDataToProps),
+  withCall(blockHeightActions, mapBlockHeightDataToProps),
+  withData(blockHeightActions, mapBlockHeightDataToProps),
 )(Sidebar)

--- a/app/containers/App/Sidebar/index.js
+++ b/app/containers/App/Sidebar/index.js
@@ -7,7 +7,7 @@ import { withRouter } from 'react-router-dom'
 import Sidebar from './Sidebar'
 import { addPendingTransaction } from '../../../actions/pendingTransactionActions'
 import withAuthData from '../../../hocs/withAuthData'
-import blockHeightActions from '../../../actions/blockHeightActions'
+import { blockHeightActions } from '../../../actions/blockHeightActions'
 
 const mapPendingTransactionsDataToProps = (
   pendingTransactions: Array<PendingTransactions>,

--- a/app/containers/Buttons/RefreshButton/index.js
+++ b/app/containers/Buttons/RefreshButton/index.js
@@ -1,6 +1,6 @@
 // @flow
 import { compose } from 'recompose'
-import { withActions, withCall } from 'spunky'
+import { withActions } from 'spunky'
 import RefreshButton from './RefreshButton'
 
 import accountActions from '../../../actions/accountActions'
@@ -9,7 +9,6 @@ import balancesActions from '../../../actions/balancesActions'
 import withAuthData from '../../../hocs/withAuthData'
 import withNetworkData from '../../../hocs/withNetworkData'
 import withFilteredTokensData from '../../../hocs/withFilteredTokensData'
-import blockHeightActions from '../../../actions/blockHeightActions'
 
 const mapAccountActionsToProps = (actions, props) => ({
   loadWalletData: () =>

--- a/app/containers/Buttons/RefreshButton/index.js
+++ b/app/containers/Buttons/RefreshButton/index.js
@@ -1,6 +1,6 @@
 // @flow
 import { compose } from 'recompose'
-import { withActions } from 'spunky'
+import { withActions, withCall } from 'spunky'
 import RefreshButton from './RefreshButton'
 
 import accountActions from '../../../actions/accountActions'
@@ -9,6 +9,7 @@ import balancesActions from '../../../actions/balancesActions'
 import withAuthData from '../../../hocs/withAuthData'
 import withNetworkData from '../../../hocs/withNetworkData'
 import withFilteredTokensData from '../../../hocs/withFilteredTokensData'
+import blockHeightActions from '../../../actions/blockHeightActions'
 
 const mapAccountActionsToProps = (actions, props) => ({
   loadWalletData: () =>


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
https://github.com/CityOfZion/neon-wallet/issues/1833

![block-height](https://user-images.githubusercontent.com/13072035/64223437-48e41e00-ce91-11e9-874b-83da55088d9a.gif)

<img width="660" alt="Screen Shot 2019-09-03 at 9 26 04 PM" src="https://user-images.githubusercontent.com/13072035/64223490-73ce7200-ce91-11e9-820c-1ddf143ccc26.png">

<img width="347" alt="Screen Shot 2019-09-03 at 9 26 39 PM" src="https://user-images.githubusercontent.com/13072035/64223514-89439c00-ce91-11e9-8131-67f63cfea3e3.png">

**What problem does this PR solve?**
This PR adds the current block height of the selected node to the sidebar component. It will update anytime the refresh button is click OR it will update automatically as per the refresh polling

**How did you solve this problem?**

**How did you make sure your solution works?**
Manual and unit testing

**Are there any special changes in the code that we should be aware of?**

**Is there anything else we should know?**

- In the future it would be a nice enhancement to add some sort of CSS transition into the number incrementing
- Might be nice to add a tooltip displaying the network, currently selected RPC node etc

- [X] Unit tests written?


