### PR TITLE
feature: Updates LX hash in tokenList.json

### DIFF
--- a/app/core/tokenList.json
+++ b/app/core/tokenList.json
@@ -366,7 +366,7 @@
     "networks": {
       "1": {
         "name": "Moonlight Lux",
-        "hash": "bb3b54ab244b3658155f2db4429fc38ac4cef625",
+        "hash": "9c1f315264200988a0d2fbb5489f2c9adb9c765f",
         "decimals": 8,
         "totalSupply": 808257693.386336
       }


### PR DESCRIPTION
Updates the fallback token list in the event that github is down. The "actual" PR to update this in production can be found here:

https://github.com/CityOfZion/neo-tokens/pull/63