### PR TITLE
critical feature: fixes broken windows build step in circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ references:
 
   win_config: &win_config
     docker:
-      - image: electronuserland/builder:wine
+      - image: electronuserland/builder:wine-01.19
         environment:
           TARGET_ARCH: x64
     working_directory: ~/neon-wallet


### PR DESCRIPTION
This PR fixes the breaking build step that just started occurring in circleCI seems to be directly related to the update here: 

https://github.com/electron-userland/electron-builder/commit/d33065bd7b7c5b21182d7a6ef03c45d5bbab5c50
