### PR TITLE
Fix french language translation

### DIFF
--- a/__tests__/components/__snapshots__/Settings.test.js.snap
+++ b/__tests__/components/__snapshots__/Settings.test.js.snap
@@ -4530,7 +4530,7 @@ exports[`Settings renders without crashing 1`] = `
                                                                                                     "value": "CHINESE",
                                                                                                   },
                                                                                                   Object {
-                                                                                                    "label": "Francés",
+                                                                                                    "label": "Français",
                                                                                                     "renderFlag": [Function],
                                                                                                     "value": "FRENCH",
                                                                                                   },
@@ -4615,7 +4615,7 @@ exports[`Settings renders without crashing 1`] = `
                                                                                                         "value": "CHINESE",
                                                                                                       },
                                                                                                       Object {
-                                                                                                        "label": "Francés",
+                                                                                                        "label": "Français",
                                                                                                         "renderFlag": [Function],
                                                                                                         "value": "FRENCH",
                                                                                                       },
@@ -4737,7 +4737,7 @@ exports[`Settings renders without crashing 1`] = `
                                                                                                           "value": "CHINESE",
                                                                                                         },
                                                                                                         Object {
-                                                                                                          "label": "Francés",
+                                                                                                          "label": "Français",
                                                                                                           "renderFlag": [Function],
                                                                                                           "value": "FRENCH",
                                                                                                         },
@@ -4839,7 +4839,7 @@ exports[`Settings renders without crashing 1`] = `
                                                                                                             "value": "CHINESE",
                                                                                                           },
                                                                                                           Object {
-                                                                                                            "label": "Francés",
+                                                                                                            "label": "Français",
                                                                                                             "renderFlag": [Function],
                                                                                                             "value": "FRENCH",
                                                                                                           },
@@ -4940,7 +4940,7 @@ exports[`Settings renders without crashing 1`] = `
                                                                                                               "value": "CHINESE",
                                                                                                             },
                                                                                                             Object {
-                                                                                                              "label": "Francés",
+                                                                                                              "label": "Français",
                                                                                                               "renderFlag": [Function],
                                                                                                               "value": "FRENCH",
                                                                                                             },
@@ -5044,7 +5044,7 @@ exports[`Settings renders without crashing 1`] = `
                                                                                                                 "value": "CHINESE",
                                                                                                               },
                                                                                                               Object {
-                                                                                                                "label": "Francés",
+                                                                                                                "label": "Français",
                                                                                                                 "renderFlag": [Function],
                                                                                                                 "value": "FRENCH",
                                                                                                               },
@@ -5145,7 +5145,7 @@ exports[`Settings renders without crashing 1`] = `
                                                                                                                   "value": "CHINESE",
                                                                                                                 },
                                                                                                                 Object {
-                                                                                                                  "label": "Francés",
+                                                                                                                  "label": "Français",
                                                                                                                   "renderFlag": [Function],
                                                                                                                   "value": "FRENCH",
                                                                                                                 },
@@ -5242,7 +5242,7 @@ exports[`Settings renders without crashing 1`] = `
                                                                                                                     "value": "CHINESE",
                                                                                                                   },
                                                                                                                   Object {
-                                                                                                                    "label": "Francés",
+                                                                                                                    "label": "Français",
                                                                                                                     "renderFlag": [Function],
                                                                                                                     "value": "FRENCH",
                                                                                                                   },
@@ -5343,7 +5343,7 @@ exports[`Settings renders without crashing 1`] = `
                                                                                                                       "value": "CHINESE",
                                                                                                                     },
                                                                                                                     Object {
-                                                                                                                      "label": "Francés",
+                                                                                                                      "label": "Français",
                                                                                                                       "renderFlag": [Function],
                                                                                                                       "value": "FRENCH",
                                                                                                                     },
@@ -5445,7 +5445,7 @@ exports[`Settings renders without crashing 1`] = `
                                                                                                                         "value": "CHINESE",
                                                                                                                       },
                                                                                                                       Object {
-                                                                                                                        "label": "Francés",
+                                                                                                                        "label": "Français",
                                                                                                                         "renderFlag": [Function],
                                                                                                                         "value": "FRENCH",
                                                                                                                       },
@@ -5546,7 +5546,7 @@ exports[`Settings renders without crashing 1`] = `
                                                                                                                           "value": "CHINESE",
                                                                                                                         },
                                                                                                                         Object {
-                                                                                                                          "label": "Francés",
+                                                                                                                          "label": "Français",
                                                                                                                           "renderFlag": [Function],
                                                                                                                           "value": "FRENCH",
                                                                                                                         },
@@ -5679,7 +5679,7 @@ exports[`Settings renders without crashing 1`] = `
                                                                                                                     "value": "CHINESE",
                                                                                                                   },
                                                                                                                   Object {
-                                                                                                                    "label": "Francés",
+                                                                                                                    "label": "Français",
                                                                                                                     "renderFlag": [Function],
                                                                                                                     "value": "FRENCH",
                                                                                                                   },
@@ -5780,7 +5780,7 @@ exports[`Settings renders without crashing 1`] = `
                                                                                                                       "value": "CHINESE",
                                                                                                                     },
                                                                                                                     Object {
-                                                                                                                      "label": "Francés",
+                                                                                                                      "label": "Français",
                                                                                                                       "renderFlag": [Function],
                                                                                                                       "value": "FRENCH",
                                                                                                                     },
@@ -5876,7 +5876,7 @@ exports[`Settings renders without crashing 1`] = `
                                                                                                                         "value": "CHINESE",
                                                                                                                       },
                                                                                                                       Object {
-                                                                                                                        "label": "Francés",
+                                                                                                                        "label": "Français",
                                                                                                                         "renderFlag": [Function],
                                                                                                                         "value": "FRENCH",
                                                                                                                       },
@@ -5977,7 +5977,7 @@ exports[`Settings renders without crashing 1`] = `
                                                                                                                           "value": "CHINESE",
                                                                                                                         },
                                                                                                                         Object {
-                                                                                                                          "label": "Francés",
+                                                                                                                          "label": "Français",
                                                                                                                           "renderFlag": [Function],
                                                                                                                           "value": "FRENCH",
                                                                                                                         },
@@ -6081,7 +6081,7 @@ exports[`Settings renders without crashing 1`] = `
                                                                                                                         "value": "CHINESE",
                                                                                                                       },
                                                                                                                       Object {
-                                                                                                                        "label": "Francés",
+                                                                                                                        "label": "Français",
                                                                                                                         "renderFlag": [Function],
                                                                                                                         "value": "FRENCH",
                                                                                                                       },
@@ -6182,7 +6182,7 @@ exports[`Settings renders without crashing 1`] = `
                                                                                                                           "value": "CHINESE",
                                                                                                                         },
                                                                                                                         Object {
-                                                                                                                          "label": "Francés",
+                                                                                                                          "label": "Français",
                                                                                                                           "renderFlag": [Function],
                                                                                                                           "value": "FRENCH",
                                                                                                                         },

--- a/app/core/constants.js
+++ b/app/core/constants.js
@@ -56,9 +56,9 @@ export const LANGUAGES = {
     renderFlag: () => <China alt="中文" />,
   },
   FRENCH: {
-    label: 'Francés',
+    label: 'Français',
     value: 'FRENCH',
-    renderFlag: () => <France alt="Francés" />,
+    renderFlag: () => <France alt="Français" />,
   },
   GERMAN: {
     label: 'Deutsch',


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**

There's no issue, I just found the bug while using the software.

**What problem does this PR solve?**

This fix the translation of the word french into french (Francés is wrong, should be Français).

**How did you solve this problem?**

By changing the translation to the right one.

**How did you make sure your solution works?**

It's just a string.

**Are there any special changes in the code that we should be aware of?**

No.

**Is there anything else we should know?**

No.

- [ ] Unit tests written?

No.