### PR TITLE
fix wallet export/import

### DIFF
--- a/app/containers/Settings/Settings.jsx
+++ b/app/containers/Settings/Settings.jsx
@@ -76,6 +76,34 @@ export const loadWalletRecovery = async (
   if (canceled || !filePaths) return
 
   const filepath = filePaths[0]
+  fs.readFile(filepath, 'utf-8', async (err, data) => {
+    if (err) {
+      showErrorNotification({
+        message: `An error occurred reading the file: ${err.message}`,
+      })
+      return
+    }
+    const walletData = JSON.parse(data)
+    const recoveryData = await recoverWallet(walletData).catch(err => {
+      showErrorNotification({
+        message: `An error occurred recovering wallet: ${err.message}`,
+      })
+    })
+
+    if (recoveryData) {
+      showSuccessNotification({ message: 'Recovery was successful.' })
+      setAccounts(recoveryData.accounts)
+    }
+  })
+}
+  showSuccessNotification: Object => any,
+  showErrorNotification: Object => any,
+  setAccounts: (Array<Object>) => any,
+) => {
+  const { canceled, filePaths } = await dialog.showOpenDialog()
+  if (canceled || !filePaths) return
+
+  const filepath = filePaths[0]
   fs.readFile(filepath, 'utf-8', (err, data) => {
     if (err) {
       showErrorNotification({

--- a/app/containers/Settings/Settings.jsx
+++ b/app/containers/Settings/Settings.jsx
@@ -67,37 +67,34 @@ type State = {
   selectedLanguage: Language,
 }
 
-export const loadWalletRecovery = (
+export const loadWalletRecovery = async (
   showSuccessNotification: Object => any,
   showErrorNotification: Object => any,
   setAccounts: (Array<Object>) => any,
 ) => {
-  dialog.showOpenDialog(fileNames => {
-    // fileNames is an array that contains all the selected
-    if (!fileNames) {
+  const { canceled, filePaths } = await dialog.showOpenDialog()
+  if (canceled || !filePaths) return
+
+  const filepath = filePaths[0]
+  fs.readFile(filepath, 'utf-8', (err, data) => {
+    if (err) {
+      showErrorNotification({
+        message: `An error occurred reading the file: ${err.message}`,
+      })
       return
     }
-    const filepath = fileNames[0]
-    fs.readFile(filepath, 'utf-8', (err, data) => {
-      if (err) {
-        showErrorNotification({
-          message: `An error occurred reading the file: ${err.message}`,
-        })
-        return
-      }
-      const walletData = JSON.parse(data)
+    const walletData = JSON.parse(data)
 
-      recoverWallet(walletData)
-        .then(data => {
-          showSuccessNotification({ message: 'Recovery was successful.' })
-          setAccounts(data.accounts)
+    recoverWallet(walletData)
+      .then(data => {
+        showSuccessNotification({ message: 'Recovery was successful.' })
+        setAccounts(data.accounts)
+      })
+      .catch(err => {
+        showErrorNotification({
+          message: `An error occurred recovering wallet: ${err.message}`,
         })
-        .catch(err => {
-          showErrorNotification({
-            message: `An error occurred recovering wallet: ${err.message}`,
-          })
-        })
-    })
+      })
   })
 }
 

--- a/app/containers/Settings/Settings.jsx
+++ b/app/containers/Settings/Settings.jsx
@@ -96,35 +96,6 @@ export const loadWalletRecovery = async (
     }
   })
 }
-  showSuccessNotification: Object => any,
-  showErrorNotification: Object => any,
-  setAccounts: (Array<Object>) => any,
-) => {
-  const { canceled, filePaths } = await dialog.showOpenDialog()
-  if (canceled || !filePaths) return
-
-  const filepath = filePaths[0]
-  fs.readFile(filepath, 'utf-8', (err, data) => {
-    if (err) {
-      showErrorNotification({
-        message: `An error occurred reading the file: ${err.message}`,
-      })
-      return
-    }
-    const walletData = JSON.parse(data)
-
-    recoverWallet(walletData)
-      .then(data => {
-        showSuccessNotification({ message: 'Recovery was successful.' })
-        setAccounts(data.accounts)
-      })
-      .catch(err => {
-        showErrorNotification({
-          message: `An error occurred recovering wallet: ${err.message}`,
-        })
-      })
-  })
-}
 
 async function storageGet(key) {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
None, I didn't create an issue

**What problem does this PR solve?**
#1998 updated the electron version from ancient (`2.x`) to recent (`8.5.2`). With the new electron version the [showSaveDialog()](https://github.com/electron/electron/blob/v8.5.2/docs/api/dialog.md#dialogshowsavedialogbrowserwindow-options) no longer accepts a callback as argument, but returns a promise. As a result wallet exporting currently does nothing (meaning; the dialog shows, but the JSON file is never written to disk). 

-edit-
same story for `showOpenDialog`. One place immediately related place I found was in importing the wallet I just exported. Didn't work. Now it does

**How did you solve this problem?**
Update code to be based on promises

**How did you make sure your solution works?**
manually tested

**Are there any special changes in the code that we should be aware of?**
no

**Is there anything else we should know?**
we got this 😆 

- [ ] Unit tests written?
