### PR TITLE
fix for getversion change in Neo 3.0.3

### DIFF
--- a/app/modules/claim.js
+++ b/app/modules/claim.js
@@ -147,7 +147,8 @@ export const handleN3GasClaim = async ({
       params: [],
     }),
   )
-  const networkMagic = version.network || version.magic || 844378958
+  const networkMagic =
+    version.protocol.network || version.network || version.magic || 860833102
 
   const CONFIG = {
     account: FROM_ACCOUNT,

--- a/app/modules/transactions.js
+++ b/app/modules/transactions.js
@@ -350,7 +350,11 @@ export const sendTransaction = ({
             }),
           )
 
-          const networkMagic = version.network || version.magic || 844378958
+          const networkMagic =
+            version.protocol.network ||
+            version.network ||
+            version.magic ||
+            860833102
 
           const FROM_ACCOUNT = new n3Wallet.Account(
             isHardwareSend ? publicKey : wif,


### PR DESCRIPTION
Neo 3.0.3 introduced a breaking change to the getversion RPC method. The network value was moved one level down under protocol. This caused issues in Neon as well as neon-js, so after this patch is merged, the patched version of neon-js@next must also be incorporated into package.json.