### PR TITLE
Stale issues workflow

### DIFF
--- a/.github/workflows/stale-issue-reminder-and-closing.yml
+++ b/.github/workflows/stale-issue-reminder-and-closing.yml
@@ -1,0 +1,23 @@
+name: Handle stale issues
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  issues: write
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          days-before-issue-stale: 14
+          days-before-issue-close: 7
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 14 days with no activity. It will be automatically closed in 7 days from now if no activity is detected."
+          close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
+          exempt-issue-labels: Bug,Blocked,Blocker,Design,enhancement
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
As discussed on Slack, this adds a Github bot to deal with stale issues. Unlike what I said on Slack this version does not seem to be able to exclude issues created by members, but only by labels. I would argue that's actually not a bad thing.

Currently it will run once every day. It will exclude issues labelled with: Bug,Blocked,Blocker,Design,enhancement
so we have to make sure that we apply any of those if we wish to avoid being reminded on an issues going stale.

There is a rate limit of 30 issues per day it can close (something todo with github APIs). This means it will initially take a couple of days to go through all open issues once merged.
