### PR TITLE
[#2285] - fix MAX gas amount

### DIFF
--- a/app/components/Send/SendPanel/index.jsx
+++ b/app/components/Send/SendPanel/index.jsx
@@ -19,6 +19,7 @@ import EditIcon from '../../../assets/icons/edit.svg'
 
 import styles from './SendPanel.scss'
 import AlertBox from '../../AlertBox'
+import TotalGasBeingSentAlert from '../../TotalGasBeingSentAlert'
 
 type Props = {
   sendRowDetails: Array<*>,
@@ -55,6 +56,7 @@ type Props = {
   hasEnoughGas: boolean,
   loading: boolean,
   isMigration: boolean,
+  isSendingTotalAmountOfGas: boolean,
 }
 
 const shouldDisableSendButton = (sendRowDetails, loading) =>
@@ -99,6 +101,7 @@ const SendPanel = ({
   hasEnoughGas,
   loading,
   isMigration,
+  isSendingTotalAmountOfGas,
 }: Props) => {
   if (noSendableAssets) {
     return <ZeroAssets address={address} />
@@ -111,6 +114,7 @@ const SendPanel = ({
   let content = (
     <form>
       {chain === 'neo2' && !isMigration && <AlertBox />}
+      {true && <TotalGasBeingSentAlert />}
       <SendRecipientList
         sendRowDetails={sendRowDetails}
         sendableAssets={sendableAssets}

--- a/app/components/Send/SendPanel/index.jsx
+++ b/app/components/Send/SendPanel/index.jsx
@@ -114,7 +114,7 @@ const SendPanel = ({
   let content = (
     <form>
       {chain === 'neo2' && !isMigration && <AlertBox />}
-      {true && <TotalGasBeingSentAlert />}
+      {isSendingTotalAmountOfGas && <TotalGasBeingSentAlert />}
       <SendRecipientList
         sendRowDetails={sendRowDetails}
         sendableAssets={sendableAssets}

--- a/app/components/TotalGasBeingSentAlert/TotalGasBeingSentAlert.scss
+++ b/app/components/TotalGasBeingSentAlert/TotalGasBeingSentAlert.scss
@@ -1,0 +1,55 @@
+@import '../../styles/variables';
+
+.alertBox {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  margin-bottom: 20px;
+  max-width: 1100px;
+  box-sizing: border-box;
+  background-color: rgba(211, 85, 231, 0.52);
+  border-radius: 3px;
+
+  .iconContainer {
+    width: 70px;
+    background-color: #d355e7;
+    display: flex;
+    align-items: center;
+    border-radius: 3px 0 0 3px;
+    height: 100px;
+    justify-content: center;
+  }
+
+  h2 {
+    font-family: var(--font-gotham-bold);
+    font-size: 15px;
+    font-weight: bold;
+    margin-bottom: 6px;
+    margin: 0 0 6px 0;
+    margin-left: 12px;
+  }
+  b {
+    font-family: var(--font-gotham-bold);
+  }
+
+  .warning {
+    margin-left: 12px;
+  }
+
+  svg {
+    margin: 6px;
+    vertical-align: center;
+    min-width: 31px;
+    min-height: 28px;
+
+    path {
+      fill: var(--input-text);
+    }
+  }
+
+  a {
+    color: var(--input-text);
+    text-decoration: underline;
+  }
+}

--- a/app/components/TotalGasBeingSentAlert/index.js
+++ b/app/components/TotalGasBeingSentAlert/index.js
@@ -1,0 +1,29 @@
+// @flow
+import React from 'react'
+
+import classNames from 'classnames'
+
+import styles from './TotalGasBeingSentAlert.scss'
+import WarningIcon from '../../assets/icons/warning.svg'
+
+const electron = require('electron').remote
+
+const TotalGasBeingSentAlert = () => (
+  <section className={classNames(styles.alertBox, 'alertBox')}>
+    <div className={styles.iconContainer}>
+      <WarningIcon />
+    </div>
+    <div>
+      <div>
+        <h2>WARNING</h2>
+      </div>
+      <div className={styles.warning}>
+        <b>You are about to send all of your GAS out of this wallet. </b>
+        You will not be able to perform any additional future transactions on N3
+        without a GAS balance to pay transaction fees.
+      </div>
+    </div>
+  </section>
+)
+
+export default TotalGasBeingSentAlert

--- a/app/containers/Send/Send.jsx
+++ b/app/containers/Send/Send.jsx
@@ -320,11 +320,11 @@ export default class Send extends React.Component<Props, State> {
       if (asset === 'GAS') {
         const existingGasAmounts =
           Number(this.calculateRowAmounts(asset, index)) -
-          this.state.expectedGasFee
+          Number(this.state.expectedGasFee)
 
         totalSendableAssets = minusNumber(
           totalSendableAssets,
-          this.state.expectedGasFee * rowsWithAsset.length,
+          Number(this.state.expectedGasFee) * rowsWithAsset.length,
         )
 
         if (totalSendableAssets < 0) {

--- a/flow-typed/declarations.js
+++ b/flow-typed/declarations.js
@@ -152,7 +152,7 @@ declare type TokenBalanceType = {
 }
 
 declare type SendEntryType = {
-  amount: string,
+  amount: string | number,
   address: string,
   symbol: SymbolType,
   contractHash?: string,


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**
https://github.com/CityOfZion/neon-wallet/issues/2285


Calculates gas fees when the send container loads so that the MAX amount can be dynamically calculated.


TODO:
- [X] Add warning when user is sending entire GAS balance


<img width="1221" alt="Screen Shot 2022-02-22 at 8 36 34 AM" src="https://user-images.githubusercontent.com/13072035/155166093-da0d0e56-f2eb-4030-903d-d8f841dc5690.png">
