### PR TITLE
CU-864dz6z38 - Wc: When not sending a signature scope the wallet shou…

### DIFF
--- a/app/components/ConnectDapp/ApproveTransaction.js
+++ b/app/components/ConnectDapp/ApproveTransaction.js
@@ -416,7 +416,7 @@ const ApproveTransaction = ({
             ])}
           >
             <label>signature scope</label>
-            {!!request.params.request.params.signers.length && (
+            {request.params.request.params.signers.length ? (
               <div>
                 {
                   WITNESS_SCOPE[
@@ -427,6 +427,8 @@ const ApproveTransaction = ({
                   String(request.params.request.params.signers[0]?.scopes)
                 ] === 'Global' && <WarningIcon />}
               </div>
+            ) : (
+              <div>{WITNESS_SCOPE['1']}</div>
             )}
           </div>
         )}

--- a/app/context/WalletConnect/helpers.js
+++ b/app/context/WalletConnect/helpers.js
@@ -330,7 +330,9 @@ class N3Helper {
       account: account.scriptHash,
     })
 
-    signer.scopes = signerEntry && signerEntry.scopes
+    signer.scopes = signerEntry
+      ? signerEntry.scopes
+      : tx.WitnessScope.CalledByEntry
     if (signerEntry && signerEntry.allowedContracts) {
       signer.allowedContracts = signerEntry.allowedContracts.map(ac =>
         Neon.u.HexString.fromHex(ac),


### PR DESCRIPTION
…ld use the default (CalledByEntry, not None. None would be if the developer explicitly says None)

**What current issue(s) from Trello/Github does this address?**

**What problem does this PR solve?**

**How did you solve this problem?**

**How did you make sure your solution works?**

**Are there any special changes in the code that we should be aware of?**

**Is there anything else we should know?**

- [ ] Unit tests written?
