### PR TITLE
CU-86a0b89zf - Wrong text on sign message confirmation window

### DIFF
--- a/app/components/DappRequest/SignMessage/SignMessage.jsx
+++ b/app/components/DappRequest/SignMessage/SignMessage.jsx
@@ -86,7 +86,7 @@ const VerifyMessage = ({
         ])}
       >
         <img src={session.peer.metadata.icons[0]} />
-        <h3>{session.peer.metadata.name} wants you to verify a message</h3>
+        <h3>{session.peer.metadata.name} asks for authentication</h3>
 
         {isHardwareLogin && (
           <DialogueBox


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**

**What problem does this PR solve?**

**How did you solve this problem?**

**How did you make sure your solution works?**

**Are there any special changes in the code that we should be aware of?**

**Is there anything else we should know?**

- [ ] Unit tests written?
