### PR TITLE
Add RPC endpoints for nodes hosted by NeoSPCC

### DIFF
--- a/app/core/n3-nodes-main-net.json
+++ b/app/core/n3-nodes-main-net.json
@@ -8,5 +8,6 @@
   { "url": "http://seed2.neo.org:10332" },
   { "url": "http://seed3.neo.org:10332" },
   { "url": "http://seed4.neo.org:10332" },
-  { "url": "http://seed5.neo.org:10332" }
+  { "url": "http://seed5.neo.org:10332" },
+  { "url": "https://rpc10.n3.nspcc.ru:10331" }
 ]

--- a/app/core/n3-nodes-test-net.json
+++ b/app/core/n3-nodes-test-net.json
@@ -5,5 +5,6 @@
   { "url": "http://seed2t5.neo.org:20332" },
   { "url": "http://seed3t5.neo.org:20332" },
   { "url": "http://seed4t5.neo.org:20332" },
-  { "url": "http://seed5t5.neo.org:20332" }
+  { "url": "http://seed5t5.neo.org:20332" },
+  { "url": "https://rpc.t5.n3.nspcc.ru:20331" }
 ]

--- a/app/core/nodes-main-net.json
+++ b/app/core/nodes-main-net.json
@@ -34,5 +34,8 @@
   },
   {
     "url": "https://mainnet3.neo2.coz.io:443"
+  },
+  {
+    "url": "https://rpc1.neolegacy.nspcc.ru:10331"
   }
 ]

--- a/app/core/nodes-test-net.json
+++ b/app/core/nodes-test-net.json
@@ -3,5 +3,6 @@
   { "url": "https://testnet2.neo2.coz.io:443" },
   { "url": "https://testnet3.neo2.coz.io:443" },
   { "url": "http://seed1.ngd.network:20332" },
-  { "url": "http://seed2.ngd.network:20332" }
+  { "url": "http://seed2.ngd.network:20332" },
+  { "url": "http://rpc1t.neolegacy.nspcc.ru:20332" }
 ]


### PR DESCRIPTION
**What current issue(s) from Trello/Github does this address?**

No such issues.

**What problem does this PR solve?**

There are a couple of public, compatible and up-to-date RPC nodes in N3 and Legacy that are hosted and continuously maintained by NeoSPCC team. It would be nice to integrate them with Neon Wallet.

**How did you solve this problem?**

Add the node's endpoints to the supported nodes lists. Original info can be found in https://status.fs.neo.org/.

**Is there anything else we should know?**

Let me know if this change is applicable. There's also a question from my side not related to the Neon Wallet: is it possible to support the same addresses for Dora Monitor (https://dora.coz.io/monitor)?
